### PR TITLE
feat(flows): add validate command for flow file validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ kestra flows deploy ./flows/ --fail-fast
 
 # Combine flags
 kestra flows deploy ./flows/ --namespace prod --override --fail-fast
+
+# Validate a single flow
+kestra flows validate path/to/flow.yaml
+
+# Validate all flows in a directory (recursive)
+kestra flows validate ./flows/
 ```
 
 ### Executions

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/kestra-io/kestra-cli/src/cli"
@@ -9,7 +8,6 @@ import (
 
 func main() {
 	if err := cli.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -23,6 +24,19 @@ type DeployResult struct {
 	Error     string `json:"error,omitempty"`
 }
 
+// ValidateResult holds the result of validating a single flow file.
+type ValidateResult struct {
+	FilePath         string   `json:"file_path"`
+	FlowID           string   `json:"flow_id,omitempty"`
+	Namespace        string   `json:"namespace,omitempty"`
+	Constraints      []string `json:"constraints,omitempty"`
+	Warnings         []string `json:"warnings,omitempty"`
+	Infos            []string `json:"infos,omitempty"`
+	DeprecationPaths []string `json:"deprecation_paths,omitempty"`
+	Outdated         bool     `json:"outdated,omitempty"`
+	Success          bool     `json:"success"`
+}
+
 func newFlowsCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "flows",
@@ -32,6 +46,7 @@ func newFlowsCommand() *cobra.Command {
 	cmd.AddCommand(newFlowsListCommand())
 	cmd.AddCommand(newFlowsGetCommand())
 	cmd.AddCommand(newFlowsDeployCommand())
+	cmd.AddCommand(newFlowsValidateCommand())
 
 	return cmd
 }
@@ -231,6 +246,221 @@ Use --fail-fast to stop on the first error.`,
 	cmd.Flags().BoolVar(&failFast, "fail-fast", false, "Stop on the first deployment error")
 
 	return cmd
+}
+
+func newFlowsValidateCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "validate <path>",
+		Short:        "Validate flows from a YAML file or directory.",
+		SilenceUsage: true,
+		Long: `Validate flow definitions from a local YAML file or directory.
+
+When a directory is provided, all .yaml and .yml files are validated recursively.
+Hidden files and directories (starting with .) are skipped.
+
+Validation fails if any flow has constraint violations.
+Warnings, infos, deprecations, and outdated flags are reported but do not fail validation.`,
+		Example: `  # Validate a single flow
+  kestra flows validate flow.yaml
+
+  # Validate all flows in a directory (recursive)
+  kestra flows validate ./flows/
+
+  # Validate with JSON output
+  kestra flows validate ./flows/ --output json`,
+		Aliases: []string{"check"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
+
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+
+			return runFlowsValidate(client, args[0])
+		},
+	}
+
+	return cmd
+}
+
+func runFlowsValidate(client *Client, path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("failed to access path '%s': %w", path, err)
+	}
+
+	var files []string
+	if info.IsDir() {
+		files, err = collectFlowFiles(path)
+		if err != nil {
+			return fmt.Errorf("failed to scan directory '%s': %w", path, err)
+		}
+		if len(files) == 0 {
+			return fmt.Errorf("no .yaml or .yml files found in directory '%s'", path)
+		}
+	} else {
+		files = []string{path}
+	}
+
+	contents := make([]string, 0, len(files))
+	for _, file := range files {
+		data, readErr := os.ReadFile(file)
+		if readErr != nil {
+			return fmt.Errorf("failed to read file '%s': %w", file, readErr)
+		}
+		contents = append(contents, string(data))
+	}
+
+	body := strings.Join(contents, "\n---\n")
+
+	violations, _, err := client.API.FlowsAPI.ValidateFlows(client.Ctx, client.Tenant).
+		Body(body).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return formatValidateResults(violations, files)
+}
+
+func formatValidateResults(violations []kestra.ValidateConstraintViolation, files []string) error {
+	results := make([]ValidateResult, len(files))
+	for i, file := range files {
+		results[i] = ValidateResult{
+			FilePath: file,
+			Success:  true,
+		}
+	}
+
+	unknownResults := make([]ValidateResult, 0)
+
+	for _, violation := range violations {
+		index := int(violation.GetIndex())
+		var target *ValidateResult
+		if index >= 0 && index < len(results) {
+			target = &results[index]
+		} else {
+			unknownResults = append(unknownResults, ValidateResult{
+				FilePath: fmt.Sprintf("<index %d>", index),
+				Success:  true,
+			})
+			target = &unknownResults[len(unknownResults)-1]
+		}
+
+		if flowID := violation.GetFlow(); strings.TrimSpace(flowID) != "" {
+			target.FlowID = flowID
+		}
+		if namespace := violation.GetNamespace(); strings.TrimSpace(namespace) != "" {
+			target.Namespace = namespace
+		}
+		if constraint := strings.TrimSpace(violation.GetConstraints()); constraint != "" {
+			constraint = strings.ReplaceAll(constraint, "\n", "; ")
+			target.Constraints = appendUniqueString(target.Constraints, constraint)
+		}
+		if warnings := violation.GetWarnings(); len(warnings) > 0 {
+			for _, warning := range warnings {
+				warning = strings.ReplaceAll(strings.TrimSpace(warning), "\n", "; ")
+				if warning != "" {
+					target.Warnings = appendUniqueString(target.Warnings, warning)
+				}
+			}
+		}
+		if infos := violation.GetInfos(); len(infos) > 0 {
+			for _, info := range infos {
+				info = strings.ReplaceAll(strings.TrimSpace(info), "\n", "; ")
+				if info != "" {
+					target.Infos = appendUniqueString(target.Infos, info)
+				}
+			}
+		}
+		if deps := violation.GetDeprecationPaths(); len(deps) > 0 {
+			for _, dep := range deps {
+				dep = strings.TrimSpace(dep)
+				if dep != "" {
+					target.DeprecationPaths = appendUniqueString(target.DeprecationPaths, dep)
+				}
+			}
+		}
+		if violation.GetOutdated() {
+			target.Outdated = true
+		}
+	}
+
+	allResults := results
+	if len(unknownResults) > 0 {
+		allResults = append(allResults, unknownResults...)
+	}
+
+	failed := 0
+	for i := range allResults {
+		if len(allResults[i].Constraints) > 0 {
+			allResults[i].Success = false
+			failed++
+		} else {
+			allResults[i].Success = true
+		}
+	}
+
+	if globalFlags.Output == "json" {
+		return printJSON(allResults)
+	}
+
+	w := tabWriter()
+	fmt.Fprintln(w, "FILE\tSTATUS\tCONSTRAINTS\tWARNINGS\tINFOS\tOUTDATED\tDEPRECATIONS")
+	for _, result := range allResults {
+		status := "OK"
+		constraints := "-"
+		if len(result.Constraints) > 0 {
+			status = "FAILED"
+			constraints = strings.Join(result.Constraints, "; ")
+		}
+		warnings := "-"
+		if len(result.Warnings) > 0 {
+			warnings = fmt.Sprintf("%d", len(result.Warnings))
+		}
+		infos := "-"
+		if len(result.Infos) > 0 {
+			infos = fmt.Sprintf("%d", len(result.Infos))
+		}
+		outdated := "false"
+		if result.Outdated {
+			outdated = "true"
+		}
+		deprecations := "-"
+		if len(result.DeprecationPaths) > 0 {
+			deprecations = fmt.Sprintf("%d", len(result.DeprecationPaths))
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			result.FilePath,
+			status,
+			constraints,
+			warnings,
+			infos,
+			outdated,
+			deprecations,
+		)
+	}
+	w.Flush()
+
+	valid := len(allResults) - failed
+	fmt.Printf("\n%d flow(s) valid, %d failed\n", valid, failed)
+	if failed > 0 {
+		return fmt.Errorf("validation failed for %d flow(s)", failed)
+	}
+	return nil
+}
+
+func appendUniqueString(list []string, value string) []string {
+	for _, existing := range list {
+		if existing == value {
+			return list
+		}
+	}
+	return append(list, value)
 }
 
 func runFlowsDeploy(client *Client, path string, override bool, namespaceOverride string, failFast bool) error {

--- a/src/cli/flows_test.go
+++ b/src/cli/flows_test.go
@@ -125,6 +125,36 @@ func TestFlowsDeployCommand_NoArgs(t *testing.T) {
 	}
 }
 
+func TestFlowsValidateCommand_NoArgs(t *testing.T) {
+	// Test that the command requires exactly 1 argument
+	cmd := newFlowsValidateCommand()
+	_, err := executeCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error when no args provided")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Fatalf("expected args error, got: %v", err)
+	}
+}
+
+func TestFlowsValidateCommand_FileNotFound(t *testing.T) {
+	// Override client factory to avoid config errors
+	original := newClientFunc
+	newClientFunc = func() (*Client, error) {
+		return &Client{Tenant: "main"}, nil
+	}
+	defer func() { newClientFunc = original }()
+
+	cmd := newFlowsValidateCommand()
+	_, err := executeCommand(cmd, "/nonexistent/path/flow.yaml")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+	if !strings.Contains(err.Error(), "failed to access path") {
+		t.Fatalf("expected path access error, got: %v", err)
+	}
+}
+
 func TestFlowsDeployCommand_FileNotFound(t *testing.T) {
 	// Override client factory to avoid config errors
 	original := newClientFunc
@@ -309,6 +339,27 @@ func TestFlowsDeployCommand_Help(t *testing.T) {
 		"--fail-fast",
 		"directory",
 		"recursive",
+	}
+	for _, s := range expectedStrings {
+		if !strings.Contains(output, s) {
+			t.Fatalf("expected help to contain '%s', got: %s", s, output)
+		}
+	}
+}
+
+func TestFlowsValidateCommand_Help(t *testing.T) {
+	cmd := newFlowsValidateCommand()
+	output, err := executeCommand(cmd, "--help")
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+
+	// Check for key elements in help text
+	expectedStrings := []string{
+		"validate <path>",
+		"directory",
+		"recursive",
+		"json",
 	}
 	for _, s := range expectedStrings {
 		if !strings.Contains(output, s) {


### PR DESCRIPTION
- Introduced a new command `validate` to validate flow definitions from YAML files or directories.
- Implemented error handling for missing arguments and nonexistent files.
- Added tests for the new command to ensure proper functionality and error reporting.
- Removed error logging from the main function for cleaner output.
- Added example in README.md