### PR TITLE
feat(host-normalization): implement host normalization and add tests

### DIFF
--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -84,7 +84,7 @@ func newClientDefault() (*Client, error) {
 // resolveConfig returns (host, tenant, token, error) using Viper for precedence: flags > env > config file.
 func resolveConfig() (string, string, string, string, string, error) {
 	// Viper handles precedence automatically: flags > env > config > defaults
-	host := viper.GetString(FlagHost)
+	host := strings.TrimSpace(viper.GetString(FlagHost))
 	tenant := viper.GetString(FlagTenant)
 	token := viper.GetString(FlagToken)
 	username := viper.GetString(FlagUsername)
@@ -98,7 +98,23 @@ func resolveConfig() (string, string, string, string, string, error) {
 		tenant = "main"
 	}
 
+	host = normalizeHost(host)
+
 	return host, tenant, token, username, password, nil
+}
+
+func normalizeHost(host string) string {
+	trimmed := strings.TrimSpace(host)
+	if trimmed == "" {
+		return trimmed
+	}
+
+	normalized := strings.TrimRight(trimmed, "/")
+	if normalized == "" {
+		return trimmed
+	}
+
+	return normalized
 }
 
 // formatSDKError extracts a user-friendly message from SDK errors.

--- a/src/cli/client_test.go
+++ b/src/cli/client_test.go
@@ -58,3 +58,51 @@ func TestTryParseNamespaceListFromError(t *testing.T) {
 		t.Fatalf("unexpected second item: %+v", items[1])
 	}
 }
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "no trailing slash",
+			in:   "http://localhost:8080",
+			want: "http://localhost:8080",
+		},
+		{
+			name: "single trailing slash",
+			in:   "http://localhost:8080/",
+			want: "http://localhost:8080",
+		},
+		{
+			name: "multiple trailing slashes",
+			in:   "http://localhost:8080///",
+			want: "http://localhost:8080",
+		},
+		{
+			name: "path trailing slash",
+			in:   "https://example.com/api/",
+			want: "https://example.com/api",
+		},
+		{
+			name: "whitespace",
+			in:   "  https://example.com/api/  ",
+			want: "https://example.com/api",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeHost(tt.in)
+			if got != tt.want {
+				t.Fatalf("expected '%s', got '%s'", tt.want, got)
+			}
+		})
+	}
+}

--- a/src/cli/config.go
+++ b/src/cli/config.go
@@ -84,7 +84,7 @@ func newConfigAddCommand() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			name, host, tenant := args[0], args[1], args[2]
+			name, host, tenant := args[0], normalizeHost(args[1]), args[2]
 
 			var authMethod string
 			if strings.TrimSpace(token) != "" {


### PR DESCRIPTION
- Introduced a new function `normalizeHost` to standardize host input by trimming whitespace and trailing slashes.
- Updated `resolveConfig` to utilize `normalizeHost` for host retrieval.
- Modified command argument parsing to normalize the host before use.
- Added unit tests for `normalizeHost` to ensure expected behavior across various input scenarios.