### PR TITLE
fix(flags): add -v shorthand for verbose

### DIFF
--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -78,7 +78,7 @@ with support for multiple authentication contexts and output formats.`,
 	root.PersistentFlags().StringVar(&globalFlags.Tenant, FlagTenant, "", "Tenant name")
 	root.PersistentFlags().StringVarP(&globalFlags.Output, FlagOutput, "o", "table", "Output format (table or json)")
 	root.PersistentFlags().String(FlagConfig, "", "config file (default is $HOME/.kestra/config.yaml)")
-	root.PersistentFlags().Bool(FlagVerbose, false, "verbose output (warning: it will print credentials in http requests")
+	root.PersistentFlags().BoolP(FlagVerbose, "v", false, "verbose output (warning: it will print credentials in http requests")
 
 	root.AddCommand(newVersionCommand())
 	root.AddCommand(newConfigCommand())


### PR DESCRIPTION
## Summary
- add -v shorthand for the verbose flag on the root command
- keep existing verbose behavior intact