### PR TITLE
fix(flows): allow listing without namespace

### DIFF
--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -132,7 +132,7 @@ func runFlowsList(client *Client, namespace string, renderer *Renderer) error {
 }
 
 func listAllFlows(client *Client) ([]kestra.Flow, error) {
-	const pageSize int32 = 100
+	const pageSize int32 = 1000
 	page := int32(1)
 	results := make([]kestra.Flow, 0)
 

--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -54,18 +54,21 @@ func newFlowsCommand() *cobra.Command {
 
 func newFlowsListCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "list <namespace>",
-		Short: "List flows in a namespace.",
-		Long: `List all flows in the specified namespace.
+		Use:   "list [namespace]",
+		Short: "List flows.",
+		Long: `List flows in a namespace or across all namespaces.
 
 Returns a table showing flow ID, namespace, description, and revision number.`,
 		Example: `  # List all flows in a namespace
   kestra flows list my.namespace
 
+  # List flows across all namespaces
+  kestra flows list
+
   # List flows with JSON output
   kestra flows list my.namespace --output json`,
 		Aliases: []string{"ls"},
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
 			if err != nil {
@@ -76,15 +79,29 @@ Returns a table showing flow ID, namespace, description, and revision number.`,
 				return err
 			}
 
-			return runFlowsList(client, args[0], renderer)
+			namespace := ""
+			if len(args) == 1 {
+				namespace = args[0]
+			}
+			return runFlowsList(client, namespace, renderer)
 		},
 	}
 }
 
 func runFlowsList(client *Client, namespace string, renderer *Renderer) error {
-	flows, _, err := client.API.FlowsAPI.ListFlowsByNamespace(client.Ctx, namespace, client.Tenant).Execute()
-	if err != nil {
-		return formatSDKError(err)
+	var flows []kestra.Flow
+	if namespace == "" {
+		var err error
+		flows, err = listAllFlows(client)
+		if err != nil {
+			return err
+		}
+	} else {
+		var err error
+		flows, _, err = client.API.FlowsAPI.ListFlowsByNamespace(client.Ctx, namespace, client.Tenant).Execute()
+		if err != nil {
+			return formatSDKError(err)
+		}
 	}
 
 	result := make([]map[string]any, len(flows))
@@ -112,6 +129,31 @@ func runFlowsList(client *Client, namespace string, renderer *Renderer) error {
 		}
 		return nil
 	})
+}
+
+func listAllFlows(client *Client) ([]kestra.Flow, error) {
+	const pageSize int32 = 100
+	page := int32(1)
+	results := make([]kestra.Flow, 0)
+
+	for {
+		resp, _, err := client.API.FlowsAPI.SearchFlows(client.Ctx, client.Tenant).
+			Page(page).
+			Size(pageSize).
+			Execute()
+		if err != nil {
+			return nil, formatSDKError(err)
+		}
+		batch := resp.GetResults()
+		results = append(results, batch...)
+
+		if len(batch) == 0 || int64(len(results)) >= resp.GetTotal() {
+			break
+		}
+		page++
+	}
+
+	return results, nil
 }
 
 func newFlowsGetCommand() *cobra.Command {

--- a/src/cli/flows_test.go
+++ b/src/cli/flows_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -90,14 +91,20 @@ func TestParseFlowYAML(t *testing.T) {
 }
 
 func TestFlowsListCommand_NoArgs(t *testing.T) {
-	// Test that the command requires exactly 1 argument
+	// Test that the command allows 0 arguments
+	original := newClientFunc
+	newClientFunc = func() (*Client, error) {
+		return nil, errors.New("client error")
+	}
+	defer func() { newClientFunc = original }()
+
 	cmd := newFlowsListCommand()
 	_, err := executeCommand(cmd)
 	if err == nil {
 		t.Fatal("expected error when no args provided")
 	}
-	if !strings.Contains(err.Error(), "accepts 1 arg") {
-		t.Fatalf("expected args error, got: %v", err)
+	if !strings.Contains(err.Error(), "client error") {
+		t.Fatalf("expected client error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- make `flows list` accept an optional namespace
- list flows across all namespaces when no namespace is provided
- keep output formatting consistent with the namespace-scoped list