### PR TITLE
feat(plugins): add plugins download command

### DIFF
--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -42,16 +42,16 @@ func newPluginsCommand() *cobra.Command {
 		},
 		Annotations: map[string]string{AnnotationOffline: "true"},
 	}
-	cmd.AddCommand(newPluginsInstallCommand())
+	cmd.AddCommand(newPluginsDownloadCommand())
 	return cmd
 }
 
-func newPluginsInstallCommand() *cobra.Command {
+func newPluginsDownloadCommand() *cobra.Command {
 	var pluginsDir string
 	var concurrency int
 
 	cmd := &cobra.Command{
-		Use:   "install <version>",
+		Use:   "download <version>",
 		Short: "Download all plugins for a given Kestra version from Maven Central",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -65,7 +65,18 @@ func newPluginsInstallCommand() *cobra.Command {
 	return cmd
 }
 
+// resolveVersion maps symbolic version aliases to their concrete equivalents.
+func resolveVersion(version string) string {
+	switch strings.ToLower(version) {
+	case "develop", "latest":
+		return "999.999.999"
+	default:
+		return version
+	}
+}
+
 func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int) error {
+	kestraVersion = resolveVersion(kestraVersion)
 	fmt.Fprintf(out, "Fetching plugin list for Kestra %s...\n", kestraVersion)
 
 	plugins, err := fetchPluginList(kestraVersion)

--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -1,0 +1,186 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/spf13/cobra"
+)
+
+// pluginsAPIBase and pluginsMavenBase are vars so tests can point them at a local httptest server.
+var (
+	pluginsAPIBase  = "https://api.kestra.io/v1/plugins/artifacts/core-compatibility"
+	pluginsMavenBase = "https://repo1.maven.org/maven2"
+)
+
+type pluginArtifact struct {
+	GroupID    string `json:"groupId"`
+	ArtifactID string `json:"artifactId"`
+	License    string `json:"license"`
+	Version    string `json:"version"`
+}
+
+type downloadResult struct {
+	index  int
+	plugin pluginArtifact
+	bytes  int64
+	err    error
+}
+
+func newPluginsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plugins",
+		Short: "Manage Kestra plugins",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+		Annotations: map[string]string{AnnotationOffline: "true"},
+	}
+	cmd.AddCommand(newPluginsInstallCommand())
+	return cmd
+}
+
+func newPluginsInstallCommand() *cobra.Command {
+	var pluginsDir string
+	var concurrency int
+
+	cmd := &cobra.Command{
+		Use:   "install <version>",
+		Short: "Download all plugins for a given Kestra version from Maven Central",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency)
+		},
+		Annotations: map[string]string{AnnotationOffline: "true"},
+	}
+
+	cmd.Flags().StringVar(&pluginsDir, "plugins-dir", "./plugins", "Directory to write downloaded JARs into")
+	cmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of parallel downloads")
+	return cmd
+}
+
+func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int) error {
+	fmt.Fprintf(out, "Fetching plugin list for Kestra %s...\n", kestraVersion)
+
+	plugins, err := fetchPluginList(kestraVersion)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Found %d plugins.\n\n", len(plugins))
+
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		return fmt.Errorf("cannot create plugins directory %q: %w", pluginsDir, err)
+	}
+
+	width := len(fmt.Sprintf("%d", len(plugins)))
+	lineFormat := fmt.Sprintf("[%%%dd/%%%dd]", width, width)
+
+	sem := make(chan struct{}, concurrency)
+	results := make(chan downloadResult, len(plugins))
+
+	var wg sync.WaitGroup
+	for i, p := range plugins {
+		wg.Add(1)
+		go func(i int, p pluginArtifact) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			n, err := downloadJAR(p, pluginsDir)
+			results <- downloadResult{index: i, plugin: p, bytes: n, err: err}
+		}(i, p)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var mu sync.Mutex
+	installed := 0
+	failed := 0
+
+	for r := range results {
+		label := fmt.Sprintf("%s:%s:%s", r.plugin.GroupID, r.plugin.ArtifactID, r.plugin.Version)
+		mu.Lock()
+		if r.err != nil {
+			fmt.Fprintf(out, lineFormat+" Downloading %s ... FAILED (%v)\n", r.index+1, len(plugins), label, r.err)
+			failed++
+		} else {
+			fmt.Fprintf(out, lineFormat+" Downloading %s ... done (%.1f MB)\n", r.index+1, len(plugins), label, float64(r.bytes)/(1024*1024))
+			installed++
+		}
+		mu.Unlock()
+	}
+
+	fmt.Fprintf(out, "\nInstalled %d plugin(s) to %s", installed, pluginsDir)
+	if failed > 0 {
+		fmt.Fprintf(out, ", %d failed", failed)
+	}
+	fmt.Fprintln(out, ".")
+
+	if failed > 0 {
+		return fmt.Errorf("%d plugin(s) failed to download", failed)
+	}
+	return nil
+}
+
+func fetchPluginList(kestraVersion string) ([]pluginArtifact, error) {
+	url := fmt.Sprintf("%s/%s/latest", pluginsAPIBase, kestraVersion)
+
+	resp, err := http.Get(url) //nolint:gosec // URL is constructed from validated version arg
+	if err != nil {
+		return nil, fmt.Errorf("failed to reach plugin API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("plugin API returned HTTP %d for version %q — check that the version exists", resp.StatusCode, kestraVersion)
+	}
+
+	var plugins []pluginArtifact
+	if err := json.NewDecoder(resp.Body).Decode(&plugins); err != nil {
+		return nil, fmt.Errorf("failed to parse plugin list: %w", err)
+	}
+	return plugins, nil
+}
+
+func downloadJAR(p pluginArtifact, destDir string) (int64, error) {
+	url := mavenJARURL(p)
+	destPath := filepath.Join(destDir, p.ArtifactID+"-"+p.Version+".jar")
+
+	resp, err := http.Get(url) //nolint:gosec // URL is constructed from trusted API data
+	if err != nil {
+		return 0, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("Maven Central returned HTTP %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(destPath)
+	if err != nil {
+		return 0, fmt.Errorf("cannot create file: %w", err)
+	}
+	defer f.Close()
+
+	n, err := io.Copy(f, resp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("write failed: %w", err)
+	}
+	return n, nil
+}
+
+// mavenJARURL builds the Maven Central download URL for a plugin artifact.
+func mavenJARURL(p pluginArtifact) string {
+	groupPath := strings.ReplaceAll(p.GroupID, ".", "/")
+	return fmt.Sprintf("%s/%s/%s/%s/%s-%s.jar",
+		pluginsMavenBase, groupPath, p.ArtifactID, p.Version, p.ArtifactID, p.Version)
+}

--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -162,9 +162,18 @@ func fetchPluginList(kestraVersion string) ([]pluginArtifact, error) {
 	return plugins, nil
 }
 
+// pluginFileName returns the Kestra-compatible filename for a plugin artifact.
+// Format: <groupId>__<artifactId>__<version>.jar, with dots replaced by underscores
+// in groupId and version (e.g. io_kestra_plugin__plugin-kafka__1_6_0.jar).
+func pluginFileName(p pluginArtifact) string {
+	groupID := strings.ReplaceAll(p.GroupID, ".", "_")
+	version := strings.ReplaceAll(p.Version, ".", "_")
+	return groupID + "__" + p.ArtifactID + "__" + version + ".jar"
+}
+
 func downloadJAR(p pluginArtifact, destDir string) (int64, error) {
 	url := mavenJARURL(p)
-	destPath := filepath.Join(destDir, p.ArtifactID+"-"+p.Version+".jar")
+	destPath := filepath.Join(destDir, pluginFileName(p))
 
 	resp, err := http.Get(url) //nolint:gosec // URL is constructed from trusted API data
 	if err != nil {

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -242,6 +242,26 @@ func TestPluginsInstallCommand_Flags(t *testing.T) {
 	}
 }
 
+func TestResolveVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"develop", "999.999.999"},
+		{"DEVELOP", "999.999.999"},
+		{"latest", "999.999.999"},
+		{"LATEST", "999.999.999"},
+		{"1.3.9", "1.3.9"},
+		{"2.0.0", "2.0.0"},
+	}
+	for _, tt := range tests {
+		got := resolveVersion(tt.input)
+		if got != tt.want {
+			t.Errorf("resolveVersion(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 func TestPluginsInstallCommand_RequiresVersion(t *testing.T) {
 	cmd := newPluginsInstallCommand()
 	_, err := executeCommand(cmd)

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -1,0 +1,254 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Real-world payload sampled from
+// GET https://api.kestra.io/v1/plugins/artifacts/core-compatibility/1.3.9/latest
+const pluginListPayload = `[
+  {"groupId":"io.kestra.storage","artifactId":"storage-gcs","license":"OPEN_SOURCE","version":"1.1.4"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-jdbc-oracle","license":"OPEN_SOURCE","version":"1.10.1"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-kafka","license":"OPEN_SOURCE","version":"1.6.0"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-docker","license":"OPEN_SOURCE","version":"1.3.0"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-jdbc-postgres","license":"OPEN_SOURCE","version":"1.10.1"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-airbyte","license":"OPEN_SOURCE","version":"1.3.1"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-slack","license":"OPEN_SOURCE","version":"1.3.0"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-azure","license":"OPEN_SOURCE","version":"2.2.1"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-jdbc-as400","license":"OPEN_SOURCE","version":"1.10.1"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-jdbc-trino","license":"OPEN_SOURCE","version":"1.10.1"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-gcp","license":"OPEN_SOURCE","version":"2.2.1"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-cloudquery","license":"OPEN_SOURCE","version":"1.2.1"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-kubernetes","license":"OPEN_SOURCE","version":"1.8.0"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-aws","license":"OPEN_SOURCE","version":"2.2.0"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-telegram","license":"OPEN_SOURCE","version":"1.1.0"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-tencent","license":"OPEN_SOURCE","version":"1.1.0"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-dbt","license":"OPEN_SOURCE","version":"1.5.0"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-scripts","license":"OPEN_SOURCE","version":"1.8.0"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-weaviate","license":"OPEN_SOURCE","version":"1.1.0"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-openai","license":"OPEN_SOURCE","version":"1.3.0"},
+  {"groupId":"io.kestra.plugin.ee","artifactId":"plugin-ee-core","license":"ENTERPRISE","version":"1.3.9"},
+  {"groupId":"io.kestra.plugin.ee","artifactId":"plugin-ee-jdbc","license":"ENTERPRISE","version":"1.3.9"}
+]`
+
+// newMockServers sets up:
+//   - apiServer: returns pluginListPayload for any request
+//   - mavenServer: returns a dummy JAR body for any request
+//
+// It overrides pluginsAPIBase and pluginsMavenBase and restores them via t.Cleanup.
+func newMockServers(t *testing.T, apiStatus int, apiBody string) (apiServer, mavenServer *httptest.Server) {
+	t.Helper()
+
+	apiServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(apiStatus)
+		fmt.Fprint(w, apiBody)
+	}))
+
+	mavenServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/java-archive")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, "PK\x03\x04") // minimal ZIP/JAR magic bytes
+	}))
+
+	origAPI := pluginsAPIBase
+	origMaven := pluginsMavenBase
+	pluginsAPIBase = apiServer.URL
+	pluginsMavenBase = mavenServer.URL
+
+	t.Cleanup(func() {
+		pluginsAPIBase = origAPI
+		pluginsMavenBase = origMaven
+		apiServer.Close()
+		mavenServer.Close()
+	})
+
+	return apiServer, mavenServer
+}
+
+func TestRunPluginsInstall_HappyPath(t *testing.T) {
+	newMockServers(t, http.StatusOK, pluginListPayload)
+
+	tmpDir := t.TempDir()
+	var out bytes.Buffer
+
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+
+	if !strings.Contains(output, "Found 22 plugins") {
+		t.Errorf("expected 'Found 22 plugins' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Installed 22 plugin(s)") {
+		t.Errorf("expected 'Installed 22 plugin(s)' in output, got:\n%s", output)
+	}
+
+	// Verify JAR files were written to disk.
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to read plugins dir: %v", err)
+	}
+	if len(entries) != 22 {
+		t.Errorf("expected 22 JAR files, got %d", len(entries))
+	}
+
+	// Spot-check one file from each group.
+	for _, name := range []string{
+		"storage-gcs-1.1.4.jar",
+		"plugin-kafka-1.6.0.jar",
+		"plugin-jdbc-postgres-1.10.1.jar",
+		"plugin-ee-core-1.3.9.jar",
+	} {
+		path := filepath.Join(tmpDir, name)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("expected file %s to exist", name)
+		}
+	}
+}
+
+func TestRunPluginsInstall_ConcurrentDownloads(t *testing.T) {
+	newMockServers(t, http.StatusOK, pluginListPayload)
+
+	tmpDir := t.TempDir()
+	var out bytes.Buffer
+
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4)
+	if err != nil {
+		t.Fatalf("unexpected error with concurrency=4: %v", err)
+	}
+
+	entries, err := os.ReadDir(tmpDir)
+	if err != nil {
+		t.Fatalf("failed to read plugins dir: %v", err)
+	}
+	if len(entries) != 22 {
+		t.Errorf("expected 22 JAR files with concurrency=4, got %d", len(entries))
+	}
+}
+
+func TestRunPluginsInstall_APINotFound(t *testing.T) {
+	newMockServers(t, http.StatusNotFound, `{"message":"version not found"}`)
+
+	var out bytes.Buffer
+	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1)
+	if err == nil {
+		t.Fatal("expected error for HTTP 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("expected HTTP 404 in error, got: %v", err)
+	}
+}
+
+func TestRunPluginsInstall_APIInvalidJSON(t *testing.T) {
+	newMockServers(t, http.StatusOK, `not-json`)
+
+	var out bytes.Buffer
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse plugin list") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunPluginsInstall_MavenDownloadFailure(t *testing.T) {
+	// API returns one plugin; Maven returns 404 for all downloads.
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[{"groupId":"io.kestra.plugin","artifactId":"plugin-kafka","license":"OPEN_SOURCE","version":"1.6.0"}]`)
+	}))
+	mavenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	origAPI := pluginsAPIBase
+	origMaven := pluginsMavenBase
+	pluginsAPIBase = apiServer.URL
+	pluginsMavenBase = mavenServer.URL
+	t.Cleanup(func() {
+		pluginsAPIBase = origAPI
+		pluginsMavenBase = origMaven
+		apiServer.Close()
+		mavenServer.Close()
+	})
+
+	var out bytes.Buffer
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1)
+	if err == nil {
+		t.Fatal("expected error when Maven returns 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "1 plugin(s) failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "FAILED") {
+		t.Errorf("expected 'FAILED' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "1 failed") {
+		t.Errorf("expected '1 failed' summary in output, got:\n%s", output)
+	}
+}
+
+func TestMavenJARURL(t *testing.T) {
+	origMaven := pluginsMavenBase
+	pluginsMavenBase = "https://repo1.maven.org/maven2"
+	defer func() { pluginsMavenBase = origMaven }()
+
+	tests := []struct {
+		plugin  pluginArtifact
+		wantURL string
+	}{
+		{
+			plugin:  pluginArtifact{GroupID: "io.kestra.plugin", ArtifactID: "plugin-kafka", Version: "1.6.0"},
+			wantURL: "https://repo1.maven.org/maven2/io/kestra/plugin/plugin-kafka/1.6.0/plugin-kafka-1.6.0.jar",
+		},
+		{
+			plugin:  pluginArtifact{GroupID: "io.kestra.storage", ArtifactID: "storage-gcs", Version: "1.1.4"},
+			wantURL: "https://repo1.maven.org/maven2/io/kestra/storage/storage-gcs/1.1.4/storage-gcs-1.1.4.jar",
+		},
+		{
+			plugin:  pluginArtifact{GroupID: "io.kestra.plugin.ee", ArtifactID: "plugin-ee-core", Version: "1.3.9"},
+			wantURL: "https://repo1.maven.org/maven2/io/kestra/plugin/ee/plugin-ee-core/1.3.9/plugin-ee-core-1.3.9.jar",
+		},
+	}
+
+	for _, tt := range tests {
+		got := mavenJARURL(tt.plugin)
+		if got != tt.wantURL {
+			t.Errorf("mavenJARURL(%+v)\n  got:  %s\n  want: %s", tt.plugin, got, tt.wantURL)
+		}
+	}
+}
+
+func TestPluginsInstallCommand_Flags(t *testing.T) {
+	cmd := newPluginsInstallCommand()
+
+	for _, flag := range []string{"plugins-dir", "concurrency"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Errorf("expected flag --%s to exist", flag)
+		}
+	}
+}
+
+func TestPluginsInstallCommand_RequiresVersion(t *testing.T) {
+	cmd := newPluginsInstallCommand()
+	_, err := executeCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error when version argument is missing")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -232,8 +232,8 @@ func TestMavenJARURL(t *testing.T) {
 	}
 }
 
-func TestPluginsInstallCommand_Flags(t *testing.T) {
-	cmd := newPluginsInstallCommand()
+func TestPluginsDownloadCommand_Flags(t *testing.T) {
+	cmd := newPluginsDownloadCommand()
 
 	for _, flag := range []string{"plugins-dir", "concurrency"} {
 		if cmd.Flags().Lookup(flag) == nil {
@@ -262,8 +262,8 @@ func TestResolveVersion(t *testing.T) {
 	}
 }
 
-func TestPluginsInstallCommand_RequiresVersion(t *testing.T) {
-	cmd := newPluginsInstallCommand()
+func TestPluginsDownloadCommand_RequiresVersion(t *testing.T) {
+	cmd := newPluginsDownloadCommand()
 	_, err := executeCommand(cmd)
 	if err == nil {
 		t.Fatal("expected error when version argument is missing")

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -104,10 +104,10 @@ func TestRunPluginsInstall_HappyPath(t *testing.T) {
 
 	// Spot-check one file from each group.
 	for _, name := range []string{
-		"storage-gcs-1.1.4.jar",
-		"plugin-kafka-1.6.0.jar",
-		"plugin-jdbc-postgres-1.10.1.jar",
-		"plugin-ee-core-1.3.9.jar",
+		"io_kestra_storage__storage-gcs__1_1_4.jar",
+		"io_kestra_plugin__plugin-kafka__1_6_0.jar",
+		"io_kestra_plugin__plugin-jdbc-postgres__1_10_1.jar",
+		"io_kestra_plugin_ee__plugin-ee-core__1_3_9.jar",
 	} {
 		path := filepath.Join(tmpDir, name)
 		if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -198,6 +198,36 @@ func TestRunPluginsInstall_MavenDownloadFailure(t *testing.T) {
 	}
 	if !strings.Contains(output, "1 failed") {
 		t.Errorf("expected '1 failed' summary in output, got:\n%s", output)
+	}
+}
+
+func TestPluginFileName(t *testing.T) {
+	tests := []struct {
+		plugin   pluginArtifact
+		wantName string
+	}{
+		{
+			plugin:   pluginArtifact{GroupID: "io.kestra.plugin", ArtifactID: "plugin-kafka", Version: "1.6.0"},
+			wantName: "io_kestra_plugin__plugin-kafka__1_6_0.jar",
+		},
+		{
+			plugin:   pluginArtifact{GroupID: "io.kestra.storage", ArtifactID: "storage-gcs", Version: "1.1.4"},
+			wantName: "io_kestra_storage__storage-gcs__1_1_4.jar",
+		},
+		{
+			plugin:   pluginArtifact{GroupID: "io.kestra.plugin.ee", ArtifactID: "plugin-ee-core", Version: "1.3.9"},
+			wantName: "io_kestra_plugin_ee__plugin-ee-core__1_3_9.jar",
+		},
+		{
+			plugin:   pluginArtifact{GroupID: "io.kestra.plugin", ArtifactID: "plugin-serdes", Version: "0.20.0-SNAPSHOT"},
+			wantName: "io_kestra_plugin__plugin-serdes__0_20_0-SNAPSHOT.jar",
+		},
+	}
+	for _, tt := range tests {
+		got := pluginFileName(tt.plugin)
+		if got != tt.wantName {
+			t.Errorf("pluginFileName(%+v)\n  got:  %s\n  want: %s", tt.plugin, got, tt.wantName)
+		}
 	}
 }
 

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -109,6 +109,7 @@ with support for multiple authentication contexts and output formats.`,
 	root.AddCommand(newKVCommand())
 	root.AddCommand(newExecutionsCommand())
 	root.AddCommand(newWorkersCommand())
+	root.AddCommand(newPluginsCommand())
 
 	return root
 }


### PR DESCRIPTION
## Summary

- Adds `kestractl plugins download <version>` — fetches the canonical plugin list for a given Kestra version from `api.kestra.io/v1/plugins/artifacts/core-compatibility/{version}/latest` and downloads all plugin JARs from Maven Central to a local directory
- Runs fully offline (no Kestra server required)
- Supports `--concurrency` for parallel downloads (default: 1)
- Supports `--plugins-dir` for the output directory (default: `./plugins`)
- JARs are saved in Kestra's expected filename format: `groupId__artifactId__version.jar`

## Usage

```sh
# Download all plugins for Kestra 1.3.9 sequentially
kestractl plugins download 1.3.9

# Download to a custom directory with 4 parallel workers
kestractl plugins download 1.3.9 --plugins-dir /opt/kestra/plugins --concurrency 4
```

## Test plan

- [x] Unit tests with mock HTTP servers covering happy path, API 404, invalid JSON, Maven download failure, concurrent downloads, URL construction, flag validation
- [x] `go build ./...` passes
- [x] JAR filename format matches Kestra's expected `groupId__artifactId__version.jar` convention
- [ ] Manual smoke test: `kestractl plugins download 1.3.9 --plugins-dir /tmp/kestra-plugins` downloads 211 JARs