### PR TITLE
fix(nsfiles): trust HTTP status in namespace existence check

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ go install ./...
 Configure your Kestra instance and credentials:
 
 ```bash
+# Token auth
 kestractl config add default http://localhost:8080 main --token YOUR_TOKEN --default
+
+# Basic auth (username + password)
+kestractl config add default http://localhost:8080 main --username you@example.com --password YOUR_PASSWORD --default
 ```
 
 This creates a configuration file at `~/.kestractl/config.yaml`:
@@ -118,6 +122,8 @@ Set `KESTRACTL_TELEMETRY_DISABLED=true` to disable telemetry.
 All commands support global flags for connection and output configuration:
 - `--host` - Kestra host URL
 - `--token` / `-t` - API authentication token
+- `--username` - Basic auth username (alternative to `--token`)
+- `--password` - Basic auth password (alternative to `--token`)
 - `--tenant` - Tenant name
 - `--header` - Extra HTTP header to include in all requests (format: `Key:Value`, repeatable)
 - `--output` / `-o` - Output format (`table` or `json`)
@@ -265,6 +271,9 @@ kestractl nsfiles upload my.namespace ./assets resources --override
 # Stop on the first error
 kestractl nsfiles upload my.namespace ./assets resources --fail-fast
 
+# Skip the pre-flight namespace existence check
+kestractl nsfiles upload my.namespace ./assets resources --allow-missing-namespace
+
 # Delete a file
 kestractl nsfiles delete my.namespace workflows/example.yaml
 
@@ -273,6 +282,29 @@ kestractl nsfiles delete my.namespace workflows --recursive
 
 # Ignore missing targets
 kestractl nsfiles delete my.namespace workflows/example.yaml --force
+```
+
+### Plugins
+
+```bash
+# Download every plugin JAR for a given Kestra version into ./plugins
+kestractl plugins download 1.3.9
+
+# Custom output directory
+kestractl plugins download 1.3.9 --plugins-dir ./vendor/plugins
+
+# Parallel downloads
+kestractl plugins download 1.3.9 --concurrency 4
+
+# `develop` and `latest` are aliases for the in-development version
+kestractl plugins download develop
+```
+
+### Workers
+
+```bash
+# Generate a worker registration token (runs offline, no Kestra instance required)
+kestractl workers registration-tokens generate
 ```
 
 ### Output Formats
@@ -323,9 +355,13 @@ kestractl/
 └── src/cli/
     ├── root.go                # Root command, global flags, Viper initialization
     ├── client.go              # Client wrapper for SDK with Viper config resolution
+    ├── client_test.go         # Unit tests
     ├── auth.go                # AuthManager - ~/.kestractl/config.yaml persistence (YAML)
+    ├── auth_test.go           # Unit tests
     ├── render.go              # Renderer: table or JSON output
+    ├── render_test.go         # Unit tests
     ├── telemetry.go           # PostHog event per command (disable via env var)
+    ├── telemetry_test.go      # Unit tests
     ├── config.go              # Config subcommands (add, show, use, remove)
     ├── flows.go               # Flows commands (list, get, deploy, validate)
     ├── flows_test.go          # Unit tests
@@ -337,6 +373,10 @@ kestractl/
     ├── kv_test.go             # Unit tests
     ├── nsfiles.go             # Namespace files commands (list, get, upload, delete)
     ├── nsfiles_test.go        # Unit tests
+    ├── plugins.go             # Plugins commands (download)
+    ├── plugins_test.go        # Unit tests
+    ├── workers.go             # Workers commands (registration-tokens generate)
+    ├── workers_test.go        # Unit tests
     └── testdata/              # Test fixtures
         └── flow.yaml
 ```

--- a/src/cli/nsfiles.go
+++ b/src/cli/nsfiles.go
@@ -593,13 +593,19 @@ func listNamespaceDirectory(client *Client, namespace, path string) ([]kestra.Fi
 
 func namespaceExists(client *Client, namespace string) (bool, error) {
 	_, resp, err := client.API.NamespacesAPI.Namespace(client.Ctx, namespace, client.Tenant).Execute()
-	if err != nil {
-		if resp != nil && resp.StatusCode == 404 {
+	if err == nil {
+		return true, nil
+	}
+	if resp != nil {
+		if resp.StatusCode == 404 {
 			return false, nil
 		}
-		return false, formatSDKError(err)
+		// OSS responses omit SDK-required fields, surfacing 2xx as a decode error.
+		if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			return true, nil
+		}
 	}
-	return true, nil
+	return false, formatSDKError(err)
 }
 
 func lookupNamespaceFileStats(client *Client, namespace, path string) (*kestra.FileAttributes, bool, error) {

--- a/src/cli/nsfiles_test.go
+++ b/src/cli/nsfiles_test.go
@@ -1,9 +1,72 @@
 package cli
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
 )
+
+func newTestClient(t *testing.T, serverURL string) *Client {
+	t.Helper()
+	cfg := kestra.NewConfiguration()
+	cfg.Servers = kestra.ServerConfigurations{{URL: serverURL}}
+	return &Client{
+		API:    kestra.NewAPIClient(cfg),
+		Ctx:    context.Background(),
+		Tenant: "main",
+	}
+}
+
+func TestNamespaceExists_OSSResponseMissingDeleted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"main"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	exists, err := namespaceExists(newTestClient(t, server.URL), "main")
+	if err != nil {
+		t.Fatalf("expected no error for 200 response, got: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected namespace to be reported as existing")
+	}
+}
+
+func TestNamespaceExists_404(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	exists, err := namespaceExists(newTestClient(t, server.URL), "missing")
+	if err != nil {
+		t.Fatalf("expected no error for 404 response, got: %v", err)
+	}
+	if exists {
+		t.Fatal("expected namespace to be reported as missing")
+	}
+}
+
+func TestNamespaceExists_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	exists, err := namespaceExists(newTestClient(t, server.URL), "main")
+	if err == nil {
+		t.Fatal("expected error for 500 response, got nil")
+	}
+	if exists {
+		t.Fatal("expected namespace to be reported as missing on server error")
+	}
+}
 
 func TestNamespaceFilesCommand_Structure(t *testing.T) {
 	cmd := newNamespaceFilesCommand()


### PR DESCRIPTION
Closes #48 

## Changes

- The nsfiles upload was failing on Kestra OSS because the pre-flight namespace existence check tried to decode the response into the SDK's Namespace model, which requires a deleted field that OSS doesn't return. We made the check trust the HTTP status instead; a 2xx means the namespace exists, even if the body can't be decoded.
- update README with authentication methods and new commands

## Test done
- [x] `nsfiles upload` against Kestra OSS succeeds
- [x] `nsfiles upload` against Kestra EE still works
- [x] Nonexistent namespace still errors with `namespace '<name>' does not exist`
- [x] `go test ./src/cli/... -run TestNamespaceExists` passes
