### PR TITLE
feat: add IAM user commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Compiled binary (built via `go build -o kestractl`)
+/kestractl
+
 # Python-generated files
 __pycache__/
 *.py[oc]
@@ -21,5 +24,3 @@ wheels/
 .idea
 
 .planning/.*
-
-.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kestra CLI
 
-A Go-based command-line interface for managing Kestra flows, executions, and namespaces.
+A Go-based command-line interface for managing Kestra flows, executions, namespaces, and IAM users.
 
 ## Installation
 
@@ -307,6 +307,47 @@ kestractl plugins download develop
 kestractl workers registration-tokens generate
 ```
 
+### Users (Enterprise Edition)
+
+User management requires Kestra Enterprise Edition. Users are instance-level resources.
+
+> Use `--user-password` to set a user's password — not `--password`, which is the
+> global basic-auth flag used to authenticate the CLI itself.
+
+```bash
+# List / filter users (alias: ls)
+kestractl users list
+kestractl users list --query alice --output json
+
+# Get user details (alias: show, describe)
+kestractl users get <user_id>
+
+# Create a user (--email is required)
+kestractl users create --email alice@example.com --first-name Alice --user-password 'S3cret!'
+
+# Create a super-admin
+kestractl users create --email bob@example.com --superadmin
+
+# Update a user — only the flags you pass change; other attributes are preserved
+kestractl users update <user_id> --first-name Alicia
+kestractl users update <user_id> --superadmin=false
+
+# Set a user's password
+kestractl users set-password <user_id> --user-password 'N3wPass!'
+
+# Set the groups a user belongs to in the active tenant (no --group clears them)
+kestractl users set-groups <user_id> --group <group_id>
+
+# Delete a user (alias: rm) — prompts for confirmation unless --yes
+kestractl users delete <user_id>
+kestractl users delete <user_id> --yes
+
+# Manage a user's API tokens (the full token is shown only once, at creation)
+kestractl users tokens create <user_id> --name ci-token
+kestractl users tokens list <user_id>
+kestractl users tokens delete <user_id> <token_id>
+```
+
 ### Output Formats
 
 ```bash
@@ -377,6 +418,8 @@ kestractl/
     ├── plugins_test.go        # Unit tests
     ├── workers.go             # Workers commands (registration-tokens generate)
     ├── workers_test.go        # Unit tests
+    ├── users.go               # IAM users commands (list, get, create, update, delete, set-groups, set-password, tokens)
+    ├── users_test.go          # Unit tests
     └── testdata/              # Test fixtures
         └── flow.yaml
 ```

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -77,7 +77,10 @@ with support for multiple authentication contexts and output formats.`,
 				fmt.Printf("resolved params: \n")
 				cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 					v := flag.Value.String()
-					if v != "" && (flag.Name == FlagToken || flag.Name == FlagPassword) {
+					// Mask any credential-bearing flag, not just the global
+					// token/password ones (e.g. users --user-password).
+					name := strings.ToLower(flag.Name)
+					if v != "" && (strings.Contains(name, "token") || strings.Contains(name, "password")) {
 						v = "XXX"
 					}
 					fmt.Printf("\t%s: %s\n", flag.Name, v)
@@ -110,6 +113,7 @@ with support for multiple authentication contexts and output formats.`,
 	root.AddCommand(newExecutionsCommand())
 	root.AddCommand(newWorkersCommand())
 	root.AddCommand(newPluginsCommand())
+	root.AddCommand(newUsersCommand())
 
 	return root
 }

--- a/src/cli/users.go
+++ b/src/cli/users.go
@@ -1,0 +1,697 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/spf13/cobra"
+)
+
+func newUsersCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "users",
+		Short: "Manage IAM users (list, get, create, update, delete)",
+		Long: `Manage IAM users in your Kestra instance.
+
+Users are instance-level resources. Managing users requires Kestra Enterprise Edition.`,
+	}
+
+	cmd.AddCommand(newUsersListCommand())
+	cmd.AddCommand(newUsersGetCommand())
+	cmd.AddCommand(newUsersCreateCommand())
+	cmd.AddCommand(newUsersUpdateCommand())
+	cmd.AddCommand(newUsersDeleteCommand())
+	cmd.AddCommand(newUsersSetGroupsCommand())
+	cmd.AddCommand(newUsersSetPasswordCommand())
+	cmd.AddCommand(newUsersTokensCommand())
+
+	return cmd
+}
+
+// userMutation holds the fields used to create or update a user, plus a record
+// of which flags the operator explicitly set.
+//
+// The *Set fields matter because the update endpoint is a full-replace PUT: any
+// attribute absent from the request body is reset to its default server-side
+// (omitting superAdmin demotes the user, omitting groups clears them, etc.).
+// So update fetches the current user and overlays only the changed flags via
+// applyTo, while create builds a fresh request via toRequest.
+type userMutation struct {
+	email      string
+	firstName  string
+	lastName   string
+	password   string
+	groups     []string
+	tenants    []string
+	superAdmin bool
+	restricted bool
+
+	emailSet      bool
+	firstNameSet  bool
+	lastNameSet   bool
+	passwordSet   bool
+	groupsSet     bool
+	tenantsSet    bool
+	superAdminSet bool
+	restrictedSet bool
+}
+
+// markChanged records which flags the operator actually passed on the command.
+func (m *userMutation) markChanged(cmd *cobra.Command) {
+	f := cmd.Flags()
+	m.emailSet = f.Changed("email")
+	m.firstNameSet = f.Changed("first-name")
+	m.lastNameSet = f.Changed("last-name")
+	m.passwordSet = f.Changed("user-password")
+	m.groupsSet = f.Changed("group")
+	m.tenantsSet = f.Changed("tenant-grant")
+	m.superAdminSet = f.Changed("superadmin")
+	m.restrictedSet = f.Changed("restricted")
+}
+
+// toRequest builds a create request from scratch.
+func (m userMutation) toRequest() kestra.IAMUserControllerApiCreateOrUpdateUserRequest {
+	req := kestra.IAMUserControllerApiCreateOrUpdateUserRequest{
+		Email: m.email,
+	}
+	m.applyTo(&req)
+	return req
+}
+
+// applyTo overlays the explicitly-set fields onto req, leaving everything else
+// (e.g. an existing user's attributes seeded from a GET) untouched.
+func (m userMutation) applyTo(req *kestra.IAMUserControllerApiCreateOrUpdateUserRequest) {
+	if m.emailSet {
+		req.Email = m.email
+	}
+	if m.firstNameSet {
+		req.FirstName = &m.firstName
+	}
+	if m.lastNameSet {
+		req.LastName = &m.lastName
+	}
+	if m.passwordSet {
+		req.Password = &m.password
+	}
+	if m.groupsSet {
+		req.Groups = m.groups
+	}
+	if m.tenantsSet {
+		req.Tenants = m.tenants
+	}
+	if m.superAdminSet {
+		req.SuperAdmin = &m.superAdmin
+	}
+	if m.restrictedSet {
+		req.Restricted = &m.restricted
+	}
+}
+
+// userRequestFromExisting seeds a full create/update request from a fetched
+// user, so a full-replace PUT preserves attributes the operator didn't touch.
+func userRequestFromExisting(u *kestra.IAMUserControllerApiUser) kestra.IAMUserControllerApiCreateOrUpdateUserRequest {
+	req := kestra.IAMUserControllerApiCreateOrUpdateUserRequest{Email: u.GetEmail()}
+	if u.FirstName != nil {
+		req.FirstName = u.FirstName
+	}
+	if u.LastName != nil {
+		req.LastName = u.LastName
+	}
+	if u.SuperAdmin != nil {
+		req.SuperAdmin = u.SuperAdmin
+	}
+	if u.Restricted != nil {
+		req.Restricted = u.Restricted
+	}
+	if groups := u.GetGroups(); len(groups) > 0 {
+		ids := make([]string, 0, len(groups))
+		for _, g := range groups {
+			ids = append(ids, g.GetId())
+		}
+		req.Groups = ids
+	}
+	if tenants := u.GetTenants(); len(tenants) > 0 {
+		ids := make([]string, 0, len(tenants))
+		for _, tn := range tenants {
+			ids = append(ids, tn.GetId())
+		}
+		req.Tenants = ids
+	}
+	return req
+}
+
+// addMutationFlags wires the create/update flags shared by both commands.
+func addMutationFlags(cmd *cobra.Command, m *userMutation) {
+	cmd.Flags().StringVar(&m.email, "email", "", "User email (login)")
+	cmd.Flags().StringVar(&m.firstName, "first-name", "", "First name")
+	cmd.Flags().StringVar(&m.lastName, "last-name", "", "Last name")
+	cmd.Flags().StringVar(&m.password, "user-password", "", "Password for the user (avoids clashing with the global --password basic-auth flag)")
+	cmd.Flags().StringArrayVar(&m.groups, "group", nil, "Group ID to assign (repeatable)")
+	cmd.Flags().StringArrayVar(&m.tenants, "tenant-grant", nil, "Tenant ID to grant access to (repeatable)")
+	cmd.Flags().BoolVar(&m.superAdmin, "superadmin", false, "Grant super-admin privileges")
+	cmd.Flags().BoolVar(&m.restricted, "restricted", false, "Mark the user as restricted")
+}
+
+func newUsersListCommand() *cobra.Command {
+	var (
+		query string
+		page  int32
+		size  int32
+		sort  []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List users.",
+		Long:  "List all users in your Kestra instance, optionally filtered with --query.",
+		Example: `  # List all users
+	  kestractl users list
+
+	  # Filter users
+	  kestractl users list --query alice
+
+	  # List users as JSON
+	  kestractl users list --output json`,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runUsersList(client, query, page, size, sort, renderer)
+		},
+	}
+
+	cmd.Flags().StringVarP(&query, "query", "q", "", "Filter users by search query")
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (e.g. 'username:asc', repeatable)")
+
+	return cmd
+}
+
+func runUsersList(client *Client, query string, page, size int32, sort []string, renderer *Renderer) error {
+	req := client.API.UsersAPI.ListUsers(client.Ctx).Page(page).Size(size)
+	if query != "" {
+		req = req.Q(query)
+	}
+	if len(sort) > 0 {
+		req = req.Sort(sort)
+	}
+
+	resp, _, err := req.Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	results := resp.GetResults()
+	if results == nil {
+		// Render an empty JSON array ([]) rather than null on no results.
+		results = []kestra.IAMUserControllerApiUserSummary{}
+	}
+
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ID\tUSERNAME\tDISPLAY NAME\tSUPERADMIN")
+		for _, u := range results {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%t\n",
+				u.GetId(), u.GetUsername(), u.GetDisplayName(), u.GetSuperAdmin())
+		}
+		fmt.Fprintf(w, "\nTotal users: %d\n", resp.GetTotal())
+		return nil
+	})
+}
+
+func newUsersGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "get <user_id>",
+		Short:   "Get user details.",
+		Long:    "Retrieve detailed information about a specific user.",
+		Aliases: []string{"show", "describe"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runUsersGet(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runUsersGet(client *Client, id string, renderer *Renderer) error {
+	user, _, err := client.API.UsersAPI.User(client.Ctx, id).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderUserDetail(user, renderer)
+}
+
+func renderUserDetail(user *kestra.IAMUserControllerApiUser, renderer *Renderer) error {
+	return renderer.Render(user, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "User Details")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ID:\t%s\n", user.GetId())
+		fmt.Fprintf(w, "Username:\t%s\n", user.GetUsername())
+		fmt.Fprintf(w, "Display Name:\t%s\n", user.GetDisplayName())
+		fmt.Fprintf(w, "Email:\t%s\n", user.GetEmail())
+		fmt.Fprintf(w, "First Name:\t%s\n", user.GetFirstName())
+		fmt.Fprintf(w, "Last Name:\t%s\n", user.GetLastName())
+		fmt.Fprintf(w, "Super Admin:\t%t\n", user.GetSuperAdmin())
+		fmt.Fprintf(w, "Restricted:\t%t\n", user.GetRestricted())
+
+		if groups := user.GetGroups(); len(groups) > 0 {
+			ids := make([]string, len(groups))
+			for i, g := range groups {
+				ids[i] = g.GetId()
+			}
+			fmt.Fprintf(w, "Groups:\t%s\n", strings.Join(ids, ", "))
+		}
+		if tenants := user.GetTenants(); len(tenants) > 0 {
+			names := make([]string, len(tenants))
+			for i, tn := range tenants {
+				names[i] = tn.GetId()
+			}
+			fmt.Fprintf(w, "Tenants:\t%s\n", strings.Join(names, ", "))
+		}
+		return nil
+	})
+}
+
+func newUsersCreateCommand() *cobra.Command {
+	var m userMutation
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a user.",
+		Long:  "Create a new user. The --email flag is required.",
+		Example: `  # Create a user
+	  kestractl users create --email alice@example.com --first-name Alice
+
+	  # Create a super-admin with a password and group
+	  kestractl users create --email bob@example.com --user-password 's3cret' --superadmin --group my-group-id`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			m.markChanged(cmd)
+			return runUsersCreate(client, m, renderer)
+		},
+	}
+
+	addMutationFlags(cmd, &m)
+	_ = cmd.MarkFlagRequired("email")
+
+	return cmd
+}
+
+func runUsersCreate(client *Client, m userMutation, renderer *Renderer) error {
+	user, _, err := client.API.UsersAPI.CreateUser(client.Ctx).
+		IAMUserControllerApiCreateOrUpdateUserRequest(m.toRequest()).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderUserDetail(user, renderer)
+}
+
+func newUsersUpdateCommand() *cobra.Command {
+	var m userMutation
+
+	cmd := &cobra.Command{
+		Use:   "update <user_id>",
+		Short: "Update a user.",
+		Long: `Update an existing user.
+
+Only the flags you pass are changed; all other attributes are preserved. The
+server endpoint is a full replace, so the current user is fetched first and the
+changed fields are merged on top before saving.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			m.markChanged(cmd)
+			return runUsersUpdate(client, args[0], m, renderer)
+		},
+	}
+
+	addMutationFlags(cmd, &m)
+
+	return cmd
+}
+
+func runUsersUpdate(client *Client, id string, m userMutation, renderer *Renderer) error {
+	// The update endpoint is a full-replace PUT, so fetch the current user and
+	// overlay only the changed flags — otherwise unspecified attributes (e.g.
+	// superAdmin, groups) would be reset to their defaults.
+	current, _, err := client.API.UsersAPI.User(client.Ctx, id).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	req := userRequestFromExisting(current)
+	m.applyTo(&req)
+
+	user, _, err := client.API.UsersAPI.UpdateUser(client.Ctx, id).
+		IAMUserControllerApiCreateOrUpdateUserRequest(req).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderUserDetail(user, renderer)
+}
+
+func newUsersDeleteCommand() *cobra.Command {
+	var skipConfirm bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <user_id>",
+		Short:   "Delete a user.",
+		Long:    "Delete a user. Prompts for confirmation unless --yes is provided.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runUsersDelete(client, args[0], skipConfirm, cmd.InOrStdin(), renderer)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation prompt")
+
+	return cmd
+}
+
+func runUsersDelete(client *Client, id string, skipConfirm bool, in io.Reader, renderer *Renderer) error {
+	if !skipConfirm {
+		// Prompt on stderr so it never pollutes stdout (e.g. --output json).
+		confirmed, err := confirm(in, os.Stderr,
+			fmt.Sprintf("Are you sure you want to delete user '%s'? [y/N]: ", id))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return renderStatus(renderer, "Cancelled.", map[string]any{"id": id, "status": "cancelled"})
+		}
+	}
+
+	if _, err := client.API.UsersAPI.DeleteUser(client.Ctx, id).Execute(); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("User '%s' deleted.", id),
+		map[string]any{"id": id, "status": "deleted"})
+}
+
+func newUsersSetGroupsCommand() *cobra.Command {
+	var groups []string
+
+	cmd := &cobra.Command{
+		Use:   "set-groups <user_id>",
+		Short: "Set the groups a user belongs to.",
+		Long:  "Replace the set of groups a user belongs to within the active tenant.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runUsersSetGroups(client, args[0], groups, renderer)
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&groups, "group", nil, "Group ID (repeatable). Pass none to clear all groups.")
+
+	return cmd
+}
+
+func runUsersSetGroups(client *Client, id string, groups []string, renderer *Renderer) error {
+	// A nil slice is dropped by the SDK serializer (IsNil), so "clear all groups"
+	// (no --group flags) would be a no-op. Send a non-nil empty slice instead,
+	// which serializes to "groupIds": [] and actually clears membership.
+	if groups == nil {
+		groups = []string{}
+	}
+
+	body := kestra.IAMUserGroupControllerApiUpdateUserGroupsRequest{GroupIds: groups}
+	if _, err := client.API.UsersAPI.UpdateUserGroups(client.Ctx, id, client.Tenant).
+		IAMUserGroupControllerApiUpdateUserGroupsRequest(body).
+		Execute(); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("Groups updated for user '%s'.", id),
+		map[string]any{"id": id, "status": "groups-updated", "groups": groups})
+}
+
+func newUsersSetPasswordCommand() *cobra.Command {
+	var password string
+
+	cmd := &cobra.Command{
+		Use:   "set-password <user_id>",
+		Short: "Set a user's password.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runUsersSetPassword(client, args[0], password, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&password, "user-password", "", "New password for the user")
+	_ = cmd.MarkFlagRequired("user-password")
+
+	return cmd
+}
+
+func runUsersSetPassword(client *Client, id, password string, renderer *Renderer) error {
+	body := kestra.IAMUserControllerApiPatchUserPasswordRequest{Password: password}
+	if _, _, err := client.API.UsersAPI.PatchUserPassword(client.Ctx, id).
+		IAMUserControllerApiPatchUserPasswordRequest(body).
+		Execute(); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("Password updated for user '%s'.", id),
+		map[string]any{"id": id, "status": "password-updated"})
+}
+
+func newUsersTokensCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tokens",
+		Short: "Manage API tokens for a user (list, create, delete)",
+	}
+
+	cmd.AddCommand(newUsersTokensListCommand())
+	cmd.AddCommand(newUsersTokensCreateCommand())
+	cmd.AddCommand(newUsersTokensDeleteCommand())
+
+	return cmd
+}
+
+func newUsersTokensListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list <user_id>",
+		Short:   "List API tokens for a user.",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runUsersTokensList(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runUsersTokensList(client *Client, userID string, renderer *Renderer) error {
+	resp, _, err := client.API.UsersAPI.ListApiTokensForUser(client.Ctx, userID).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	tokens := resp.GetResults()
+	if tokens == nil {
+		// Render an empty JSON array ([]) rather than null on no results.
+		tokens = []kestra.ApiToken{}
+	}
+
+	return renderer.Render(tokens, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ID\tNAME\tPREFIX\tEXPIRED\tLAST USED")
+		for _, tok := range tokens {
+			lastUsed := ""
+			if tok.LastUsed != nil {
+				lastUsed = tok.LastUsed.Format(time.RFC3339)
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%t\t%s\n",
+				tok.GetId(), tok.GetName(), tok.GetPrefix(), tok.GetExpired(), lastUsed)
+		}
+		fmt.Fprintf(w, "\nTotal tokens: %d\n", len(tokens))
+		return nil
+	})
+}
+
+func newUsersTokensCreateCommand() *cobra.Command {
+	var (
+		name        string
+		description string
+		maxAge      string
+		extended    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create <user_id>",
+		Short: "Create an API token for a user.",
+		Long: `Create an API token for a user.
+
+The full token value is shown only once, at creation time. Store it securely.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runUsersTokensCreate(client, args[0], name, description, maxAge, extended, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Token name (lowercase alphanumeric and dashes)")
+	cmd.Flags().StringVar(&description, "description", "", "Token description")
+	cmd.Flags().StringVar(&maxAge, "max-age", "", "Token max age (ISO-8601 duration, e.g. P30D)")
+	cmd.Flags().BoolVar(&extended, "extended", false, "Create an extended token")
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func runUsersTokensCreate(client *Client, userID, name, description, maxAge string, extended bool, renderer *Renderer) error {
+	body := kestra.CreateApiTokenRequest{Name: name, Extended: &extended}
+	if description != "" {
+		body.Description = &description
+	}
+	if maxAge != "" {
+		body.MaxAge = &maxAge
+	}
+
+	resp, _, err := client.API.UsersAPI.CreateApiTokensForUser(client.Ctx, userID).
+		CreateApiTokenRequest(body).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderer.Render(resp, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "API token created.")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ID:\t%s\n", resp.GetId())
+		fmt.Fprintf(w, "Name:\t%s\n", resp.GetName())
+		fmt.Fprintf(w, "Token:\t%s\n", resp.GetFullToken())
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Store this token now — it will not be shown again.")
+		return nil
+	})
+}
+
+func newUsersTokensDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete <user_id> <token_id>",
+		Short:   "Delete an API token for a user.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runUsersTokensDelete(client, args[0], args[1], renderer)
+		},
+	}
+	return cmd
+}
+
+func runUsersTokensDelete(client *Client, userID, tokenID string, renderer *Renderer) error {
+	if _, err := client.API.UsersAPI.DeleteApiTokenForUser(client.Ctx, userID, tokenID).Execute(); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("Token '%s' deleted for user '%s'.", tokenID, userID),
+		map[string]any{"id": tokenID, "userId": userID, "status": "deleted"})
+}
+
+// renderStatus reports the outcome of a mutating command: a JSON object when
+// --output json is set, or a plain-text message in table mode. This keeps
+// commands that have no resource body to return (delete, set-groups, …)
+// honoring the JSON output contract.
+func renderStatus(renderer *Renderer, message string, fields map[string]any) error {
+	return renderer.Render(fields, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, message)
+		return nil
+	})
+}
+
+// confirm prints prompt to w and reads a yes/no answer from in.
+// It returns true only for "y" or "yes" (case-insensitive).
+func confirm(in io.Reader, w io.Writer, prompt string) (bool, error) {
+	fmt.Fprint(w, prompt)
+	line, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
+}

--- a/src/cli/users_test.go
+++ b/src/cli/users_test.go
@@ -1,0 +1,399 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTableRenderer(out io.Writer) *Renderer {
+	r, _ := NewRenderer(OutputTable, out)
+	return r
+}
+
+func newJSONRenderer(out io.Writer) *Renderer {
+	r, _ := NewRenderer(OutputJSON, out)
+	return r
+}
+
+// captureBody spins up a server that records the decoded JSON request body.
+func captureBody(t *testing.T, status int, respBody string) (*httptest.Server, *map[string]any) {
+	t.Helper()
+	body := map[string]any{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(respBody))
+	}))
+	t.Cleanup(server.Close)
+	return server, &body
+}
+
+func TestUsersCommand_Structure(t *testing.T) {
+	cmd := newUsersCommand()
+	if cmd.Use != "users" {
+		t.Fatalf("expected use 'users', got %q", cmd.Use)
+	}
+
+	want := map[string]bool{
+		"list": false, "get": false, "create": false, "update": false,
+		"delete": false, "set-groups": false, "set-password": false, "tokens": false,
+	}
+	for _, sub := range cmd.Commands() {
+		name := strings.Fields(sub.Use)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestUsersCreateCommand_RequiredEmail(t *testing.T) {
+	cmd := newUsersCreateCommand()
+	if cmd.Flags().Lookup("email") == nil {
+		t.Fatal("expected --email flag")
+	}
+	if cmd.Flags().Lookup("tenant-grant") == nil {
+		t.Fatal("expected --tenant-grant flag")
+	}
+	// email is marked required
+	if _, err := executeCommand(cmd); err == nil {
+		t.Fatal("expected error when --email is missing")
+	}
+}
+
+func TestUsersDeleteCommand_HasYesFlag(t *testing.T) {
+	cmd := newUsersDeleteCommand()
+	f := cmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("expected --yes flag")
+	}
+	if f.Shorthand != "y" {
+		t.Fatalf("expected -y shorthand, got %q", f.Shorthand)
+	}
+}
+
+func TestConfirm(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"y\n", true},
+		{"Y\n", true},
+		{"yes\n", true},
+		{"YES\n", true},
+		{"n\n", false},
+		{"\n", false},
+		{"nope\n", false},
+		{"", false}, // EOF
+	}
+	for _, c := range cases {
+		var buf bytes.Buffer
+		got, err := confirm(strings.NewReader(c.in), &buf, "prompt: ")
+		if err != nil {
+			t.Fatalf("confirm(%q) error: %v", c.in, err)
+		}
+		if got != c.want {
+			t.Errorf("confirm(%q) = %v, want %v", c.in, got, c.want)
+		}
+		if !strings.Contains(buf.String(), "prompt: ") {
+			t.Errorf("confirm did not write prompt for input %q", c.in)
+		}
+	}
+}
+
+func TestRunUsersList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"u1","username":"alice","displayName":"Alice","superAdmin":true},
+			{"id":"u2","username":"bob","displayName":"Bob","superAdmin":false}
+		],"total":2}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runUsersList(newTestClient(t, server.URL), "", 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runUsersList error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"alice", "bob", "Alice", "true", "Total users: 2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunUsersGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"u1","username":"alice","email":"alice@example.com",
+			"superAdmin":true,"groups":[{"id":"g1"}],"tenants":[{"id":"main"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runUsersGet(newTestClient(t, server.URL), "u1", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runUsersGet error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"alice@example.com", "g1", "main", "Super Admin:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunUsersCreate_SendsBody(t *testing.T) {
+	var gotBody map[string]any
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"new","username":"alice","email":"alice@example.com"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	m := userMutation{
+		email:        "alice@example.com",
+		firstName:    "Alice",
+		groups:       []string{"g1"},
+		emailSet:     true,
+		firstNameSet: true,
+		groupsSet:    true,
+	}
+	var buf bytes.Buffer
+	if err := runUsersCreate(newTestClient(t, server.URL), m, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runUsersCreate error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotBody["email"] != "alice@example.com" {
+		t.Errorf("expected email in body, got %v", gotBody["email"])
+	}
+	if gotBody["firstName"] != "Alice" {
+		t.Errorf("expected firstName in body, got %v", gotBody["firstName"])
+	}
+	if !strings.Contains(buf.String(), "alice@example.com") {
+		t.Errorf("expected created user rendered, got:\n%s", buf.String())
+	}
+}
+
+func TestRunUsersDelete_CancelMakesNoRequest(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runUsersDelete(newTestClient(t, server.URL), "u1", false, strings.NewReader("n\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runUsersDelete error: %v", err)
+	}
+	if hit {
+		t.Error("expected no API request when deletion is cancelled")
+	}
+	if !strings.Contains(buf.String(), "Cancelled") {
+		t.Errorf("expected cancellation message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunUsersDelete_Confirmed(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runUsersDelete(newTestClient(t, server.URL), "u1", false, strings.NewReader("y\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runUsersDelete error: %v", err)
+	}
+	if !hit {
+		t.Error("expected API request when deletion is confirmed")
+	}
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Errorf("expected deletion message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunUsersDelete_SkipConfirm(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	// Empty reader: must not block or cancel because confirmation is skipped.
+	err := runUsersDelete(newTestClient(t, server.URL), "u1", true, strings.NewReader(""), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runUsersDelete error: %v", err)
+	}
+	if !hit {
+		t.Error("expected API request when --yes is set")
+	}
+}
+
+func TestRunUsersTokensCreate_ShowsFullToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"t1","name":"ci","fullToken":"SECRET-TOKEN-VALUE"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runUsersTokensCreate(newTestClient(t, server.URL), "u1", "ci", "", "", false, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runUsersTokensCreate error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "SECRET-TOKEN-VALUE") {
+		t.Errorf("expected full token in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "not be shown again") {
+		t.Errorf("expected one-time warning, got:\n%s", out)
+	}
+}
+
+func TestUsersCreateCommand_NoGlobalPasswordCollision(t *testing.T) {
+	// Regression: the user-password flag must not be named "password", which
+	// would shadow the global basic-auth --password flag.
+	cmd := newUsersCreateCommand()
+	if cmd.Flags().Lookup("user-password") == nil {
+		t.Fatal("expected --user-password flag")
+	}
+	if f := cmd.Flags().Lookup("password"); f != nil {
+		t.Fatal("users create must not define a local --password flag (collides with global basic-auth password)")
+	}
+}
+
+func TestRunUsersUpdate_PreservesExistingSuperAdmin(t *testing.T) {
+	// The current user (returned by the GET) is a super-admin; the operator
+	// updates only the first name. The full-replace PUT must carry superAdmin
+	// true so the user is not silently demoted.
+	server, body := captureBody(t, http.StatusOK,
+		`{"id":"u1","email":"u1@b.com","superAdmin":true}`)
+
+	m := userMutation{firstName: "Renamed", firstNameSet: true}
+	var buf bytes.Buffer
+	if err := runUsersUpdate(newTestClient(t, server.URL), "u1", m, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runUsersUpdate error: %v", err)
+	}
+	if (*body)["superAdmin"] != true {
+		t.Errorf("update must preserve existing superAdmin=true, body: %v", *body)
+	}
+	if (*body)["firstName"] != "Renamed" {
+		t.Errorf("update must apply the changed firstName, body: %v", *body)
+	}
+	if (*body)["email"] != "u1@b.com" {
+		t.Errorf("update must preserve the existing email, body: %v", *body)
+	}
+}
+
+func TestRunUsersUpdate_AppliesExplicitSuperAdminFalse(t *testing.T) {
+	// Existing user is a super-admin, operator explicitly passes --superadmin=false.
+	server, body := captureBody(t, http.StatusOK,
+		`{"id":"u1","email":"u1@b.com","superAdmin":true}`)
+
+	m := userMutation{superAdmin: false, superAdminSet: true}
+	var buf bytes.Buffer
+	if err := runUsersUpdate(newTestClient(t, server.URL), "u1", m, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runUsersUpdate error: %v", err)
+	}
+	if (*body)["superAdmin"] != false {
+		t.Errorf("explicit --superadmin=false must be applied, body: %v", *body)
+	}
+}
+
+func TestRunUsersSetGroups_ClearsWithEmptyArray(t *testing.T) {
+	server, body := captureBody(t, http.StatusOK, ``)
+
+	// No groups → must send "groupIds": [] (not omit it) so membership is cleared.
+	var buf bytes.Buffer
+	if err := runUsersSetGroups(newTestClient(t, server.URL), "u1", nil, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runUsersSetGroups error: %v", err)
+	}
+	v, ok := (*body)["groupIds"]
+	if !ok {
+		t.Fatalf("groupIds must be present (empty array) to clear groups, body: %v", *body)
+	}
+	if arr, isArr := v.([]any); !isArr || len(arr) != 0 {
+		t.Errorf("expected groupIds=[], got %v", v)
+	}
+}
+
+func TestRunUsersDelete_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runUsersDelete(newTestClient(t, server.URL), "u1", true, strings.NewReader(""), newJSONRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runUsersDelete error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("delete -o json must emit valid JSON, got %q: %v", buf.String(), err)
+	}
+	if got["status"] != "deleted" || got["id"] != "u1" {
+		t.Errorf("unexpected JSON payload: %v", got)
+	}
+}
+
+func TestRunUsersList_EmptyJSONIsArray(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":null,"total":0}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runUsersList(newTestClient(t, server.URL), "", 1, 100, nil, newJSONRenderer(&buf)); err != nil {
+		t.Fatalf("runUsersList error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "[]") || strings.Contains(buf.String(), "null") {
+		t.Errorf("empty list must render [] not null, got: %s", buf.String())
+	}
+}
+
+func TestRunUsersList_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"boom"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runUsersList(newTestClient(t, server.URL), "", 1, 100, nil, newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected error from failing API")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("expected formatted SDK error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Adds a `kestractl users` command group for IAM user management (Kestra EE), backed by the SDK's `UsersAPI`. Implements #52.

### Commands
- `users list` — `--query`, `--page`, `--size`, `--sort`; table + JSON
- `users get <id>`
- `users create` — `--email` (required), `--first-name/--last-name/--user-password/--group/--tenant-grant/--superadmin/--restricted`
- `users update <id>` — partial-safe (see below)
- `users delete <id>` — confirmation prompt, skippable with `-y/--yes`
- `users set-groups <id>` — `--group` (repeatable); no flags clears membership
- `users set-password <id>` — `--user-password`
- `users tokens list|create|delete` — `create` reveals the full token once

## Notes / design decisions
- **`--user-password`, not `--password`** — avoids shadowing the global basic-auth `--password` persistent flag (a collision would otherwise send the new user's password as the auth credential).
- **Partial-safe update** — `superAdmin`/`restricted` are only sent when the operator actually passes the flag (tracked via `Flags().Changed`). The SDK serializes any non-nil `*bool`, so always-sending would silently demote a super-admin on an unrelated update.
- **Clearing groups works** — `set-groups` with no `--group` sends `"groupIds": []` (a non-nil empty slice) rather than omitting the field.
- **JSON output contract honored** — mutating commands (delete/set-groups/set-password/token delete) emit a JSON status object under `--output json`; the confirmation prompt goes to stderr so it never pollutes stdout.
- **Empty lists render `[]`**, not `null`.
- Credentials masked under `--verbose` (root.go now masks any flag whose name contains `token`/`password`).

## Testing
- `go build`, `go vet` clean
- `go test ./src/...` — 169 pass (incl. regression tests for the collision fix, partial-update, group clearing, JSON output, empty-list rendering)
- Manually QA'd against a local Kestra EE instance

## Out of scope (follow-ups)
- Advanced endpoints (impersonate, super-admin patch, refresh-token, auth-method deletion)
- `set-groups` tenant scoping is implicit (uses active tenant); `tokens list` total reflects page length

🤖 Generated with [Claude Code](https://claude.com/claude-code)