### PR TITLE
feat(iam): manage groups via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,36 @@ kestractl users tokens list <user_id>
 kestractl users tokens delete <user_id> <token_id>
 ```
 
+### Groups (Enterprise Edition)
+
+Group management requires Kestra Enterprise Edition. Groups are tenant-scoped resources.
+
+```bash
+# List / filter groups (alias: ls)
+kestractl groups list
+kestractl groups list --query admins --output json
+
+# Get group details (alias: show, describe)
+kestractl groups get <group_id>
+
+# Create a group (--name is required; --member is repeatable for initial members)
+kestractl groups create --name admins --description 'Platform admins'
+kestractl groups create --name admins --member <user_id> --member <user_id>
+
+# Update a group — only the flags you pass change; other attributes are preserved
+kestractl groups update <group_id> --description 'Updated description'
+kestractl groups update <group_id> --name platform-admins
+
+# Delete a group (alias: rm) — prompts for confirmation unless --yes
+kestractl groups delete <group_id>
+kestractl groups delete <group_id> --yes
+
+# Manage group members
+kestractl groups members list <group_id>
+kestractl groups members add <group_id> <user_id>
+kestractl groups members remove <group_id> <user_id>
+```
+
 ### Output Formats
 
 ```bash

--- a/src/cli/groups.go
+++ b/src/cli/groups.go
@@ -1,0 +1,450 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"text/tabwriter"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/spf13/cobra"
+)
+
+func newGroupsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "groups",
+		Short: "Manage IAM groups (list, get, create, update, delete, members)",
+		Long: `Manage IAM groups in your Kestra instance.
+
+Groups are tenant-scoped resources. Managing groups requires Kestra Enterprise Edition.`,
+	}
+
+	cmd.AddCommand(newGroupsListCommand())
+	cmd.AddCommand(newGroupsGetCommand())
+	cmd.AddCommand(newGroupsCreateCommand())
+	cmd.AddCommand(newGroupsUpdateCommand())
+	cmd.AddCommand(newGroupsDeleteCommand())
+	cmd.AddCommand(newGroupsMembersCommand())
+
+	return cmd
+}
+
+func newGroupsListCommand() *cobra.Command {
+	var (
+		query string
+		page  int32
+		size  int32
+		sort  []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List groups.",
+		Long:  "List all groups in the active tenant, optionally filtered with --query.",
+		Example: `  # List all groups
+	  kestractl groups list
+
+	  # Filter groups
+	  kestractl groups list --query admins
+
+	  # List groups as JSON
+	  kestractl groups list --output json`,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runGroupsList(client, query, page, size, sort, renderer)
+		},
+	}
+
+	cmd.Flags().StringVarP(&query, "query", "q", "", "Filter groups by search query")
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (e.g. 'name:asc', repeatable)")
+
+	return cmd
+}
+
+func runGroupsList(client *Client, query string, page, size int32, sort []string, renderer *Renderer) error {
+	req := client.API.GroupsAPI.SearchGroups(client.Ctx, client.Tenant).Page(page).Size(size)
+	if query != "" {
+		req = req.Q(query)
+	}
+	if len(sort) > 0 {
+		req = req.Sort(sort)
+	}
+
+	resp, _, err := req.Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	results := resp.GetResults()
+	if results == nil {
+		// Render an empty JSON array ([]) rather than null on no results.
+		results = []kestra.ApiGroupSummary{}
+	}
+
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ID\tNAME")
+		for _, g := range results {
+			fmt.Fprintf(w, "%s\t%s\n", g.GetId(), g.GetName())
+		}
+		fmt.Fprintf(w, "\nTotal groups: %d\n", resp.GetTotal())
+		return nil
+	})
+}
+
+func newGroupsGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "get <group_id>",
+		Short:   "Get group details.",
+		Long:    "Retrieve detailed information about a specific group.",
+		Aliases: []string{"show", "describe"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runGroupsGet(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runGroupsGet(client *Client, id string, renderer *Renderer) error {
+	group, _, err := client.API.GroupsAPI.Group(client.Ctx, id, client.Tenant).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderGroupDetail(group, renderer)
+}
+
+func renderGroupDetail(group *kestra.IAMGroupControllerApiGroupDetail, renderer *Renderer) error {
+	return renderer.Render(group, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "Group Details")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ID:\t%s\n", group.GetId())
+		fmt.Fprintf(w, "Name:\t%s\n", group.GetName())
+		fmt.Fprintf(w, "Description:\t%s\n", group.GetDescription())
+		return nil
+	})
+}
+
+func newGroupsCreateCommand() *cobra.Command {
+	var (
+		name        string
+		description string
+		members     []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a group.",
+		Long:  "Create a new group. The --name flag is required.",
+		Example: `  # Create a group
+	  kestractl groups create --name admins
+
+	  # Create a group with a description and initial members
+	  kestractl groups create --name admins --description 'Platform admins' --member user-id-1 --member user-id-2`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runGroupsCreate(client, name, description, members, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Group name")
+	cmd.Flags().StringVar(&description, "description", "", "Group description")
+	cmd.Flags().StringArrayVar(&members, "member", nil, "User ID to add as an initial member (repeatable)")
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func runGroupsCreate(client *Client, name, description string, members []string, renderer *Renderer) error {
+	body := kestra.IAMGroupControllerApiCreateGroupRequest{Name: name}
+	if description != "" {
+		body.Description = &description
+	}
+	if len(members) > 0 {
+		body.MembersId = members
+	}
+
+	group, _, err := client.API.GroupsAPI.CreateGroup(client.Ctx, client.Tenant).
+		IAMGroupControllerApiCreateGroupRequest(body).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderGroupDetail(group, renderer)
+}
+
+func newGroupsUpdateCommand() *cobra.Command {
+	var (
+		name        string
+		description string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <group_id>",
+		Short: "Update a group.",
+		Long: `Update an existing group.
+
+Only the flags you pass are changed; all other attributes are preserved. The
+server endpoint is a full replace, so the current group is fetched first and the
+changed fields are merged on top before saving.
+
+Group membership is not changed here — use 'groups members add/remove'.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			nameSet := cmd.Flags().Changed("name")
+			descSet := cmd.Flags().Changed("description")
+			return runGroupsUpdate(client, args[0], name, nameSet, description, descSet, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Group name")
+	cmd.Flags().StringVar(&description, "description", "", "Group description")
+
+	return cmd
+}
+
+func runGroupsUpdate(client *Client, id, name string, nameSet bool, description string, descSet bool, renderer *Renderer) error {
+	// The update endpoint is a full-replace PUT, so fetch the current group and
+	// overlay only the changed flags — otherwise unspecified attributes (e.g.
+	// name when only --description is passed) would be reset to their defaults.
+	current, _, err := client.API.GroupsAPI.Group(client.Ctx, id, client.Tenant).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	body := kestra.IAMGroupControllerApiUpdateGroupRequest{Name: current.GetName()}
+	if desc := current.GetDescription(); desc != "" {
+		body.Description = &desc
+	}
+	if nameSet {
+		body.Name = name
+	}
+	if descSet {
+		body.Description = &description
+	}
+
+	group, _, err := client.API.GroupsAPI.UpdateGroup(client.Ctx, id, client.Tenant).
+		IAMGroupControllerApiUpdateGroupRequest(body).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderGroupDetail(group, renderer)
+}
+
+func newGroupsDeleteCommand() *cobra.Command {
+	var skipConfirm bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <group_id>",
+		Short:   "Delete a group.",
+		Long:    "Delete a group. Prompts for confirmation unless --yes is provided.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runGroupsDelete(client, args[0], skipConfirm, cmd.InOrStdin(), renderer)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation prompt")
+
+	return cmd
+}
+
+func runGroupsDelete(client *Client, id string, skipConfirm bool, in io.Reader, renderer *Renderer) error {
+	if !skipConfirm {
+		// Prompt on stderr so it never pollutes stdout (e.g. --output json).
+		confirmed, err := confirm(in, os.Stderr,
+			fmt.Sprintf("Are you sure you want to delete group '%s'? [y/N]: ", id))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return renderStatus(renderer, "Cancelled.", map[string]any{"id": id, "status": "cancelled"})
+		}
+	}
+
+	if _, err := client.API.GroupsAPI.DeleteGroup(client.Ctx, id, client.Tenant).Execute(); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("Group '%s' deleted.", id),
+		map[string]any{"id": id, "status": "deleted"})
+}
+
+func newGroupsMembersCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "members",
+		Short: "Manage members of a group (list, add, remove)",
+	}
+
+	cmd.AddCommand(newGroupsMembersListCommand())
+	cmd.AddCommand(newGroupsMembersAddCommand())
+	cmd.AddCommand(newGroupsMembersRemoveCommand())
+
+	return cmd
+}
+
+func newGroupsMembersListCommand() *cobra.Command {
+	var (
+		query string
+		page  int32
+		size  int32
+		sort  []string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list <group_id>",
+		Short:   "List members of a group.",
+		Long:    "List the users that belong to a group, optionally filtered with --query.",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runGroupsMembersList(client, args[0], query, page, size, sort, renderer)
+		},
+	}
+
+	cmd.Flags().StringVarP(&query, "query", "q", "", "Filter members by search query")
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (e.g. 'username:asc', repeatable)")
+
+	return cmd
+}
+
+func runGroupsMembersList(client *Client, id, query string, page, size int32, sort []string, renderer *Renderer) error {
+	req := client.API.GroupsAPI.SearchGroupMembers(client.Ctx, id, client.Tenant).Page(page).Size(size)
+	if query != "" {
+		req = req.Q(query)
+	}
+	if len(sort) > 0 {
+		req = req.Sort(sort)
+	}
+
+	resp, _, err := req.Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	members := resp.GetResults()
+	if members == nil {
+		// Render an empty JSON array ([]) rather than null on no results.
+		members = []kestra.IAMGroupControllerApiGroupMember{}
+	}
+
+	return renderer.Render(members, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ID\tUSERNAME\tDISPLAY NAME")
+		for _, m := range members {
+			fmt.Fprintf(w, "%s\t%s\t%s\n", m.GetId(), m.GetUsername(), m.GetDisplayName())
+		}
+		fmt.Fprintf(w, "\nTotal members: %d\n", resp.GetTotal())
+		return nil
+	})
+}
+
+func newGroupsMembersAddCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add <group_id> <user_id>",
+		Short: "Add a user to a group.",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runGroupsMembersAdd(client, args[0], args[1], renderer)
+		},
+	}
+	return cmd
+}
+
+func runGroupsMembersAdd(client *Client, groupID, userID string, renderer *Renderer) error {
+	if _, _, err := client.API.GroupsAPI.AddUserToGroup(client.Ctx, groupID, userID, client.Tenant).Execute(); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("User '%s' added to group '%s'.", userID, groupID),
+		map[string]any{"groupId": groupID, "userId": userID, "status": "added"})
+}
+
+func newGroupsMembersRemoveCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "remove <group_id> <user_id>",
+		Short:   "Remove a user from a group.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runGroupsMembersRemove(client, args[0], args[1], renderer)
+		},
+	}
+	return cmd
+}
+
+func runGroupsMembersRemove(client *Client, groupID, userID string, renderer *Renderer) error {
+	if _, _, err := client.API.GroupsAPI.DeleteUserFromGroup(client.Ctx, groupID, userID, client.Tenant).Execute(); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("User '%s' removed from group '%s'.", userID, groupID),
+		map[string]any{"groupId": groupID, "userId": userID, "status": "removed"})
+}

--- a/src/cli/groups_test.go
+++ b/src/cli/groups_test.go
@@ -1,0 +1,318 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestGroupsCommand_Structure(t *testing.T) {
+	cmd := newGroupsCommand()
+	if cmd.Use != "groups" {
+		t.Fatalf("expected use 'groups', got %q", cmd.Use)
+	}
+
+	want := map[string]bool{
+		"list": false, "get": false, "create": false,
+		"update": false, "delete": false, "members": false,
+	}
+	membersFound := false
+	memberWant := map[string]bool{"list": false, "add": false, "remove": false}
+	for _, sub := range cmd.Commands() {
+		name := strings.Fields(sub.Use)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+		if name == "members" {
+			membersFound = true
+			for _, m := range sub.Commands() {
+				mname := strings.Fields(m.Use)[0]
+				if _, ok := memberWant[mname]; ok {
+					memberWant[mname] = true
+				}
+			}
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+	if !membersFound {
+		t.Fatal("missing 'members' subcommand")
+	}
+	for name, found := range memberWant {
+		if !found {
+			t.Errorf("missing members subcommand %q", name)
+		}
+	}
+}
+
+func TestGroupsCreateCommand_RequiredName(t *testing.T) {
+	cmd := newGroupsCreateCommand()
+	if cmd.Flags().Lookup("name") == nil {
+		t.Fatal("expected --name flag")
+	}
+	if cmd.Flags().Lookup("member") == nil {
+		t.Fatal("expected --member flag")
+	}
+	if _, err := executeCommand(cmd); err == nil {
+		t.Fatal("expected error when --name is missing")
+	}
+}
+
+func TestGroupsDeleteCommand_HasYesFlag(t *testing.T) {
+	cmd := newGroupsDeleteCommand()
+	f := cmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("expected --yes flag")
+	}
+	if f.Shorthand != "y" {
+		t.Fatalf("expected -y shorthand, got %q", f.Shorthand)
+	}
+}
+
+func TestRunGroupsList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"g1","name":"admins"},
+			{"id":"g2","name":"developers"}
+		],"total":2}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runGroupsList(newTestClient(t, server.URL), "", 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runGroupsList error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"g1", "admins", "developers", "Total groups: 2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunGroupsList_EmptyJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[],"total":0}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runGroupsList(newTestClient(t, server.URL), "", 1, 100, nil, newJSONRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runGroupsList error: %v", err)
+	}
+	// Empty results must render as [] rather than null.
+	if got := strings.TrimSpace(buf.String()); got != "[]" {
+		t.Errorf("expected empty JSON array, got %q", got)
+	}
+}
+
+func TestRunGroupsGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"g1","name":"admins","description":"Platform admins"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runGroupsGet(newTestClient(t, server.URL), "g1", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runGroupsGet error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"g1", "admins", "Platform admins", "Description:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunGroupsCreate_SendsBody(t *testing.T) {
+	var gotBody map[string]any
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"new","name":"admins","description":"Platform admins"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runGroupsCreate(newTestClient(t, server.URL), "admins", "Platform admins", []string{"u1", "u2"}, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runGroupsCreate error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotBody["name"] != "admins" {
+		t.Errorf("expected name in body, got %v", gotBody["name"])
+	}
+	if gotBody["description"] != "Platform admins" {
+		t.Errorf("expected description in body, got %v", gotBody["description"])
+	}
+	members, ok := gotBody["membersId"].([]any)
+	if !ok || len(members) != 2 {
+		t.Errorf("expected 2 membersId in body, got %v", gotBody["membersId"])
+	}
+	if !strings.Contains(buf.String(), "admins") {
+		t.Errorf("expected created group rendered, got:\n%s", buf.String())
+	}
+}
+
+func TestRunGroupsUpdate_PreservesExistingName(t *testing.T) {
+	// The operator updates only the description; the full-replace PUT must carry
+	// the existing name so the group is not renamed to an empty string.
+	server, body := captureBody(t, http.StatusOK,
+		`{"id":"g1","name":"admins","description":"old"}`)
+
+	var buf bytes.Buffer
+	if err := runGroupsUpdate(newTestClient(t, server.URL), "g1", "", false, "new desc", true, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runGroupsUpdate error: %v", err)
+	}
+	if (*body)["name"] != "admins" {
+		t.Errorf("update must preserve existing name, body: %v", *body)
+	}
+	if (*body)["description"] != "new desc" {
+		t.Errorf("update must apply the changed description, body: %v", *body)
+	}
+}
+
+func TestRunGroupsUpdate_AppliesChangedName(t *testing.T) {
+	server, body := captureBody(t, http.StatusOK,
+		`{"id":"g1","name":"admins","description":"keep"}`)
+
+	var buf bytes.Buffer
+	if err := runGroupsUpdate(newTestClient(t, server.URL), "g1", "renamed", true, "", false, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runGroupsUpdate error: %v", err)
+	}
+	if (*body)["name"] != "renamed" {
+		t.Errorf("update must apply the changed name, body: %v", *body)
+	}
+	if (*body)["description"] != "keep" {
+		t.Errorf("update must preserve existing description, body: %v", *body)
+	}
+}
+
+func TestRunGroupsDelete_CancelMakesNoRequest(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runGroupsDelete(newTestClient(t, server.URL), "g1", false, strings.NewReader("n\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runGroupsDelete error: %v", err)
+	}
+	if hit {
+		t.Error("expected no API request when deletion is cancelled")
+	}
+	if !strings.Contains(buf.String(), "Cancelled") {
+		t.Errorf("expected cancellation message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunGroupsDelete_Confirmed(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runGroupsDelete(newTestClient(t, server.URL), "g1", false, strings.NewReader("y\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runGroupsDelete error: %v", err)
+	}
+	if !hit {
+		t.Error("expected API request when deletion is confirmed")
+	}
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Errorf("expected deletion message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunGroupsMembersList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"u1","username":"alice","displayName":"Alice"},
+			{"id":"u2","username":"bob","displayName":"Bob"}
+		],"total":2}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runGroupsMembersList(newTestClient(t, server.URL), "g1", "", 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runGroupsMembersList error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"alice", "bob", "Alice", "Total members: 2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunGroupsMembersAdd(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"u1","username":"alice"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runGroupsMembersAdd(newTestClient(t, server.URL), "g1", "u1", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runGroupsMembersAdd error: %v", err)
+	}
+	if !hit {
+		t.Error("expected API request")
+	}
+	if !strings.Contains(buf.String(), "added to group") {
+		t.Errorf("expected add confirmation, got:\n%s", buf.String())
+	}
+}
+
+func TestRunGroupsMembersRemove(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"u1","username":"alice"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runGroupsMembersRemove(newTestClient(t, server.URL), "g1", "u1", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runGroupsMembersRemove error: %v", err)
+	}
+	if !hit {
+		t.Error("expected API request")
+	}
+	if !strings.Contains(buf.String(), "removed from group") {
+		t.Errorf("expected remove confirmation, got:\n%s", buf.String())
+	}
+}

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -114,6 +114,7 @@ with support for multiple authentication contexts and output formats.`,
 	root.AddCommand(newWorkersCommand())
 	root.AddCommand(newPluginsCommand())
 	root.AddCommand(newUsersCommand())
+	root.AddCommand(newGroupsCommand())
 
 	return root
 }


### PR DESCRIPTION
## What

Adds a `kestractl groups` command group backed by the Go SDK's `GroupsAPI` (tenant-scoped), implementing all SDK-supported operations from #53:

| Command | SDK method |
|---|---|
| `groups list` | `SearchGroups` |
| `groups get <id>` | `Group` |
| `groups create` | `CreateGroup` |
| `groups update <id>` | `UpdateGroup` |
| `groups delete <id>` | `DeleteGroup` |
| `groups members list <id>` | `SearchGroupMembers` |
| `groups members add <id> <user>` | `AddUserToGroup` |
| `groups members remove <id> <user>` | `DeleteUserFromGroup` |

## Notes

- **Update is a full-replace PUT.** The current group is fetched first and only the changed flags (`--name` / `--description`) are overlaid, so updating one field never blanks the other. Membership is intentionally *not* mutated by `update` — that goes through `groups members add/remove`.
- `create` accepts initial members via repeatable `--member` (maps to `membersId`).
- Follows the existing `users.go` command pattern: pure `runGroups…()` functions, `NewClient()`, tenant via `client.Tenant`, table + JSON output, `validateOutputFormat()` early (via `NewRendererFromFlags`), SDK errors wrapped with `formatSDKError`.

## Acceptance criteria

- [x] `newGroupsCommand()` + pure `runGroups…()` in `src/cli/groups.go`
- [x] Registered in `root.go`
- [x] Tenant passed via `client.Tenant`
- [x] Table + JSON output; `validateOutputFormat()` early
- [x] SDK errors wrapped with `formatSDKError`
- [x] Unit tests in `src/cli/groups_test.go`
- [x] Follows CLAUDE.md / CONTRIBUTING.md command pattern

## Testing

- `go build` ✓
- `go vet ./src/...` ✓ (no issues)
- `go test ./src/...` ✓ (183 passed)
- `--help` smoke tests on `groups` and `groups members` ✓

> Requires Kestra EE.

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)