### PR TITLE
feat(iam): manage roles via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kestra CLI
 
-A Go-based command-line interface for managing Kestra flows, executions, namespaces, and IAM users.
+A Go-based command-line interface for managing Kestra flows, executions, namespaces, and IAM users and roles.
 
 ## Installation
 
@@ -378,6 +378,52 @@ kestractl groups members add <group_id> <user_id>
 kestractl groups members remove <group_id> <user_id>
 ```
 
+### Roles (Enterprise Edition)
+
+Role management requires Kestra Enterprise Edition. Roles are tenant-scoped (the
+active tenant is used).
+
+A role carries a `permissions` payload: a map of resource type (e.g. `FLOW`,
+`EXECUTION`, `NAMESPACE`, `SECRET`, `KVSTORE`, …) to a list of permission levels
+(`READ`, `CREATE`, `UPDATE`, `DELETE`). You can provide it inline with the
+repeatable `--permission TYPE:LEVEL[,LEVEL]` flag, or from a YAML/JSON file with
+`--permissions-file` — but not both at once.
+
+```bash
+# List / filter roles (alias: ls)
+kestractl roles list
+kestractl roles list --query editor --output json
+kestractl roles list --page 1 --size 50 --sort name:asc
+
+# Get role details, including its permissions (aliases: show, describe)
+kestractl roles get <role_id>
+
+# Create a role with inline permissions (--name is required, plus at least one permission)
+kestractl roles create --name editor \
+  --description "Can edit flows and view executions" \
+  --permission FLOW:READ,CREATE,UPDATE \
+  --permission EXECUTION:READ
+
+# Create a role from a permissions file (YAML or JSON)
+kestractl roles create --name viewer --permissions-file perms.yaml
+
+# perms.yaml
+#   FLOW:
+#     - READ
+#   EXECUTION:
+#     - READ
+
+# Update a role — only the flags you pass change; other attributes are preserved.
+# Passing --permission replaces the entire permissions block (it does not merge).
+kestractl roles update <role_id> --description "Updated description"
+kestractl roles update <role_id> --permission FLOW:READ,CREATE,UPDATE,DELETE
+kestractl roles update <role_id> --default
+
+# Delete a role (alias: rm) — prompts for confirmation unless --yes
+kestractl roles delete <role_id>
+kestractl roles delete <role_id> --yes
+```
+
 ### Output Formats
 
 ```bash
@@ -450,6 +496,8 @@ kestractl/
     ├── workers_test.go        # Unit tests
     ├── users.go               # IAM users commands (list, get, create, update, delete, set-groups, set-password, tokens)
     ├── users_test.go          # Unit tests
+    ├── roles.go               # IAM roles commands (list, get, create, update, delete)
+    ├── roles_test.go          # Unit tests
     └── testdata/              # Test fixtures
         └── flow.yaml
 ```

--- a/src/cli/roles.go
+++ b/src/cli/roles.go
@@ -1,0 +1,496 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+func newRolesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "roles",
+		Short: "Manage IAM roles (list, get, create, update, delete)",
+		Long: `Manage IAM roles in your Kestra instance.
+
+Roles are tenant-scoped resources. Managing roles requires Kestra Enterprise Edition.`,
+	}
+
+	cmd.AddCommand(newRolesListCommand())
+	cmd.AddCommand(newRolesGetCommand())
+	cmd.AddCommand(newRolesCreateCommand())
+	cmd.AddCommand(newRolesUpdateCommand())
+	cmd.AddCommand(newRolesDeleteCommand())
+
+	return cmd
+}
+
+// roleMutation holds the fields used to create or update a role, plus a record
+// of which flags the operator explicitly set.
+//
+// As with users, the update endpoint is a full-replace PUT: any attribute
+// absent from the request body is reset server-side. So update fetches the
+// current role and overlays only the changed flags via applyTo, while create
+// builds a fresh request via toRequest.
+type roleMutation struct {
+	name        string
+	description string
+	isDefault   bool
+	permPairs   []string // raw --permission "FLOW:READ,CREATE" values (repeatable)
+	permFile    string   // --permissions-file path
+
+	nameSet        bool
+	descriptionSet bool
+	isDefaultSet   bool
+	permsSet       bool
+}
+
+// addRoleMutationFlags wires the create/update flags shared by both commands.
+func addRoleMutationFlags(cmd *cobra.Command, m *roleMutation) {
+	cmd.Flags().StringVar(&m.name, "name", "", "Role name")
+	cmd.Flags().StringVar(&m.description, "description", "", "Role description")
+	cmd.Flags().BoolVar(&m.isDefault, "default", false, "Mark the role as a default role")
+	cmd.Flags().StringArrayVar(&m.permPairs, "permission", nil,
+		"Permission as TYPE:LEVEL[,LEVEL] (e.g. FLOW:READ,CREATE). Repeatable.")
+	cmd.Flags().StringVar(&m.permFile, "permissions-file", "",
+		"Path to a YAML or JSON file mapping resource types to permission levels")
+}
+
+// markChanged records which flags the operator actually passed on the command.
+func (m *roleMutation) markChanged(cmd *cobra.Command) {
+	f := cmd.Flags()
+	m.nameSet = f.Changed("name")
+	m.descriptionSet = f.Changed("description")
+	m.isDefaultSet = f.Changed("default")
+	m.permsSet = f.Changed("permission") || f.Changed("permissions-file")
+}
+
+// parsePermissions builds the permissions payload from either the repeatable
+// --permission flag or --permissions-file. Passing both is an error.
+func (m roleMutation) parsePermissions() (*kestra.IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions, error) {
+	if len(m.permPairs) > 0 && m.permFile != "" {
+		return nil, fmt.Errorf("use either --permission or --permissions-file, not both")
+	}
+
+	perms := map[string][]string{}
+
+	if m.permFile != "" {
+		data, err := os.ReadFile(m.permFile)
+		if err != nil {
+			return nil, fmt.Errorf("reading permissions file: %w", err)
+		}
+		// yaml.v3 parses JSON too, since JSON is a subset of YAML.
+		if err := yaml.Unmarshal(data, &perms); err != nil {
+			return nil, fmt.Errorf("parsing permissions file: %w", err)
+		}
+	}
+
+	for _, pair := range m.permPairs {
+		key, levels, err := parsePermPair(pair)
+		if err != nil {
+			return nil, err
+		}
+		perms[key] = append(perms[key], levels...)
+	}
+
+	return permissionsToStruct(perms)
+}
+
+// parsePermPair parses "FLOW:READ,CREATE" into the resource type and its levels.
+// Both the type and levels are upper-cased to match the API enum.
+func parsePermPair(s string) (string, []string, error) {
+	parts := strings.SplitN(s, ":", 2)
+	if len(parts) != 2 {
+		return "", nil, fmt.Errorf("invalid permission %q: expected TYPE:LEVEL[,LEVEL]", s)
+	}
+	key := strings.ToUpper(strings.TrimSpace(parts[0]))
+	if key == "" {
+		return "", nil, fmt.Errorf("invalid permission %q: empty resource type", s)
+	}
+
+	var levels []string
+	for _, lvl := range strings.Split(parts[1], ",") {
+		lvl = strings.ToUpper(strings.TrimSpace(lvl))
+		if lvl != "" {
+			levels = append(levels, lvl)
+		}
+	}
+	if len(levels) == 0 {
+		return "", nil, fmt.Errorf("invalid permission %q: no levels specified", s)
+	}
+	return key, levels, nil
+}
+
+// permissionsToStruct converts a resource-type → levels map into the SDK
+// permissions struct via a JSON round-trip. This leans on the struct's JSON
+// tags (which match the uppercase resource keys) so we don't maintain a switch
+// over the ~24 resource types and stay forward-compatible with new ones.
+func permissionsToStruct(m map[string][]string) (*kestra.IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions, error) {
+	data, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	var perms kestra.IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions
+	if err := json.Unmarshal(data, &perms); err != nil {
+		return nil, fmt.Errorf("invalid permissions: %w", err)
+	}
+	return &perms, nil
+}
+
+// permissionsToMap is the reverse of permissionsToStruct, used for display.
+func permissionsToMap(p *kestra.IAMRoleControllerApiRoleCreateOrUpdateRequestPermissions) (map[string][]string, error) {
+	if p == nil {
+		return map[string][]string{}, nil
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		return nil, err
+	}
+	m := map[string][]string{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// toRequest builds a create request from scratch.
+func (m roleMutation) toRequest() (kestra.IAMRoleControllerApiRoleCreateOrUpdateRequest, error) {
+	req := kestra.IAMRoleControllerApiRoleCreateOrUpdateRequest{Name: m.name}
+	if err := m.applyTo(&req); err != nil {
+		return req, err
+	}
+	return req, nil
+}
+
+// applyTo overlays the explicitly-set fields onto req, leaving everything else
+// (e.g. an existing role's attributes seeded from a GET) untouched.
+func (m roleMutation) applyTo(req *kestra.IAMRoleControllerApiRoleCreateOrUpdateRequest) error {
+	if m.nameSet {
+		req.Name = m.name
+	}
+	if m.descriptionSet {
+		req.Description = &m.description
+	}
+	if m.isDefaultSet {
+		req.IsDefault = &m.isDefault
+	}
+	if m.permsSet {
+		perms, err := m.parsePermissions()
+		if err != nil {
+			return err
+		}
+		req.Permissions = *perms
+	}
+	return nil
+}
+
+// roleRequestFromExisting seeds a full create/update request from a fetched
+// role, so a full-replace PUT preserves attributes the operator didn't touch.
+func roleRequestFromExisting(r *kestra.IAMRoleControllerApiRoleDetail) kestra.IAMRoleControllerApiRoleCreateOrUpdateRequest {
+	req := kestra.IAMRoleControllerApiRoleCreateOrUpdateRequest{Name: r.GetName()}
+	if r.Description != nil {
+		req.Description = r.Description
+	}
+	if r.IsDefault != nil {
+		req.IsDefault = r.IsDefault
+	}
+	if r.Permissions != nil {
+		req.Permissions = *r.Permissions
+	}
+	return req
+}
+
+func newRolesListCommand() *cobra.Command {
+	var (
+		query string
+		page  int32
+		size  int32
+		sort  []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List roles.",
+		Long:  "List all roles in the active tenant, optionally filtered with --query.",
+		Example: `  # List all roles
+  kestractl roles list
+
+  # Filter roles
+  kestractl roles list --query editor
+
+  # List roles as JSON
+  kestractl roles list --output json`,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runRolesList(client, query, page, size, sort, renderer)
+		},
+	}
+
+	cmd.Flags().StringVarP(&query, "query", "q", "", "Filter roles by search query")
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (e.g. 'name:asc', repeatable)")
+
+	return cmd
+}
+
+func runRolesList(client *Client, query string, page, size int32, sort []string, renderer *Renderer) error {
+	req := client.API.RolesAPI.SearchRoles(client.Ctx, client.Tenant).Page(page).Size(size)
+	if query != "" {
+		req = req.Q(query)
+	}
+	if len(sort) > 0 {
+		req = req.Sort(sort)
+	}
+
+	resp, _, err := req.Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	results := resp.GetResults()
+	if results == nil {
+		// Render an empty JSON array ([]) rather than null on no results.
+		results = []kestra.ApiRoleSummary{}
+	}
+
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ID\tNAME\tDEFAULT\tMANAGED")
+		for _, r := range results {
+			fmt.Fprintf(w, "%s\t%s\t%t\t%t\n",
+				r.GetId(), r.GetName(), r.GetIsDefault(), r.GetIsManaged())
+		}
+		fmt.Fprintf(w, "\nTotal roles: %d\n", resp.GetTotal())
+		return nil
+	})
+}
+
+func newRolesGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "get <role_id>",
+		Short:   "Get role details.",
+		Long:    "Retrieve detailed information about a specific role, including its permissions.",
+		Aliases: []string{"show", "describe"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runRolesGet(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runRolesGet(client *Client, id string, renderer *Renderer) error {
+	role, _, err := client.API.RolesAPI.Role(client.Ctx, id, client.Tenant).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderRoleDetail(role, renderer)
+}
+
+func renderRoleDetail(role *kestra.IAMRoleControllerApiRoleDetail, renderer *Renderer) error {
+	return renderer.Render(role, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "Role Details")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ID:\t%s\n", role.GetId())
+		fmt.Fprintf(w, "Name:\t%s\n", role.GetName())
+		fmt.Fprintf(w, "Description:\t%s\n", role.GetDescription())
+		fmt.Fprintf(w, "Default:\t%t\n", role.GetIsDefault())
+		fmt.Fprintf(w, "Managed:\t%t\n", role.GetIsManaged())
+
+		perms, err := permissionsToMap(role.Permissions)
+		if err != nil {
+			return err
+		}
+		if len(perms) > 0 {
+			fmt.Fprintln(w, "Permissions:")
+			keys := make([]string, 0, len(perms))
+			for k := range perms {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				fmt.Fprintf(w, "  %s:\t%s\n", k, strings.Join(perms[k], ", "))
+			}
+		}
+		return nil
+	})
+}
+
+func newRolesCreateCommand() *cobra.Command {
+	var m roleMutation
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a role.",
+		Long: `Create a new role. The --name flag is required, along with at least one
+permission (via --permission or --permissions-file).`,
+		Example: `  # Create a role with inline permissions
+  kestractl roles create --name editor \
+    --permission FLOW:READ,CREATE,UPDATE \
+    --permission EXECUTION:READ
+
+  # Create a role from a permissions file
+  kestractl roles create --name editor --permissions-file perms.yaml`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			m.markChanged(cmd)
+			return runRolesCreate(client, m, renderer)
+		},
+	}
+
+	addRoleMutationFlags(cmd, &m)
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func runRolesCreate(client *Client, m roleMutation, renderer *Renderer) error {
+	if !m.permsSet {
+		return fmt.Errorf("at least one permission is required: use --permission or --permissions-file")
+	}
+
+	req, err := m.toRequest()
+	if err != nil {
+		return err
+	}
+
+	role, _, err := client.API.RolesAPI.CreateRole(client.Ctx, client.Tenant).
+		IAMRoleControllerApiRoleCreateOrUpdateRequest(req).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderRoleDetail(role, renderer)
+}
+
+func newRolesUpdateCommand() *cobra.Command {
+	var m roleMutation
+
+	cmd := &cobra.Command{
+		Use:   "update <role_id>",
+		Short: "Update a role.",
+		Long: `Update an existing role.
+
+Only the flags you pass are changed; all other attributes are preserved. The
+server endpoint is a full replace, so the current role is fetched first and the
+changed fields are merged on top before saving.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			m.markChanged(cmd)
+			return runRolesUpdate(client, args[0], m, renderer)
+		},
+	}
+
+	addRoleMutationFlags(cmd, &m)
+
+	return cmd
+}
+
+func runRolesUpdate(client *Client, id string, m roleMutation, renderer *Renderer) error {
+	// The update endpoint is a full-replace PUT, so fetch the current role and
+	// overlay only the changed flags — otherwise unspecified attributes (e.g.
+	// permissions, isDefault) would be reset to their defaults.
+	current, _, err := client.API.RolesAPI.Role(client.Ctx, id, client.Tenant).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	req := roleRequestFromExisting(current)
+	if err := m.applyTo(&req); err != nil {
+		return err
+	}
+
+	role, _, err := client.API.RolesAPI.UpdateRole(client.Ctx, id, client.Tenant).
+		IAMRoleControllerApiRoleCreateOrUpdateRequest(req).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderRoleDetail(role, renderer)
+}
+
+func newRolesDeleteCommand() *cobra.Command {
+	var skipConfirm bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <role_id>",
+		Short:   "Delete a role.",
+		Long:    "Delete a role. Prompts for confirmation unless --yes is provided.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runRolesDelete(client, args[0], skipConfirm, cmd.InOrStdin(), renderer)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation prompt")
+
+	return cmd
+}
+
+func runRolesDelete(client *Client, id string, skipConfirm bool, in io.Reader, renderer *Renderer) error {
+	if !skipConfirm {
+		// Prompt on stderr so it never pollutes stdout (e.g. --output json).
+		confirmed, err := confirm(in, os.Stderr,
+			fmt.Sprintf("Are you sure you want to delete role '%s'? [y/N]: ", id))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return renderStatus(renderer, "Cancelled.", map[string]any{"id": id, "status": "cancelled"})
+		}
+	}
+
+	if _, err := client.API.RolesAPI.DeleteRole(client.Ctx, id, client.Tenant).Execute(); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("Role '%s' deleted.", id),
+		map[string]any{"id": id, "status": "deleted"})
+}

--- a/src/cli/roles_test.go
+++ b/src/cli/roles_test.go
@@ -1,0 +1,306 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRolesCommand_Structure(t *testing.T) {
+	cmd := newRolesCommand()
+	if cmd.Use != "roles" {
+		t.Fatalf("expected use 'roles', got %q", cmd.Use)
+	}
+
+	want := map[string]bool{
+		"list": false, "get": false, "create": false, "update": false, "delete": false,
+	}
+	for _, sub := range cmd.Commands() {
+		name := strings.Fields(sub.Use)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestRolesCreateCommand_RequiredName(t *testing.T) {
+	cmd := newRolesCreateCommand()
+	if cmd.Flags().Lookup("name") == nil {
+		t.Fatal("expected --name flag")
+	}
+	if cmd.Flags().Lookup("permission") == nil {
+		t.Fatal("expected --permission flag")
+	}
+	if cmd.Flags().Lookup("permissions-file") == nil {
+		t.Fatal("expected --permissions-file flag")
+	}
+	// name is marked required
+	if _, err := executeCommand(cmd); err == nil {
+		t.Fatal("expected error when --name is missing")
+	}
+}
+
+func TestRolesDeleteCommand_HasYesFlag(t *testing.T) {
+	cmd := newRolesDeleteCommand()
+	f := cmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("expected --yes flag")
+	}
+	if f.Shorthand != "y" {
+		t.Fatalf("expected -y shorthand, got %q", f.Shorthand)
+	}
+}
+
+func TestParsePermPair(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantKey  string
+		wantLvls []string
+		wantErr  bool
+	}{
+		{"FLOW:READ,CREATE", "FLOW", []string{"READ", "CREATE"}, false},
+		{"flow:read", "FLOW", []string{"READ"}, false},
+		{" execution : read , update ", "EXECUTION", []string{"READ", "UPDATE"}, false},
+		{"FLOW", "", nil, true},
+		{":READ", "", nil, true},
+		{"FLOW:", "", nil, true},
+		{"FLOW:,", "", nil, true},
+	}
+	for _, c := range cases {
+		key, lvls, err := parsePermPair(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("parsePermPair(%q): expected error, got none", c.in)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parsePermPair(%q): unexpected error: %v", c.in, err)
+			continue
+		}
+		if key != c.wantKey {
+			t.Errorf("parsePermPair(%q): key = %q, want %q", c.in, key, c.wantKey)
+		}
+		if !reflect.DeepEqual(lvls, c.wantLvls) {
+			t.Errorf("parsePermPair(%q): levels = %v, want %v", c.in, lvls, c.wantLvls)
+		}
+	}
+}
+
+func TestParsePermissions_FlagAndFileConflict(t *testing.T) {
+	m := roleMutation{permPairs: []string{"FLOW:READ"}, permFile: "perms.yaml"}
+	if _, err := m.parsePermissions(); err == nil {
+		t.Fatal("expected error when both --permission and --permissions-file are set")
+	}
+}
+
+func TestParsePermissions_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "perms.yaml")
+	content := "FLOW:\n  - READ\n  - CREATE\nEXECUTION:\n  - READ\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	m := roleMutation{permFile: path}
+	perms, err := m.parsePermissions()
+	if err != nil {
+		t.Fatalf("parsePermissions error: %v", err)
+	}
+	if !reflect.DeepEqual(perms.FLOW, []string{"READ", "CREATE"}) {
+		t.Errorf("FLOW = %v, want [READ CREATE]", perms.FLOW)
+	}
+	if !reflect.DeepEqual(perms.EXECUTION, []string{"READ"}) {
+		t.Errorf("EXECUTION = %v, want [READ]", perms.EXECUTION)
+	}
+}
+
+func TestRunRolesList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"r1","name":"admin","isDefault":true,"isManaged":true},
+			{"id":"r2","name":"editor","isDefault":false,"isManaged":false}
+		],"total":2}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runRolesList(newTestClient(t, server.URL), "", 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runRolesList error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"admin", "editor", "Total roles: 2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunRolesGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"r1","name":"editor","description":"Editors",
+			"isDefault":false,"permissions":{"FLOW":["READ","CREATE"],"EXECUTION":["READ"]}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runRolesGet(newTestClient(t, server.URL), "r1", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runRolesGet error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"editor", "Editors", "FLOW", "READ, CREATE", "EXECUTION", "Permissions:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunRolesCreate_SendsBody(t *testing.T) {
+	var gotBody map[string]any
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"new","name":"editor"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	m := roleMutation{
+		name:      "editor",
+		permPairs: []string{"FLOW:READ,CREATE", "EXECUTION:READ"},
+		nameSet:   true,
+		permsSet:  true,
+	}
+	var buf bytes.Buffer
+	if err := runRolesCreate(newTestClient(t, server.URL), m, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runRolesCreate error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotBody["name"] != "editor" {
+		t.Errorf("expected name in body, got %v", gotBody["name"])
+	}
+	perms, ok := gotBody["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected permissions object in body, got %v", gotBody["permissions"])
+	}
+	flow, ok := perms["FLOW"].([]any)
+	if !ok || len(flow) != 2 {
+		t.Errorf("expected FLOW with 2 levels, got %v", perms["FLOW"])
+	}
+}
+
+func TestRunRolesCreate_RequiresPermissions(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	m := roleMutation{name: "editor", nameSet: true}
+	var buf bytes.Buffer
+	if err := runRolesCreate(newTestClient(t, server.URL), m, newTableRenderer(&buf)); err == nil {
+		t.Fatal("expected error when no permissions are provided")
+	}
+	if hit {
+		t.Error("expected no API request when permissions are missing")
+	}
+}
+
+func TestRunRolesUpdate_OverlaysExisting(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"id":"r1","name":"editor","description":"orig",
+				"permissions":{"FLOW":["READ"]}}`))
+		case http.MethodPut:
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_, _ = w.Write([]byte(`{"id":"r1","name":"editor","description":"updated"}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	// Only change the description; name and permissions must be preserved from GET.
+	m := roleMutation{description: "updated", descriptionSet: true}
+	var buf bytes.Buffer
+	if err := runRolesUpdate(newTestClient(t, server.URL), "r1", m, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runRolesUpdate error: %v", err)
+	}
+
+	if gotBody["name"] != "editor" {
+		t.Errorf("expected preserved name 'editor', got %v", gotBody["name"])
+	}
+	if gotBody["description"] != "updated" {
+		t.Errorf("expected updated description, got %v", gotBody["description"])
+	}
+	perms, ok := gotBody["permissions"].(map[string]any)
+	if !ok || perms["FLOW"] == nil {
+		t.Errorf("expected preserved permissions, got %v", gotBody["permissions"])
+	}
+}
+
+func TestRunRolesDelete_Confirmed(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runRolesDelete(newTestClient(t, server.URL), "r1", false, strings.NewReader("y\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runRolesDelete error: %v", err)
+	}
+	if !hit {
+		t.Error("expected API request when deletion is confirmed")
+	}
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Errorf("expected deletion message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunRolesDelete_CancelMakesNoRequest(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runRolesDelete(newTestClient(t, server.URL), "r1", false, strings.NewReader("n\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runRolesDelete error: %v", err)
+	}
+	if hit {
+		t.Error("expected no API request when deletion is cancelled")
+	}
+	if !strings.Contains(buf.String(), "Cancelled") {
+		t.Errorf("expected cancellation message, got:\n%s", buf.String())
+	}
+}

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -115,6 +115,7 @@ with support for multiple authentication contexts and output formats.`,
 	root.AddCommand(newPluginsCommand())
 	root.AddCommand(newUsersCommand())
 	root.AddCommand(newGroupsCommand())
+	root.AddCommand(newRolesCommand())
 
 	return root
 }


### PR DESCRIPTION
## Summary

Adds a `kestractl roles` command group backed by the Go SDK's `RolesAPI` (tenant-scoped), implementing all SDK-supported operations:

| Command | SDK call |
|---------|----------|
| `roles list` | `SearchRoles` (supports `--query`, `--page`, `--size`, `--sort`) |
| `roles get <id>` | `Role` |
| `roles create` | `CreateRole` |
| `roles update <id>` | `UpdateRole` |
| `roles delete <id>` | `DeleteRole` |

Closes #54.

## Permissions input

A role carries a `permissions` payload (resource type → permission levels). Two input methods are supported (mutually exclusive):

- Inline, repeatable: `--permission FLOW:READ,CREATE --permission EXECUTION:READ`
- From file: `--permissions-file perms.yaml` (YAML or JSON)

Both feed a `map[string][]string` that is converted to the SDK permissions struct via a **JSON round-trip**, leaning on the struct's JSON tags. This avoids a hand-maintained switch over the ~24 resource types and stays forward-compatible with new ones.

## Notable behavior

- **Full-replace update**: the update endpoint is a PUT, so `update` fetches the current role and overlays only the changed flags, preserving untouched attributes — matching the pattern established for users in #56. Passing `--permission` on update **replaces** the entire permissions block (it does not merge).
- Tenant threaded via `client.Tenant`; `validateOutputFormat()` runs early; all SDK errors wrapped with `formatSDKError`; table + JSON output (empty results render as `[]`); delete prompts for confirmation unless `--yes`.

## Testing

- Unit tests in `src/cli/roles_test.go`: command structure, required `--name`, `parsePermPair` table tests, flag/file conflict, file parsing, list/get rendering (incl. permissions block), create body assertion, create-requires-permissions, update-overlays-existing, delete confirmed/cancelled.
- `go test ./src/...` → **182 passed**; `gofmt`/`go vet` clean.
- README updated with a Roles section and project-structure entries.

> Requires Kestra EE. No e2e tests added (the issue's acceptance criteria lists unit tests only) — happy to add a roles e2e flow if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)