### PR TITLE
feat(iam): manage service accounts via CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kestra CLI
 
-A Go-based command-line interface for managing Kestra flows, executions, namespaces, and IAM users and roles.
+A Go-based command-line interface for managing Kestra flows, executions, namespaces, and IAM users, groups, roles, and service accounts.
 
 ## Installation
 
@@ -424,6 +424,45 @@ kestractl roles delete <role_id>
 kestractl roles delete <role_id> --yes
 ```
 
+### Service Accounts (Enterprise Edition)
+
+Service account management requires Kestra Enterprise Edition. Service accounts
+are instance-level resources (command aliases: `service-account`, `sa`).
+
+> `update` is a partial update of the name/description only. Tenant access,
+> super-admin status and group membership are left untouched — set those at
+> creation time.
+
+```bash
+# List service accounts (alias: ls)
+kestractl service-accounts list
+kestractl service-accounts list --output json
+kestractl service-accounts list --page 1 --size 50 --sort name:asc
+
+# Get service account details (aliases: show, describe)
+kestractl service-accounts get <service_account_id>
+
+# Create a service account (--name is required; lowercase alphanumeric and dashes)
+kestractl service-accounts create --name ci-bot --description "CI pipeline"
+
+# Create a super-admin service account with tenant access (--tenant-grant is repeatable)
+kestractl service-accounts create --name ops-bot --superadmin --tenant-grant main
+
+# Update name/description — other attributes are preserved
+kestractl service-accounts update <service_account_id> --description "Updated description"
+kestractl service-accounts update <service_account_id> --name new-bot-name
+
+# Delete a service account (alias: rm) — prompts for confirmation unless --yes
+kestractl service-accounts delete <service_account_id>
+kestractl service-accounts delete <service_account_id> --yes
+
+# Manage a service account's API tokens (the full token is shown only once, at creation)
+kestractl service-accounts tokens create <service_account_id> --name deploy-token
+kestractl service-accounts tokens create <service_account_id> --name short-lived --max-age P30D --extended
+kestractl service-accounts tokens list <service_account_id>
+kestractl service-accounts tokens delete <service_account_id> <token_id>
+```
+
 ### Output Formats
 
 ```bash
@@ -496,8 +535,12 @@ kestractl/
     ├── workers_test.go        # Unit tests
     ├── users.go               # IAM users commands (list, get, create, update, delete, set-groups, set-password, tokens)
     ├── users_test.go          # Unit tests
+    ├── groups.go              # IAM groups commands (list, get, create, update, delete, members)
+    ├── groups_test.go         # Unit tests
     ├── roles.go               # IAM roles commands (list, get, create, update, delete)
     ├── roles_test.go          # Unit tests
+    ├── service_accounts.go    # IAM service accounts commands (list, get, create, update, delete, tokens)
+    ├── service_accounts_test.go # Unit tests
     └── testdata/              # Test fixtures
         └── flow.yaml
 ```

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -116,6 +116,7 @@ with support for multiple authentication contexts and output formats.`,
 	root.AddCommand(newUsersCommand())
 	root.AddCommand(newGroupsCommand())
 	root.AddCommand(newRolesCommand())
+	root.AddCommand(newServiceAccountsCommand())
 
 	return root
 }

--- a/src/cli/service_accounts.go
+++ b/src/cli/service_accounts.go
@@ -1,0 +1,530 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/spf13/cobra"
+)
+
+func newServiceAccountsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "service-accounts",
+		Aliases: []string{"service-account", "sa"},
+		Short:   "Manage IAM service accounts (list, get, create, update, delete)",
+		Long: `Manage IAM service accounts in your Kestra instance.
+
+Service accounts are instance-level resources. Managing them requires Kestra
+Enterprise Edition.`,
+	}
+
+	cmd.AddCommand(newServiceAccountsListCommand())
+	cmd.AddCommand(newServiceAccountsGetCommand())
+	cmd.AddCommand(newServiceAccountsCreateCommand())
+	cmd.AddCommand(newServiceAccountsUpdateCommand())
+	cmd.AddCommand(newServiceAccountsDeleteCommand())
+	cmd.AddCommand(newServiceAccountsTokensCommand())
+
+	return cmd
+}
+
+// serviceAccountMutation holds the fields used to create a service account,
+// plus a record of which flags the operator explicitly set.
+//
+// Unlike users/roles, update is a true PATCH (PatchServiceAccountDetails) that
+// only touches name and description — so the *Set bookkeeping is only needed
+// for create, where superAdmin and tenants are also settable.
+type serviceAccountMutation struct {
+	name        string
+	description string
+	superAdmin  bool
+	tenants     []string
+
+	nameSet        bool
+	descriptionSet bool
+	superAdminSet  bool
+	tenantsSet     bool
+}
+
+// markChanged records which flags the operator actually passed on the command.
+func (m *serviceAccountMutation) markChanged(cmd *cobra.Command) {
+	f := cmd.Flags()
+	m.nameSet = f.Changed("name")
+	m.descriptionSet = f.Changed("description")
+	m.superAdminSet = f.Changed("superadmin")
+	m.tenantsSet = f.Changed("tenant-grant")
+}
+
+func newServiceAccountsListCommand() *cobra.Command {
+	var (
+		page int32
+		size int32
+		sort []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List service accounts.",
+		Long:  "List all service accounts in your Kestra instance.",
+		Example: `  # List all service accounts
+  kestractl service-accounts list
+
+  # List service accounts as JSON
+  kestractl service-accounts list --output json`,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runServiceAccountsList(client, page, size, sort, renderer)
+		},
+	}
+
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (e.g. 'name:asc', repeatable)")
+
+	return cmd
+}
+
+func runServiceAccountsList(client *Client, page, size int32, sort []string, renderer *Renderer) error {
+	req := client.API.ServiceAccountAPI.ListServiceAccounts(client.Ctx).Page(page).Size(size)
+	if len(sort) > 0 {
+		req = req.Sort(sort)
+	}
+
+	resp, _, err := req.Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	results := resp.GetResults()
+	if results == nil {
+		// Render an empty JSON array ([]) rather than null on no results.
+		results = []kestra.IAMServiceAccountControllerApiServiceAccountDetail{}
+	}
+
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ID\tNAME\tSUPERADMIN\tTENANTS")
+		for _, sa := range results {
+			fmt.Fprintf(w, "%s\t%s\t%t\t%s\n",
+				sa.GetId(), sa.GetName(), sa.GetSuperAdmin(), strings.Join(tenantIDs(sa.GetTenants()), ", "))
+		}
+		fmt.Fprintf(w, "\nTotal service accounts: %d\n", resp.GetTotal())
+		return nil
+	})
+}
+
+func newServiceAccountsGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "get <service_account_id>",
+		Short:   "Get service account details.",
+		Long:    "Retrieve detailed information about a specific service account.",
+		Aliases: []string{"show", "describe"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runServiceAccountsGet(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runServiceAccountsGet(client *Client, id string, renderer *Renderer) error {
+	sa, _, err := client.API.ServiceAccountAPI.ServiceAccount(client.Ctx, id).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderServiceAccountDetail(sa, renderer)
+}
+
+func renderServiceAccountDetail(sa *kestra.IAMServiceAccountControllerApiServiceAccountDetail, renderer *Renderer) error {
+	return renderer.Render(sa, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "Service Account Details")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ID:\t%s\n", sa.GetId())
+		fmt.Fprintf(w, "Name:\t%s\n", sa.GetName())
+		fmt.Fprintf(w, "Description:\t%s\n", sa.GetDescription())
+		fmt.Fprintf(w, "Super Admin:\t%t\n", sa.GetSuperAdmin())
+		if tenants := sa.GetTenants(); len(tenants) > 0 {
+			fmt.Fprintf(w, "Tenants:\t%s\n", strings.Join(tenantIDs(tenants), ", "))
+		}
+		return nil
+	})
+}
+
+// tenantIDs extracts the tenant identifiers from a service account's tenant
+// summaries, for compact display.
+func tenantIDs(tenants []kestra.ApiTenantSummary) []string {
+	ids := make([]string, 0, len(tenants))
+	for _, t := range tenants {
+		ids = append(ids, t.GetId())
+	}
+	return ids
+}
+
+func newServiceAccountsCreateCommand() *cobra.Command {
+	var m serviceAccountMutation
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a service account.",
+		Long: `Create a new service account. The --name flag is required.
+
+Names must be lowercase alphanumeric, optionally separated by dashes.`,
+		Example: `  # Create a service account
+  kestractl service-accounts create --name ci-bot --description "CI pipeline"
+
+  # Create a super-admin service account with tenant access
+  kestractl service-accounts create --name ops-bot --superadmin --tenant-grant main`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			m.markChanged(cmd)
+			return runServiceAccountsCreate(client, m, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&m.name, "name", "", "Service account name (lowercase alphanumeric and dashes)")
+	cmd.Flags().StringVar(&m.description, "description", "", "Service account description")
+	cmd.Flags().BoolVar(&m.superAdmin, "superadmin", false, "Grant super-admin privileges")
+	cmd.Flags().StringArrayVar(&m.tenants, "tenant-grant", nil, "Tenant ID to grant access to (repeatable)")
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func runServiceAccountsCreate(client *Client, m serviceAccountMutation, renderer *Renderer) error {
+	body := kestra.IAMServiceAccountControllerApiCreateServiceAccountRequest{Name: m.name}
+	if m.descriptionSet {
+		body.Description = &m.description
+	}
+	if m.superAdminSet {
+		body.SuperAdmin = &m.superAdmin
+	}
+	if m.tenantsSet {
+		body.Tenants = m.tenants
+	}
+
+	sa, _, err := client.API.ServiceAccountAPI.CreateServiceAccount(client.Ctx).
+		IAMServiceAccountControllerApiCreateServiceAccountRequest(body).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderServiceAccountDetail(sa, renderer)
+}
+
+func newServiceAccountsUpdateCommand() *cobra.Command {
+	var m serviceAccountMutation
+
+	cmd := &cobra.Command{
+		Use:   "update <service_account_id>",
+		Short: "Update a service account's name or description.",
+		Long: `Update an existing service account.
+
+This is a partial update: only --name and --description are changed. Tenant
+access, super-admin status and group membership are left untouched.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			m.markChanged(cmd)
+			return runServiceAccountsUpdate(client, args[0], m, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&m.name, "name", "", "New name (lowercase alphanumeric and dashes)")
+	cmd.Flags().StringVar(&m.description, "description", "", "New description")
+
+	return cmd
+}
+
+func runServiceAccountsUpdate(client *Client, id string, m serviceAccountMutation, renderer *Renderer) error {
+	if !m.nameSet && !m.descriptionSet {
+		return fmt.Errorf("nothing to update: pass --name and/or --description")
+	}
+
+	// PatchServiceAccountRequest.Name is required, so fetch the current account
+	// to fill in the unchanged name when only --description is provided.
+	current, _, err := client.API.ServiceAccountAPI.ServiceAccount(client.Ctx, id).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	body := kestra.IAMServiceAccountControllerApiPatchServiceAccountRequest{Name: current.GetName()}
+	if m.nameSet {
+		body.Name = m.name
+	}
+	if m.descriptionSet {
+		body.Description = &m.description
+	} else if current.Description != nil {
+		body.Description = current.Description
+	}
+
+	sa, _, err := client.API.ServiceAccountAPI.PatchServiceAccountDetails(client.Ctx, id).
+		IAMServiceAccountControllerApiPatchServiceAccountRequest(body).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderServiceAccountDetail(sa, renderer)
+}
+
+func newServiceAccountsDeleteCommand() *cobra.Command {
+	var skipConfirm bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <service_account_id>",
+		Short:   "Delete a service account.",
+		Long:    "Delete a service account. Prompts for confirmation unless --yes is provided.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runServiceAccountsDelete(client, args[0], skipConfirm, cmd.InOrStdin(), renderer)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation prompt")
+
+	return cmd
+}
+
+func runServiceAccountsDelete(client *Client, id string, skipConfirm bool, in io.Reader, renderer *Renderer) error {
+	if !skipConfirm {
+		// Prompt on stderr so it never pollutes stdout (e.g. --output json).
+		confirmed, err := confirm(in, os.Stderr,
+			fmt.Sprintf("Are you sure you want to delete service account '%s'? [y/N]: ", id))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return renderStatus(renderer, "Cancelled.", map[string]any{"id": id, "status": "cancelled"})
+		}
+	}
+
+	if _, err := client.API.ServiceAccountAPI.DeleteServiceAccount(client.Ctx, id).Execute(); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("Service account '%s' deleted.", id),
+		map[string]any{"id": id, "status": "deleted"})
+}
+
+func newServiceAccountsTokensCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tokens",
+		Short: "Manage API tokens for a service account (list, create, delete)",
+	}
+
+	cmd.AddCommand(newServiceAccountsTokensListCommand())
+	cmd.AddCommand(newServiceAccountsTokensCreateCommand())
+	cmd.AddCommand(newServiceAccountsTokensDeleteCommand())
+
+	return cmd
+}
+
+// decodeTokenInto re-decodes a loosely-typed token response (the SDK's
+// ServiceAccount token endpoints return map[string]interface{}) into the
+// strongly-typed token struct via a JSON round-trip.
+func decodeTokenInto(raw map[string]interface{}, out any) error {
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return fmt.Errorf("decoding token response: %w", err)
+	}
+	return nil
+}
+
+func newServiceAccountsTokensListCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list <service_account_id>",
+		Short:   "List API tokens for a service account.",
+		Aliases: []string{"ls"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runServiceAccountsTokensList(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runServiceAccountsTokensList(client *Client, id string, renderer *Renderer) error {
+	raw, _, err := client.API.ServiceAccountAPI.ListApiTokensForServiceAccount(client.Ctx, id).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	var list kestra.ApiTokenList
+	if err := decodeTokenInto(raw, &list); err != nil {
+		return err
+	}
+
+	tokens := list.GetResults()
+	if tokens == nil {
+		// Render an empty JSON array ([]) rather than null on no results.
+		tokens = []kestra.ApiToken{}
+	}
+
+	return renderer.Render(tokens, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ID\tNAME\tPREFIX\tEXPIRED\tLAST USED")
+		for _, tok := range tokens {
+			lastUsed := ""
+			if tok.LastUsed != nil {
+				lastUsed = tok.LastUsed.Format(time.RFC3339)
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%t\t%s\n",
+				tok.GetId(), tok.GetName(), tok.GetPrefix(), tok.GetExpired(), lastUsed)
+		}
+		fmt.Fprintf(w, "\nTotal tokens: %d\n", len(tokens))
+		return nil
+	})
+}
+
+func newServiceAccountsTokensCreateCommand() *cobra.Command {
+	var (
+		name        string
+		description string
+		maxAge      string
+		extended    bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create <service_account_id>",
+		Short: "Create an API token for a service account.",
+		Long: `Create an API token for a service account.
+
+The full token value is shown only once, at creation time. Store it securely.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runServiceAccountsTokensCreate(client, args[0], name, description, maxAge, extended, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Token name (lowercase alphanumeric and dashes)")
+	cmd.Flags().StringVar(&description, "description", "", "Token description")
+	cmd.Flags().StringVar(&maxAge, "max-age", "", "Token max age (ISO-8601 duration, e.g. P30D)")
+	cmd.Flags().BoolVar(&extended, "extended", false, "Create an extended token")
+	_ = cmd.MarkFlagRequired("name")
+
+	return cmd
+}
+
+func runServiceAccountsTokensCreate(client *Client, id, name, description, maxAge string, extended bool, renderer *Renderer) error {
+	body := kestra.CreateApiTokenRequest{Name: name, Extended: &extended}
+	if description != "" {
+		body.Description = &description
+	}
+	if maxAge != "" {
+		body.MaxAge = &maxAge
+	}
+
+	raw, _, err := client.API.ServiceAccountAPI.CreateApiTokensForServiceAccount(client.Ctx, id).
+		CreateApiTokenRequest(body).
+		Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	var resp kestra.CreateApiTokenResponse
+	if err := decodeTokenInto(raw, &resp); err != nil {
+		return err
+	}
+
+	return renderer.Render(&resp, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "API token created.")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ID:\t%s\n", resp.GetId())
+		fmt.Fprintf(w, "Name:\t%s\n", resp.GetName())
+		fmt.Fprintf(w, "Token:\t%s\n", resp.GetFullToken())
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "Store this token now — it will not be shown again.")
+		return nil
+	})
+}
+
+func newServiceAccountsTokensDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete <service_account_id> <token_id>",
+		Short:   "Delete an API token for a service account.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runServiceAccountsTokensDelete(client, args[0], args[1], renderer)
+		},
+	}
+	return cmd
+}
+
+func runServiceAccountsTokensDelete(client *Client, id, tokenID string, renderer *Renderer) error {
+	if _, _, err := client.API.ServiceAccountAPI.DeleteApiTokenForServiceAccount(client.Ctx, id, tokenID).Execute(); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("Token '%s' deleted for service account '%s'.", tokenID, id),
+		map[string]any{"id": tokenID, "serviceAccountId": id, "status": "deleted"})
+}

--- a/src/cli/service_accounts_test.go
+++ b/src/cli/service_accounts_test.go
@@ -1,0 +1,285 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestServiceAccountsCommand_Structure(t *testing.T) {
+	cmd := newServiceAccountsCommand()
+	if cmd.Use != "service-accounts" {
+		t.Fatalf("expected use 'service-accounts', got %q", cmd.Use)
+	}
+
+	want := map[string]bool{
+		"list": false, "get": false, "create": false, "update": false, "delete": false, "tokens": false,
+	}
+	for _, sub := range cmd.Commands() {
+		name := strings.Fields(sub.Use)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestServiceAccountsTokensCommand_Structure(t *testing.T) {
+	cmd := newServiceAccountsTokensCommand()
+	want := map[string]bool{"list": false, "create": false, "delete": false}
+	for _, sub := range cmd.Commands() {
+		name := strings.Fields(sub.Use)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing tokens subcommand %q", name)
+		}
+	}
+}
+
+func TestServiceAccountsCreateCommand_RequiredName(t *testing.T) {
+	cmd := newServiceAccountsCreateCommand()
+	if cmd.Flags().Lookup("name") == nil {
+		t.Fatal("expected --name flag")
+	}
+	if _, err := executeCommand(cmd); err == nil {
+		t.Fatal("expected error when --name is missing")
+	}
+}
+
+func TestServiceAccountsDeleteCommand_HasYesFlag(t *testing.T) {
+	cmd := newServiceAccountsDeleteCommand()
+	f := cmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("expected --yes flag")
+	}
+	if f.Shorthand != "y" {
+		t.Fatalf("expected -y shorthand, got %q", f.Shorthand)
+	}
+}
+
+func TestRunServiceAccountsList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"sa1","name":"ci-bot","superAdmin":false,"tenants":[{"id":"main"}]},
+			{"id":"sa2","name":"ops-bot","superAdmin":true}
+		],"total":2}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runServiceAccountsList(newTestClient(t, server.URL), 1, 100, nil, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runServiceAccountsList error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"ci-bot", "ops-bot", "main", "Total service accounts: 2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunServiceAccountsGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"sa1","name":"ci-bot","description":"CI pipeline",
+			"superAdmin":false,"tenants":[{"id":"main"},{"id":"dev"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runServiceAccountsGet(newTestClient(t, server.URL), "sa1", newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runServiceAccountsGet error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"ci-bot", "CI pipeline", "main, dev"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunServiceAccountsCreate_SendsBody(t *testing.T) {
+	var gotBody map[string]any
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"new","name":"ci-bot"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	m := serviceAccountMutation{
+		name:           "ci-bot",
+		description:    "CI pipeline",
+		tenants:        []string{"main"},
+		nameSet:        true,
+		descriptionSet: true,
+		tenantsSet:     true,
+	}
+	var buf bytes.Buffer
+	if err := runServiceAccountsCreate(newTestClient(t, server.URL), m, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runServiceAccountsCreate error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotBody["name"] != "ci-bot" {
+		t.Errorf("expected name in body, got %v", gotBody["name"])
+	}
+	if gotBody["description"] != "CI pipeline" {
+		t.Errorf("expected description in body, got %v", gotBody["description"])
+	}
+	tenants, ok := gotBody["tenants"].([]any)
+	if !ok || len(tenants) != 1 || tenants[0] != "main" {
+		t.Errorf("expected tenants [main], got %v", gotBody["tenants"])
+	}
+}
+
+func TestRunServiceAccountsUpdate_FillsNameFromCurrent(t *testing.T) {
+	var gotBody map[string]any
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"id":"sa1","name":"ci-bot","description":"old"}`))
+		default:
+			gotMethod = r.Method
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_, _ = w.Write([]byte(`{"id":"sa1","name":"ci-bot","description":"new"}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	// Only --description is set; name must be backfilled from the GET.
+	m := serviceAccountMutation{description: "new", descriptionSet: true}
+	var buf bytes.Buffer
+	if err := runServiceAccountsUpdate(newTestClient(t, server.URL), "sa1", m, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runServiceAccountsUpdate error: %v", err)
+	}
+
+	if gotMethod != http.MethodPatch {
+		t.Errorf("expected PATCH, got %s", gotMethod)
+	}
+	if gotBody["name"] != "ci-bot" {
+		t.Errorf("expected name backfilled to 'ci-bot', got %v", gotBody["name"])
+	}
+	if gotBody["description"] != "new" {
+		t.Errorf("expected description 'new', got %v", gotBody["description"])
+	}
+}
+
+func TestRunServiceAccountsUpdate_NothingToUpdate(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runServiceAccountsUpdate(newTestClient(t, server.URL), "sa1", serviceAccountMutation{}, newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected error when no fields are set")
+	}
+	if hit {
+		t.Error("expected no HTTP call when nothing to update")
+	}
+}
+
+func TestRunServiceAccountsDelete_Confirmed(t *testing.T) {
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runServiceAccountsDelete(newTestClient(t, server.URL), "sa1", true, strings.NewReader(""), newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runServiceAccountsDelete error: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("expected DELETE, got %s", gotMethod)
+	}
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Errorf("expected deletion message, got %q", buf.String())
+	}
+}
+
+func TestRunServiceAccountsTokensList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total":1,"results":[
+			{"id":"tok1","name":"deploy","prefix":"abc","expired":false}
+		]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runServiceAccountsTokensList(newTestClient(t, server.URL), "sa1", newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runServiceAccountsTokensList error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"tok1", "deploy", "abc", "Total tokens: 1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunServiceAccountsTokensCreate_ShowsFullToken(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"tok1","name":"deploy","fullToken":"secret-token-value"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runServiceAccountsTokensCreate(newTestClient(t, server.URL), "sa1", "deploy", "", "", false, newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runServiceAccountsTokensCreate error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"deploy", "secret-token-value", "will not be shown again"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunServiceAccountsTokensDelete(t *testing.T) {
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runServiceAccountsTokensDelete(newTestClient(t, server.URL), "sa1", "tok1", newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runServiceAccountsTokensDelete error: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("expected DELETE, got %s", gotMethod)
+	}
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Errorf("expected deletion message, got %q", buf.String())
+	}
+}


### PR DESCRIPTION
Closes #55. Part of #12 — IAM management via CLI.

Adds a `service-accounts` command group backed by the SDK's `ServiceAccountAPI`.

## Commands
| Command | SDK method |
|---|---|
| `service-accounts list` | `ListServiceAccounts` |
| `service-accounts get <id>` | `ServiceAccount` |
| `service-accounts create` | `CreateServiceAccount` |
| `service-accounts update <id>` | `PatchServiceAccountDetails` |
| `service-accounts delete <id>` | `DeleteServiceAccount` |
| `service-accounts tokens list\|create\|delete <id>` | `*ApiTokensForServiceAccount` |

Aliases: `service-account`, `sa`.

## Design notes
- **Instance-level (non-tenant) endpoints**, mirroring `users.go` — service accounts span tenants.
- **`update` is a partial PATCH** (`PatchServiceAccountDetails`) for name/description. A full PUT was avoided because the GET detail model has no `groups` field, so a replace would silently wipe group membership. The required `name` is backfilled from a GET when only `--description` is passed.
- **Token endpoints return `map[string]interface{}`** (unlike the typed User token endpoints) — decoded into `ApiTokenList`/`CreateApiTokenResponse` via a JSON round-trip, the same technique `roles.go` uses for permissions.
- **No `--query` flag**: the list endpoint's server-side `q` filter is non-functional (returns 0 even for existing accounts). Verified `--query` *does* work for `users`/`roles`, so it was removed only here.

## Acceptance criteria
- [x] `newServiceAccountsCommand()` + pure `runServiceAccounts...()` in `src/cli/service_accounts.go`
- [x] Registered in `root.go`
- [x] Table + JSON output; `validateOutputFormat()` early
- [x] SDK errors wrapped with `formatSDKError`
- [x] Newly-created token secret never logged; masked under `--verbose`
- [x] Unit tests in `src/cli/service_accounts_test.go`
- [x] Follows CLAUDE.md / CONTRIBUTING.md command pattern

## Testing
- `go build`, `go vet`, `go test ./src/...` — 209 pass (13 new).
- Manually QA'd every command (create/get/update/tokens/delete) against a live Kestra EE instance.

> Requires Kestra EE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)