### PR TITLE
feat(plugins): add --force-redownload flag with SHA-1 checksum verification

### DIFF
--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"crypto/sha1" //nolint:gosec // SHA-1 is used only for checksum comparison, not cryptographic security
 	"encoding/json"
 	"fmt"
 	"io"
@@ -27,10 +28,11 @@ type pluginArtifact struct {
 }
 
 type downloadResult struct {
-	index  int
-	plugin pluginArtifact
-	bytes  int64
-	err    error
+	index   int
+	plugin  pluginArtifact
+	bytes   int64
+	err     error
+	skipped bool
 }
 
 func newPluginsCommand() *cobra.Command {
@@ -49,19 +51,21 @@ func newPluginsCommand() *cobra.Command {
 func newPluginsDownloadCommand() *cobra.Command {
 	var pluginsDir string
 	var concurrency int
+	var forceRedownload bool
 
 	cmd := &cobra.Command{
 		Use:   "download <version>",
 		Short: "Download all plugins for a given Kestra version from Maven Central",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency)
+			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency, forceRedownload)
 		},
 		Annotations: map[string]string{AnnotationOffline: "true"},
 	}
 
 	cmd.Flags().StringVar(&pluginsDir, "plugins-dir", "./plugins", "Directory to write downloaded JARs into")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of parallel downloads")
+	cmd.Flags().BoolVar(&forceRedownload, "force-redownload", false, "Re-download plugins even if they already exist and pass checksum verification")
 	return cmd
 }
 
@@ -75,7 +79,7 @@ func resolveVersion(version string) string {
 	}
 }
 
-func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int) error {
+func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool) error {
 	kestraVersion = resolveVersion(kestraVersion)
 	fmt.Fprintf(out, "Fetching plugin list for Kestra %s...\n", kestraVersion)
 
@@ -103,8 +107,8 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 			defer wg.Done()
 			sem <- struct{}{}
 			defer func() { <-sem }()
-			n, err := downloadJAR(p, pluginsDir)
-			results <- downloadResult{index: i, plugin: p, bytes: n, err: err}
+			n, skipped, err := downloadJAR(p, pluginsDir, forceRedownload)
+			results <- downloadResult{index: i, plugin: p, bytes: n, err: err, skipped: skipped}
 		}(i, p)
 	}
 
@@ -114,23 +118,31 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 	}()
 
 	var mu sync.Mutex
-	installed := 0
+	downloaded := 0
+	skippedCount := 0
 	failed := 0
 
 	for r := range results {
 		label := fmt.Sprintf("%s:%s:%s", r.plugin.GroupID, r.plugin.ArtifactID, r.plugin.Version)
 		mu.Lock()
 		if r.err != nil {
-			fmt.Fprintf(out, lineFormat+" Downloading %s ... FAILED (%v)\n", r.index+1, len(plugins), label, r.err)
+			fmt.Fprintf(out, lineFormat+" %s ... FAILED (%v)\n", r.index+1, len(plugins), label, r.err)
 			failed++
+		} else if r.skipped {
+			fmt.Fprintf(out, lineFormat+" %s ... already up to date\n", r.index+1, len(plugins), label)
+			skippedCount++
 		} else {
-			fmt.Fprintf(out, lineFormat+" Downloading %s ... done (%.1f MB)\n", r.index+1, len(plugins), label, float64(r.bytes)/(1024*1024))
-			installed++
+			fmt.Fprintf(out, lineFormat+" %s ... done (%.1f MB)\n", r.index+1, len(plugins), label, float64(r.bytes)/(1024*1024))
+			downloaded++
 		}
 		mu.Unlock()
 	}
 
-	fmt.Fprintf(out, "\nInstalled %d plugin(s) to %s", installed, pluginsDir)
+	fmt.Fprintf(out, "\nDownloaded %d", downloaded)
+	if skippedCount > 0 {
+		fmt.Fprintf(out, ", skipped %d (already up to date)", skippedCount)
+	}
+	fmt.Fprintf(out, " plugin(s) to %s", pluginsDir)
 	if failed > 0 {
 		fmt.Fprintf(out, ", %d failed", failed)
 	}
@@ -171,31 +183,97 @@ func pluginFileName(p pluginArtifact) string {
 	return groupID + "__" + p.ArtifactID + "__" + version + ".jar"
 }
 
-func downloadJAR(p pluginArtifact, destDir string) (int64, error) {
-	url := mavenJARURL(p)
+func downloadJAR(p pluginArtifact, destDir string, forceRedownload bool) (int64, bool, error) {
 	destPath := filepath.Join(destDir, pluginFileName(p))
 
+	if !forceRedownload {
+		if _, err := os.Stat(destPath); err == nil {
+			remoteSHA1, shaErr := fetchMavenSHA1(p)
+			if shaErr == nil {
+				localHash, hashErr := localFileSHA1(destPath)
+				if hashErr == nil && localHash == remoteSHA1 {
+					return 0, true, nil // already up-to-date
+				}
+				// SHA-1 mismatch: file is corrupted or truncated — remove and re-download.
+				_ = os.Remove(destPath)
+			} else {
+				// Can't reach Maven for SHA-1 — fall back to ZIP magic byte check.
+				if isValidZIP(destPath) {
+					return 0, true, nil
+				}
+			}
+		}
+	}
+
+	url := mavenJARURL(p)
 	resp, err := http.Get(url) //nolint:gosec // URL is constructed from trusted API data
 	if err != nil {
-		return 0, fmt.Errorf("HTTP request failed: %w", err)
+		return 0, false, fmt.Errorf("HTTP request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("Maven Central returned HTTP %d", resp.StatusCode)
+		return 0, false, fmt.Errorf("Maven Central returned HTTP %d", resp.StatusCode)
 	}
 
 	f, err := os.Create(destPath)
 	if err != nil {
-		return 0, fmt.Errorf("cannot create file: %w", err)
+		return 0, false, fmt.Errorf("cannot create file: %w", err)
 	}
 	defer f.Close()
 
 	n, err := io.Copy(f, resp.Body)
 	if err != nil {
-		return 0, fmt.Errorf("write failed: %w", err)
+		return 0, false, fmt.Errorf("write failed: %w", err)
 	}
-	return n, nil
+	return n, false, nil
+}
+
+// fetchMavenSHA1 retrieves the SHA-1 checksum published by Maven Central for the artifact.
+func fetchMavenSHA1(p pluginArtifact) (string, error) {
+	url := mavenJARURL(p) + ".sha1"
+	resp, err := http.Get(url) //nolint:gosec // URL is constructed from trusted API data
+	if err != nil {
+		return "", fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Maven Central returned HTTP %d for SHA-1", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read failed: %w", err)
+	}
+	// Maven .sha1 files contain the hex digest, optionally followed by whitespace and filename.
+	return strings.Fields(string(body))[0], nil
+}
+
+// localFileSHA1 computes the hex-encoded SHA-1 digest of the file at path.
+func localFileSHA1(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha1.New() //nolint:gosec // SHA-1 used only for checksum comparison
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+// isValidZIP checks whether path starts with the ZIP/JAR magic bytes (PK\x03\x04).
+func isValidZIP(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+	var magic [4]byte
+	if _, err := io.ReadFull(f, magic[:]); err != nil {
+		return false
+	}
+	return magic[0] == 'P' && magic[1] == 'K' && magic[2] == 0x03 && magic[3] == 0x04
 }
 
 // mavenJARURL builds the Maven Central download URL for a plugin artifact.

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"crypto/sha1" //nolint:gosec
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -38,9 +39,19 @@ const pluginListPayload = `[
   {"groupId":"io.kestra.plugin.ee","artifactId":"plugin-ee-jdbc","license":"ENTERPRISE","version":"1.3.9"}
 ]`
 
+// mockJARBody is the dummy JAR content returned by the mock Maven server.
+const mockJARBody = "PK\x03\x04"
+
+// mockJARSHA1 is the hex SHA-1 of mockJARBody, used by the mock .sha1 endpoint.
+var mockJARSHA1 = func() string {
+	h := sha1.New() //nolint:gosec
+	h.Write([]byte(mockJARBody))
+	return fmt.Sprintf("%x", h.Sum(nil))
+}()
+
 // newMockServers sets up:
 //   - apiServer: returns pluginListPayload for any request
-//   - mavenServer: returns a dummy JAR body for any request
+//   - mavenServer: returns a dummy JAR body for .jar requests and its SHA-1 for .sha1 requests
 //
 // It overrides pluginsAPIBase and pluginsMavenBase and restores them via t.Cleanup.
 func newMockServers(t *testing.T, apiStatus int, apiBody string) (apiServer, mavenServer *httptest.Server) {
@@ -53,9 +64,14 @@ func newMockServers(t *testing.T, apiStatus int, apiBody string) (apiServer, mav
 	}))
 
 	mavenServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".sha1") {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, mockJARSHA1)
+			return
+		}
 		w.Header().Set("Content-Type", "application/java-archive")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "PK\x03\x04") // minimal ZIP/JAR magic bytes
+		fmt.Fprint(w, mockJARBody)
 	}))
 
 	origAPI := pluginsAPIBase
@@ -79,7 +95,7 @@ func TestRunPluginsInstall_HappyPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1)
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -89,8 +105,8 @@ func TestRunPluginsInstall_HappyPath(t *testing.T) {
 	if !strings.Contains(output, "Found 22 plugins") {
 		t.Errorf("expected 'Found 22 plugins' in output, got:\n%s", output)
 	}
-	if !strings.Contains(output, "Installed 22 plugin(s)") {
-		t.Errorf("expected 'Installed 22 plugin(s)' in output, got:\n%s", output)
+	if !strings.Contains(output, "Downloaded 22") {
+		t.Errorf("expected 'Downloaded 22' in output, got:\n%s", output)
 	}
 
 	// Verify JAR files were written to disk.
@@ -122,7 +138,7 @@ func TestRunPluginsInstall_ConcurrentDownloads(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4)
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false)
 	if err != nil {
 		t.Fatalf("unexpected error with concurrency=4: %v", err)
 	}
@@ -140,7 +156,7 @@ func TestRunPluginsInstall_APINotFound(t *testing.T) {
 	newMockServers(t, http.StatusNotFound, `{"message":"version not found"}`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1)
+	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false)
 	if err == nil {
 		t.Fatal("expected error for HTTP 404, got nil")
 	}
@@ -153,7 +169,7 @@ func TestRunPluginsInstall_APIInvalidJSON(t *testing.T) {
 	newMockServers(t, http.StatusOK, `not-json`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false)
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
@@ -184,7 +200,7 @@ func TestRunPluginsInstall_MavenDownloadFailure(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false)
 	if err == nil {
 		t.Fatal("expected error when Maven returns 404, got nil")
 	}
@@ -265,7 +281,7 @@ func TestMavenJARURL(t *testing.T) {
 func TestPluginsDownloadCommand_Flags(t *testing.T) {
 	cmd := newPluginsDownloadCommand()
 
-	for _, flag := range []string{"plugins-dir", "concurrency"} {
+	for _, flag := range []string{"plugins-dir", "concurrency", "force-redownload"} {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("expected flag --%s to exist", flag)
 		}
@@ -300,5 +316,136 @@ func TestPluginsDownloadCommand_RequiresVersion(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "accepts 1 arg") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// singlePluginPayload is a minimal plugin list used for skip/force tests.
+const singlePluginPayload = `[{"groupId":"io.kestra.plugin","artifactId":"plugin-kafka","license":"OPEN_SOURCE","version":"1.6.0"}]`
+
+func TestRunPluginsInstall_SkipsExistingValidJAR(t *testing.T) {
+	newMockServers(t, http.StatusOK, singlePluginPayload)
+
+	tmpDir := t.TempDir()
+
+	// Pre-create the JAR with the same content the mock Maven server serves.
+	jarPath := filepath.Join(tmpDir, "io_kestra_plugin__plugin-kafka__1_6_0.jar")
+	if err := os.WriteFile(jarPath, []byte(mockJARBody), 0o644); err != nil {
+		t.Fatalf("failed to create pre-existing JAR: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "already up to date") {
+		t.Errorf("expected 'already up to date' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "skipped 1") {
+		t.Errorf("expected 'skipped 1' in output, got:\n%s", output)
+	}
+	if strings.Contains(output, "Downloaded 1") {
+		t.Errorf("did not expect 'Downloaded 1' when plugin is up to date, got:\n%s", output)
+	}
+}
+
+func TestRunPluginsInstall_ForceRedownloadsExistingJAR(t *testing.T) {
+	newMockServers(t, http.StatusOK, singlePluginPayload)
+
+	tmpDir := t.TempDir()
+
+	// Pre-create the JAR with matching content.
+	jarPath := filepath.Join(tmpDir, "io_kestra_plugin__plugin-kafka__1_6_0.jar")
+	if err := os.WriteFile(jarPath, []byte(mockJARBody), 0o644); err != nil {
+		t.Fatalf("failed to create pre-existing JAR: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if strings.Contains(output, "already up to date") {
+		t.Errorf("did not expect 'already up to date' with --force-redownload, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Downloaded 1") {
+		t.Errorf("expected 'Downloaded 1' with --force-redownload, got:\n%s", output)
+	}
+}
+
+func TestRunPluginsInstall_RedownloadsCorruptedJAR(t *testing.T) {
+	newMockServers(t, http.StatusOK, singlePluginPayload)
+
+	tmpDir := t.TempDir()
+
+	// Pre-create the JAR with corrupt content (SHA-1 will not match).
+	jarPath := filepath.Join(tmpDir, "io_kestra_plugin__plugin-kafka__1_6_0.jar")
+	if err := os.WriteFile(jarPath, []byte("corrupted-data"), 0o644); err != nil {
+		t.Fatalf("failed to create corrupted JAR: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if strings.Contains(output, "already up to date") {
+		t.Errorf("did not expect 'already up to date' for corrupted JAR, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Downloaded 1") {
+		t.Errorf("expected 'Downloaded 1' after re-downloading corrupted JAR, got:\n%s", output)
+	}
+
+	// Verify the file was replaced with valid content.
+	content, err := os.ReadFile(jarPath)
+	if err != nil {
+		t.Fatalf("failed to read JAR after re-download: %v", err)
+	}
+	if string(content) != mockJARBody {
+		t.Errorf("expected JAR to contain mock body after re-download, got: %q", string(content))
+	}
+}
+
+func TestIsValidZIP(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	validPath := filepath.Join(tmpDir, "valid.jar")
+	if err := os.WriteFile(validPath, []byte("PK\x03\x04extra"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if !isValidZIP(validPath) {
+		t.Error("expected isValidZIP to return true for valid ZIP magic bytes")
+	}
+
+	invalidPath := filepath.Join(tmpDir, "invalid.jar")
+	if err := os.WriteFile(invalidPath, []byte("not-a-zip"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	if isValidZIP(invalidPath) {
+		t.Error("expected isValidZIP to return false for non-ZIP content")
+	}
+}
+
+func TestLocalFileSHA1(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.jar")
+	content := []byte("hello")
+	if err := os.WriteFile(path, content, 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	h := sha1.New() //nolint:gosec
+	h.Write(content)
+	want := fmt.Sprintf("%x", h.Sum(nil))
+
+	got, err := localFileSHA1(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("localFileSHA1 = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- Before downloading a plugin JAR, `plugins download` now checks whether the file already exists and compares its SHA-1 against the `.sha1` sidecar file published by Maven Central alongside every artifact
- If checksums match → skip with "already up to date" message
- If checksums mismatch (corrupted/truncated file) → remove and re-download
- If the `.sha1` endpoint is unreachable (network blip) → fall back to ZIP magic-byte (`PK\x03\x04`) validation; skip if valid
- New `--force-redownload` flag bypasses all checks and always downloads fresh

## Test plan

- [ ] `TestRunPluginsInstall_SkipsExistingValidJAR` — SHA-1 match → skip
- [ ] `TestRunPluginsInstall_ForceRedownloadsExistingJAR` — `--force-redownload` bypasses check
- [ ] `TestRunPluginsInstall_RedownloadsCorruptedJAR` — SHA-1 mismatch → re-download and replace
- [ ] `TestIsValidZIP` — magic-byte fallback helper
- [ ] `TestLocalFileSHA1` — local SHA-1 computation helper
- [ ] `TestPluginsDownloadCommand_Flags` — `--force-redownload` flag registered
- [ ] Manual smoke test: run `kestractl plugins download 1.3.9` twice; second run should report all plugins as "already up to date"