### PR TITLE
feat(plugins): add --edition flag to filter plugins by OSS or EE

### DIFF
--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -16,7 +16,7 @@ import (
 
 // pluginsAPIBase and pluginsMavenBase are vars so tests can point them at a local httptest server.
 var (
-	pluginsAPIBase  = "https://api.kestra.io/v1/plugins/artifacts/core-compatibility"
+	pluginsAPIBase   = "https://api.kestra.io/v1/plugins/artifacts/core-compatibility"
 	pluginsMavenBase = "https://repo1.maven.org/maven2"
 )
 
@@ -52,13 +52,18 @@ func newPluginsDownloadCommand() *cobra.Command {
 	var pluginsDir string
 	var concurrency int
 	var forceRedownload bool
+	var edition string
 
 	cmd := &cobra.Command{
 		Use:   "download <version>",
 		Short: "Download all plugins for a given Kestra version from Maven Central",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency, forceRedownload)
+			license, err := editionToLicense(edition)
+			if err != nil {
+				return err
+			}
+			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency, forceRedownload, license)
 		},
 		Annotations: map[string]string{AnnotationOffline: "true"},
 	}
@@ -66,7 +71,23 @@ func newPluginsDownloadCommand() *cobra.Command {
 	cmd.Flags().StringVar(&pluginsDir, "plugins-dir", "./plugins", "Directory to write downloaded JARs into")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of parallel downloads")
 	cmd.Flags().BoolVar(&forceRedownload, "force-redownload", false, "Re-download plugins even if they already exist and pass checksum verification")
+	cmd.Flags().StringVar(&edition, "edition", "ALL", "Edition to download: ALL, OSS (open-source only), or EE (enterprise only)")
 	return cmd
+}
+
+// editionToLicense maps the user-facing --edition value to the API license query param.
+// Returns an empty string for ALL (no filtering).
+func editionToLicense(edition string) (string, error) {
+	switch strings.ToUpper(edition) {
+	case "ALL":
+		return "", nil
+	case "OSS":
+		return "OPEN_SOURCE", nil
+	case "EE":
+		return "ENTERPRISE", nil
+	default:
+		return "", fmt.Errorf("invalid --edition %q: must be ALL, OSS, or EE", edition)
+	}
 }
 
 // resolveVersion maps symbolic version aliases to their concrete equivalents.
@@ -79,11 +100,11 @@ func resolveVersion(version string) string {
 	}
 }
 
-func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool) error {
+func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool, license string) error {
 	kestraVersion = resolveVersion(kestraVersion)
 	fmt.Fprintf(out, "Fetching plugin list for Kestra %s...\n", kestraVersion)
 
-	plugins, err := fetchPluginList(kestraVersion)
+	plugins, err := fetchPluginList(kestraVersion, license)
 	if err != nil {
 		return err
 	}
@@ -154,8 +175,11 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 	return nil
 }
 
-func fetchPluginList(kestraVersion string) ([]pluginArtifact, error) {
+func fetchPluginList(kestraVersion string, license string) ([]pluginArtifact, error) {
 	url := fmt.Sprintf("%s/%s/latest", pluginsAPIBase, kestraVersion)
+	if license != "" {
+		url += "?license=" + license
+	}
 
 	resp, err := http.Get(url) //nolint:gosec // URL is constructed from validated version arg
 	if err != nil {

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -95,7 +95,7 @@ func TestRunPluginsInstall_HappyPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false)
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestRunPluginsInstall_ConcurrentDownloads(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false)
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false, "")
 	if err != nil {
 		t.Fatalf("unexpected error with concurrency=4: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestRunPluginsInstall_APINotFound(t *testing.T) {
 	newMockServers(t, http.StatusNotFound, `{"message":"version not found"}`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false)
+	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false, "")
 	if err == nil {
 		t.Fatal("expected error for HTTP 404, got nil")
 	}
@@ -169,7 +169,7 @@ func TestRunPluginsInstall_APIInvalidJSON(t *testing.T) {
 	newMockServers(t, http.StatusOK, `not-json`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "")
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
@@ -200,7 +200,7 @@ func TestRunPluginsInstall_MavenDownloadFailure(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "")
 	if err == nil {
 		t.Fatal("expected error when Maven returns 404, got nil")
 	}
@@ -281,7 +281,7 @@ func TestMavenJARURL(t *testing.T) {
 func TestPluginsDownloadCommand_Flags(t *testing.T) {
 	cmd := newPluginsDownloadCommand()
 
-	for _, flag := range []string{"plugins-dir", "concurrency", "force-redownload"} {
+	for _, flag := range []string{"plugins-dir", "concurrency", "force-redownload", "edition"} {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("expected flag --%s to exist", flag)
 		}
@@ -334,7 +334,7 @@ func TestRunPluginsInstall_SkipsExistingValidJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -362,7 +362,7 @@ func TestRunPluginsInstall_ForceRedownloadsExistingJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -387,7 +387,7 @@ func TestRunPluginsInstall_RedownloadsCorruptedJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -447,5 +447,114 @@ func TestLocalFileSHA1(t *testing.T) {
 	}
 	if got != want {
 		t.Errorf("localFileSHA1 = %q, want %q", got, want)
+	}
+}
+
+func TestEditionToLicense(t *testing.T) {
+	tests := []struct {
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{"ALL", "", false},
+		{"all", "", false},
+		{"OSS", "OPEN_SOURCE", false},
+		{"oss", "OPEN_SOURCE", false},
+		{"EE", "ENTERPRISE", false},
+		{"ee", "ENTERPRISE", false},
+		{"INVALID", "", true},
+		{"CE", "", true},
+	}
+	for _, tt := range tests {
+		got, err := editionToLicense(tt.input)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("editionToLicense(%q): expected error, got nil", tt.input)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("editionToLicense(%q): unexpected error: %v", tt.input, err)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("editionToLicense(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFetchPluginList_LicenseQueryParam(t *testing.T) {
+	var capturedQuery string
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `[]`)
+	}))
+	t.Cleanup(apiServer.Close)
+
+	orig := pluginsAPIBase
+	pluginsAPIBase = apiServer.URL
+	t.Cleanup(func() { pluginsAPIBase = orig })
+
+	tests := []struct {
+		license   string
+		wantQuery string
+	}{
+		{"", ""},
+		{"OPEN_SOURCE", "license=OPEN_SOURCE"},
+		{"ENTERPRISE", "license=ENTERPRISE"},
+	}
+	for _, tt := range tests {
+		capturedQuery = ""
+		if _, err := fetchPluginList("1.3.9", tt.license); err != nil {
+			t.Fatalf("fetchPluginList(%q): unexpected error: %v", tt.license, err)
+		}
+		if capturedQuery != tt.wantQuery {
+			t.Errorf("fetchPluginList license=%q: query = %q, want %q", tt.license, capturedQuery, tt.wantQuery)
+		}
+	}
+}
+
+func TestRunPluginsInstall_EditionOSS(t *testing.T) {
+	// API returns only OSS plugins (simulating a ?license=OPEN_SOURCE filtered response).
+	ossPayload := `[
+	  {"groupId":"io.kestra.plugin","artifactId":"plugin-kafka","license":"OPEN_SOURCE","version":"1.6.0"},
+	  {"groupId":"io.kestra.plugin","artifactId":"plugin-docker","license":"OPEN_SOURCE","version":"1.3.0"}
+	]`
+	newMockServers(t, http.StatusOK, ossPayload)
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "OPEN_SOURCE"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Found 2 plugins") {
+		t.Errorf("expected 'Found 2 plugins' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Downloaded 2") {
+		t.Errorf("expected 'Downloaded 2' in output, got:\n%s", output)
+	}
+}
+
+func TestRunPluginsInstall_EditionEE(t *testing.T) {
+	// API returns only EE plugins (simulating a ?license=ENTERPRISE filtered response).
+	eePayload := `[
+	  {"groupId":"io.kestra.plugin.ee","artifactId":"plugin-ee-core","license":"ENTERPRISE","version":"1.3.9"}
+	]`
+	newMockServers(t, http.StatusOK, eePayload)
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "ENTERPRISE"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Found 1 plugins") {
+		t.Errorf("expected 'Found 1 plugins' in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Downloaded 1") {
+		t.Errorf("expected 'Downloaded 1' in output, got:\n%s", output)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `--edition` flag to `plugins download` (default: `ALL`)
- Passes `?license=OPEN_SOURCE` or `?license=ENTERPRISE` to the compatibility API when `OSS` or `EE` is specified, respectively
- Flag values are case-insensitive; any other value returns a clear error
- No behaviour change when `--edition ALL` (or the flag is omitted)

## Usage

```sh
kestractl plugins download 1.3.9 --edition OSS   # open-source plugins only
kestractl plugins download 1.3.9 --edition EE    # enterprise plugins only
kestractl plugins download 1.3.9                 # all plugins (default)
```

## Test plan

- [ ] `TestEditionToLicense` — maps ALL/OSS/EE (case-insensitive) and rejects invalid values
- [ ] `TestFetchPluginList_LicenseQueryParam` — verifies the correct `?license=` query param is sent (or omitted for ALL)
- [ ] `TestRunPluginsInstall_EditionOSS` — end-to-end with an OSS-filtered plugin list
- [ ] `TestRunPluginsInstall_EditionEE` — end-to-end with an EE-filtered plugin list
- [ ] `TestPluginsDownloadCommand_Flags` — `--edition` flag is registered
- [ ] Manual: `kestractl plugins download 1.3.9 --edition EE` should only download enterprise plugins