### PR TITLE
feat(iam): manage invitations and bindings via CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kestra-io/kestractl
 go 1.25
 
 require (
-	github.com/kestra-io/client-sdk/go-sdk v1.0.0
+	github.com/kestra-io/client-sdk/go-sdk v1.1.0
 	github.com/posthog/posthog-go v1.10.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/kestra-io/client-sdk/go-sdk v1.0.0 h1:/sjrI3oeIhNInkViwE4+sw95S+mETg5Myr2JiQsOzNA=
-github.com/kestra-io/client-sdk/go-sdk v1.0.0/go.mod h1:LnykElq2sqYgAn7ar6uCa9w3nTOB99+bWwFZDdvz14E=
+github.com/kestra-io/client-sdk/go-sdk v1.1.0 h1:fgSd9U6bxZq1kRy+erAGky+nhws+PzJjQhCVQQbcQVI=
+github.com/kestra-io/client-sdk/go-sdk v1.1.0/go.mod h1:6oIOWghMHfNXWJcs/HA9qr6oMagBFBHoVrhPsdBEep4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/src/cli/bindings.go
+++ b/src/cli/bindings.go
@@ -1,0 +1,321 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/spf13/cobra"
+)
+
+func newBindingsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "bindings",
+		Short: "Manage IAM role bindings (list, get, create, delete)",
+		Long: `Manage role bindings in your Kestra instance.
+
+A binding assigns a role to a user or group, optionally scoped to a namespace.
+Bindings are tenant-scoped resources. Managing bindings requires Kestra
+Enterprise Edition.`,
+	}
+
+	cmd.AddCommand(newBindingsListCommand())
+	cmd.AddCommand(newBindingsGetCommand())
+	cmd.AddCommand(newBindingsCreateCommand())
+	cmd.AddCommand(newBindingsDeleteCommand())
+
+	return cmd
+}
+
+func newBindingsListCommand() *cobra.Command {
+	var (
+		bindingType string
+		externalID  string
+		namespace   string
+		page        int
+		size        int
+		sort        []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List bindings.",
+		Long:  "List all role bindings in the active tenant, optionally filtered by --type, --external-id or --namespace.",
+		Example: `  # List all bindings
+  kestractl bindings list
+
+  # List bindings of a group
+  kestractl bindings list --type GROUP --external-id group_id
+
+  # List bindings scoped to a namespace
+  kestractl bindings list --namespace company.team
+
+  # List bindings as JSON
+  kestractl bindings list --output json`,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runBindingsList(client, bindingType, externalID, namespace, page, size, sort, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&bindingType, "type", "", "Filter bindings by subject type (USER or GROUP)")
+	cmd.Flags().StringVar(&externalID, "external-id", "", "Filter bindings by the bound user/group ID")
+	cmd.Flags().StringVar(&namespace, "namespace", "", "Filter bindings by namespace")
+	cmd.Flags().IntVar(&page, "page", 1, "Page number")
+	cmd.Flags().IntVar(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (repeatable)")
+
+	return cmd
+}
+
+func runBindingsList(client *Client, bindingType, externalID, namespace string, page, size int, sort []string, renderer *Renderer) error {
+	typeFilter, err := parseBindingType(bindingType)
+	if err != nil {
+		return err
+	}
+
+	var externalIDFilter, namespaceFilter *string
+	if externalID != "" {
+		externalIDFilter = &externalID
+	}
+	if namespace != "" {
+		namespaceFilter = &namespace
+	}
+
+	resp, err := client.Kestra.Bindings().SearchBindings(
+		client.Ctx, client.Tenant, &page, &size, sort, typeFilter, externalIDFilter, namespaceFilter, nil)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	results := resp.Results
+	if results == nil {
+		// Render an empty JSON array ([]) rather than null on no results.
+		results = []kestra.IAMBindingControllerApiBindingDetail{}
+	}
+
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ID\tTYPE\tSUBJECT\tROLE\tNAMESPACE")
+		for _, b := range results {
+			role := ""
+			if b.Role != nil {
+				role = b.Role.GetName()
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				b.GetId(), b.GetType(), bindingSubject(b), role, b.GetNamespace())
+		}
+		fmt.Fprintf(w, "\nTotal bindings: %d\n", resp.Total)
+		return nil
+	})
+}
+
+// bindingSubject renders the bound principal: the user's username or the
+// group's name, depending on the binding type.
+func bindingSubject(b kestra.IAMBindingControllerApiBindingDetail) string {
+	if user, ok := b.GetUserOk(); ok && user != nil {
+		return user.GetUsername()
+	}
+	if group, ok := b.GetGroupOk(); ok && group != nil {
+		return group.GetName()
+	}
+	return ""
+}
+
+func newBindingsGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "get <binding_id>",
+		Short:   "Get binding details.",
+		Long:    "Retrieve detailed information about a specific role binding.",
+		Aliases: []string{"show", "describe"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runBindingsGet(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runBindingsGet(client *Client, id string, renderer *Renderer) error {
+	binding, err := client.Kestra.Bindings().Binding(client.Ctx, id, client.Tenant)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderBindingDetail(binding, renderer)
+}
+
+func renderBindingDetail(b *kestra.IAMBindingControllerApiBindingDetail, renderer *Renderer) error {
+	return renderer.Render(b, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "Binding Details")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ID:\t%s\n", b.GetId())
+		fmt.Fprintf(w, "Type:\t%s\n", b.GetType())
+		fmt.Fprintf(w, "Subject:\t%s\n", bindingSubject(*b))
+		if b.Role != nil {
+			fmt.Fprintf(w, "Role:\t%s (%s)\n", b.Role.GetName(), b.Role.GetId())
+		}
+		if ns := b.GetNamespace(); ns != "" {
+			fmt.Fprintf(w, "Namespace:\t%s\n", ns)
+		}
+		if user, ok := b.GetUserOk(); ok && user != nil {
+			fmt.Fprintf(w, "User ID:\t%s\n", user.GetId())
+			if dn := user.GetDisplayName(); dn != "" {
+				fmt.Fprintf(w, "Display name:\t%s\n", dn)
+			}
+		}
+		if group, ok := b.GetGroupOk(); ok && group != nil {
+			fmt.Fprintf(w, "Group ID:\t%s\n", group.GetId())
+		}
+		return nil
+	})
+}
+
+func newBindingsCreateCommand() *cobra.Command {
+	var (
+		bindingType string
+		externalID  string
+		roleID      string
+		namespace   string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a binding.",
+		Long: `Create a role binding, assigning a role to a user or group.
+
+Pass --namespace to scope the binding to a namespace; otherwise it applies
+tenant-wide.`,
+		Example: `  # Assign a role to a user tenant-wide
+  kestractl bindings create --type USER --external-id user_id --role role_id
+
+  # Assign a role to a group within a namespace
+  kestractl bindings create --type GROUP --external-id group_id --role role_id \
+    --namespace company.team`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runBindingsCreate(client, bindingType, externalID, roleID, namespace, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&bindingType, "type", "", "Subject type (USER or GROUP)")
+	cmd.Flags().StringVar(&externalID, "external-id", "", "ID of the user or group to bind")
+	cmd.Flags().StringVar(&roleID, "role", "", "Role ID to assign")
+	cmd.Flags().StringVar(&namespace, "namespace", "", "Namespace to scope the binding to (optional)")
+	_ = cmd.MarkFlagRequired("type")
+	_ = cmd.MarkFlagRequired("external-id")
+	_ = cmd.MarkFlagRequired("role")
+
+	return cmd
+}
+
+func runBindingsCreate(client *Client, bindingType, externalID, roleID, namespace string, renderer *Renderer) error {
+	typeValue, err := parseBindingType(bindingType)
+	if err != nil {
+		return err
+	}
+
+	req := kestra.IAMBindingControllerApiCreateBindingRequest{
+		Type:       *typeValue,
+		ExternalId: externalID,
+		RoleId:     roleID,
+	}
+	if namespace != "" {
+		req.NamespaceId = *kestra.NewNullableString(&namespace)
+	}
+
+	binding, err := client.Kestra.Bindings().CreateBinding(client.Ctx, client.Tenant, req)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderBindingDetail(binding, renderer)
+}
+
+func newBindingsDeleteCommand() *cobra.Command {
+	var skipConfirm bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <binding_id>",
+		Short:   "Delete a binding.",
+		Long:    "Delete a role binding. Prompts for confirmation unless --yes is provided.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runBindingsDelete(client, args[0], skipConfirm, cmd.InOrStdin(), renderer)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation prompt")
+
+	return cmd
+}
+
+func runBindingsDelete(client *Client, id string, skipConfirm bool, in io.Reader, renderer *Renderer) error {
+	if !skipConfirm {
+		// Prompt on stderr so it never pollutes stdout (e.g. --output json).
+		confirmed, err := confirm(in, os.Stderr,
+			fmt.Sprintf("Are you sure you want to delete binding '%s'? [y/N]: ", id))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return renderStatus(renderer, "Cancelled.", map[string]any{"id": id, "status": "cancelled"})
+		}
+	}
+
+	if err := client.Kestra.Bindings().DeleteBinding(client.Ctx, id, client.Tenant); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("Binding '%s' deleted.", id),
+		map[string]any{"id": id, "status": "deleted"})
+}
+
+// parseBindingType validates an optional --type value against the SDK enum.
+// An empty input returns (nil, nil) so it can be passed straight to search.
+func parseBindingType(s string) (*kestra.BindingType, error) {
+	if s == "" {
+		return nil, nil
+	}
+	parsed, err := kestra.NewBindingTypeFromValue(strings.ToUpper(strings.TrimSpace(s)))
+	if err != nil {
+		values := make([]string, 0, len(kestra.AllowedBindingTypeEnumValues))
+		for _, v := range kestra.AllowedBindingTypeEnumValues {
+			values = append(values, string(v))
+		}
+		return nil, fmt.Errorf("invalid type %q: expected one of %s", s, strings.Join(values, ", "))
+	}
+	return parsed, nil
+}

--- a/src/cli/bindings.go
+++ b/src/cli/bindings.go
@@ -35,8 +35,8 @@ func newBindingsListCommand() *cobra.Command {
 		bindingType string
 		externalID  string
 		namespace   string
-		page        int
-		size        int
+		page        int32
+		size        int32
 		sort        []string
 	)
 
@@ -72,14 +72,14 @@ func newBindingsListCommand() *cobra.Command {
 	cmd.Flags().StringVar(&bindingType, "type", "", "Filter bindings by subject type (USER or GROUP)")
 	cmd.Flags().StringVar(&externalID, "external-id", "", "Filter bindings by the bound user/group ID")
 	cmd.Flags().StringVar(&namespace, "namespace", "", "Filter bindings by namespace")
-	cmd.Flags().IntVar(&page, "page", 1, "Page number")
-	cmd.Flags().IntVar(&size, "size", 100, "Page size")
-	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (repeatable)")
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (e.g. 'namespace:asc', repeatable)")
 
 	return cmd
 }
 
-func runBindingsList(client *Client, bindingType, externalID, namespace string, page, size int, sort []string, renderer *Renderer) error {
+func runBindingsList(client *Client, bindingType, externalID, namespace string, page, size int32, sort []string, renderer *Renderer) error {
 	typeFilter, err := parseBindingType(bindingType)
 	if err != nil {
 		return err
@@ -93,10 +93,15 @@ func runBindingsList(client *Client, bindingType, externalID, namespace string, 
 		namespaceFilter = &namespace
 	}
 
+	pageParam, sizeParam := int(page), int(size)
 	resp, err := client.Kestra.Bindings().SearchBindings(
-		client.Ctx, client.Tenant, &page, &size, sort, typeFilter, externalIDFilter, namespaceFilter, nil)
+		client.Ctx, client.Tenant, &pageParam, &sizeParam, sort, typeFilter, externalIDFilter, namespaceFilter, nil)
 	if err != nil {
 		return formatSDKError(err)
+	}
+	if resp == nil {
+		// The SDK returns (nil, nil) on a 2xx response with an empty body.
+		resp = &kestra.PagedResultsIAMBindingControllerApiBindingDetail{}
 	}
 
 	results := resp.Results
@@ -252,6 +257,11 @@ func runBindingsCreate(client *Client, bindingType, externalID, roleID, namespac
 	if err != nil {
 		return formatSDKError(err)
 	}
+	if binding == nil {
+		// The SDK returns (nil, nil) on a 2xx response with an empty body.
+		return renderStatus(renderer, "Binding created.",
+			map[string]any{"externalId": externalID, "roleId": roleID, "status": "created"})
+	}
 	return renderBindingDetail(binding, renderer)
 }
 
@@ -311,11 +321,8 @@ func parseBindingType(s string) (*kestra.BindingType, error) {
 	}
 	parsed, err := kestra.NewBindingTypeFromValue(strings.ToUpper(strings.TrimSpace(s)))
 	if err != nil {
-		values := make([]string, 0, len(kestra.AllowedBindingTypeEnumValues))
-		for _, v := range kestra.AllowedBindingTypeEnumValues {
-			values = append(values, string(v))
-		}
-		return nil, fmt.Errorf("invalid type %q: expected one of %s", s, strings.Join(values, ", "))
+		return nil, fmt.Errorf("invalid type %q: expected one of %s",
+			s, joinEnumValues(kestra.AllowedBindingTypeEnumValues))
 	}
 	return parsed, nil
 }

--- a/src/cli/bindings_test.go
+++ b/src/cli/bindings_test.go
@@ -1,0 +1,243 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestBindingsCommand_Structure(t *testing.T) {
+	cmd := newBindingsCommand()
+	if cmd.Use != "bindings" {
+		t.Fatalf("expected use 'bindings', got %q", cmd.Use)
+	}
+
+	want := map[string]bool{
+		"list": false, "get": false, "create": false, "delete": false,
+	}
+	for _, sub := range cmd.Commands() {
+		name := strings.Fields(sub.Use)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestBindingsCreateCommand_RequiredFlags(t *testing.T) {
+	cmd := newBindingsCreateCommand()
+	for _, flag := range []string{"type", "external-id", "role", "namespace"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Fatalf("expected --%s flag", flag)
+		}
+	}
+	// type, external-id and role are marked required
+	if _, err := executeCommand(cmd); err == nil {
+		t.Fatal("expected error when required flags are missing")
+	}
+}
+
+func TestBindingsDeleteCommand_HasYesFlag(t *testing.T) {
+	cmd := newBindingsDeleteCommand()
+	f := cmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("expected --yes flag")
+	}
+	if f.Shorthand != "y" {
+		t.Fatalf("expected -y shorthand, got %q", f.Shorthand)
+	}
+}
+
+func TestParseBindingType(t *testing.T) {
+	if v, err := parseBindingType(""); err != nil || v != nil {
+		t.Fatalf("expected nil,nil for empty input, got %v, %v", v, err)
+	}
+	if v, err := parseBindingType("group"); err != nil || string(*v) != "GROUP" {
+		t.Fatalf("expected GROUP for lowercase input, got %v, %v", v, err)
+	}
+	if _, err := parseBindingType("BOGUS"); err == nil || !strings.Contains(err.Error(), "USER") {
+		t.Fatalf("expected error listing allowed values, got %v", err)
+	}
+}
+
+func TestRunBindingsList(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"b1","type":"USER","role":{"id":"r1","name":"admin"},
+			 "user":{"id":"u1","username":"jane"},"namespace":"company.team"},
+			{"id":"b2","type":"GROUP","role":{"id":"r2","name":"editor"},
+			 "group":{"id":"g1","name":"devs"}}
+		],"total":2}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBindingsList(newTestClient(t, server.URL), "user", "u1", "company.team", 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBindingsList error: %v", err)
+	}
+
+	for _, want := range []string{"type=USER", "id=u1", "namespace=company.team"} {
+		if !strings.Contains(gotQuery, want) {
+			t.Errorf("expected %q in query, got %q", want, gotQuery)
+		}
+	}
+	out := buf.String()
+	for _, want := range []string{"jane", "devs", "admin", "editor", "company.team", "Total bindings: 2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunBindingsList_InvalidType(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBindingsList(newTestClient(t, server.URL), "BOGUS", "", "", 1, 100, nil, newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected error for invalid type")
+	}
+	if hit {
+		t.Error("expected no API request for invalid type")
+	}
+}
+
+func TestRunBindingsGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"b1","type":"USER","namespace":"company.team",
+			"role":{"id":"r1","name":"admin"},
+			"user":{"id":"u1","username":"jane","displayName":"Jane Doe"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBindingsGet(newTestClient(t, server.URL), "b1", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBindingsGet error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"b1", "USER", "jane", "admin (r1)", "company.team", "Jane Doe"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunBindingsCreate_SendsBody(t *testing.T) {
+	var gotBody map[string]any
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"new","type":"GROUP","role":{"id":"r1","name":"editor"},
+			"group":{"id":"g1","name":"devs"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBindingsCreate(newTestClient(t, server.URL), "group", "g1", "r1", "company.team", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBindingsCreate error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotBody["type"] != "GROUP" {
+		t.Errorf("expected type GROUP in body, got %v", gotBody["type"])
+	}
+	if gotBody["externalId"] != "g1" {
+		t.Errorf("expected externalId in body, got %v", gotBody["externalId"])
+	}
+	if gotBody["roleId"] != "r1" {
+		t.Errorf("expected roleId in body, got %v", gotBody["roleId"])
+	}
+	if gotBody["namespaceId"] != "company.team" {
+		t.Errorf("expected namespaceId in body, got %v", gotBody["namespaceId"])
+	}
+	if !strings.Contains(buf.String(), "devs") {
+		t.Errorf("expected binding detail output, got:\n%s", buf.String())
+	}
+}
+
+func TestRunBindingsCreate_OmitsNamespaceWhenUnset(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"new","type":"USER"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBindingsCreate(newTestClient(t, server.URL), "USER", "u1", "r1", "", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBindingsCreate error: %v", err)
+	}
+	if _, present := gotBody["namespaceId"]; present {
+		t.Errorf("expected namespaceId omitted, got %v", gotBody["namespaceId"])
+	}
+}
+
+func TestRunBindingsDelete_Confirmed(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBindingsDelete(newTestClient(t, server.URL), "b1", false, strings.NewReader("y\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBindingsDelete error: %v", err)
+	}
+	if !hit {
+		t.Error("expected API request when deletion is confirmed")
+	}
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Errorf("expected deletion message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunBindingsDelete_CancelMakesNoRequest(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBindingsDelete(newTestClient(t, server.URL), "b1", false, strings.NewReader("n\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBindingsDelete error: %v", err)
+	}
+	if hit {
+		t.Error("expected no API request when deletion is cancelled")
+	}
+	if !strings.Contains(buf.String(), "Cancelled") {
+		t.Errorf("expected cancellation message, got:\n%s", buf.String())
+	}
+}

--- a/src/cli/bindings_test.go
+++ b/src/cli/bindings_test.go
@@ -100,6 +100,38 @@ func TestRunBindingsList(t *testing.T) {
 	}
 }
 
+func TestRunBindingsList_EmptyBodyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBindingsList(newTestClient(t, server.URL), "", "", "", 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("expected empty list on empty-body response, got error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Total bindings: 0") {
+		t.Errorf("expected empty list output, got:\n%s", buf.String())
+	}
+}
+
+func TestRunBindingsCreate_EmptyBodyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBindingsCreate(newTestClient(t, server.URL), "USER", "u1", "r1", "", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("expected status message on empty-body response, got error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Binding created") {
+		t.Errorf("expected creation message, got:\n%s", buf.String())
+	}
+}
+
 func TestRunBindingsList_InvalidType(t *testing.T) {
 	hit := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -12,8 +13,14 @@ import (
 )
 
 // Client wraps the Kestra SDK with authentication and tenant info.
+//
+// API is the generated-style client (request builders + Execute). Kestra is the
+// SDK's hand-written client, which exposes endpoints the generated surface does
+// not (e.g. invitations, bindings). Both are built from the same resolved
+// config, so they share host, auth, and headers.
 type Client struct {
 	API    *kestra.APIClient
+	Kestra *kestra.KestraClient
 	Ctx    context.Context
 	Tenant string
 }
@@ -70,20 +77,30 @@ func newClientDefault() (*Client, error) {
 
 	client := kestra.NewAPIClient(cfg)
 
+	// The hand-written client shares the same resolved host, headers, and debug
+	// setting; auth is appended per-branch below.
+	opts := []kestra.ClientOption{kestra.WithDebug(isVerbose)}
+	if len(parsed) > 0 {
+		opts = append(opts, kestra.WithHeaders(parsed))
+	}
+
 	ctx := context.Background()
 	if token != "" {
 		ctx = context.WithValue(ctx, kestra.ContextAccessToken, token)
+		opts = append(opts, kestra.WithTokenAuth(token))
 	} else if username != "" && password != "" {
 		ctx = context.WithValue(ctx, kestra.ContextBasicAuth, kestra.BasicAuth{
 			UserName: username,
 			Password: password,
 		})
+		opts = append(opts, kestra.WithBasicAuth(username, password))
 	} else {
 		return nil, fmt.Errorf("could not init client without any auth, at least token or username+password is required")
 	}
 
 	return &Client{
 		API:    client,
+		Kestra: kestra.NewClient(host, opts...),
 		Ctx:    ctx,
 		Tenant: tenant,
 	}, nil
@@ -138,46 +155,53 @@ func normalizeHost(host string) string {
 	return normalized
 }
 
-// formatSDKError extracts a user-friendly message from SDK errors.
+// formatSDKError extracts a user-friendly message from SDK errors. It handles
+// both SDK error types: GenericOpenAPIError from the generated client and
+// ApiError from the hand-written client.
 func formatSDKError(err error) error {
 	if sdkErr, ok := err.(*kestra.GenericOpenAPIError); ok {
-		body := sdkErr.Body()
-
-		// Try to parse as JSON first
-		if len(body) > 0 {
-			var jsonErr map[string]any
-			if json.Unmarshal(body, &jsonErr) == nil {
-				// Extract message from JSON response
-				if msg, ok := jsonErr["message"].(string); ok && msg != "" {
-					return fmt.Errorf("API error: %s", msg)
-				}
-				if msg, ok := jsonErr["error"].(string); ok && msg != "" {
-					return fmt.Errorf("API error: %s", msg)
-				}
-			}
-		}
-
-		bodyStr := string(body)
-
-		// Check if response is HTML (common for 404s, auth errors, etc.)
-		isHTML := len(bodyStr) > 0 && bodyStr[0] == '<'
-		if isHTML {
-			// Extract HTTP status from error message if available
-			errMsg := sdkErr.Error()
-			if errMsg != "" {
-				return fmt.Errorf("API request failed: %s (received HTML response instead of JSON)", errMsg)
-			}
-			return fmt.Errorf("API request failed: received HTML response instead of JSON. Check your host URL and authentication")
-		}
-
-		// For non-HTML/non-JSON responses, show the error message
-		if errMsg := sdkErr.Error(); errMsg != "" {
-			return fmt.Errorf("API error: %s", errMsg)
-		}
-
-		return fmt.Errorf("API error: unknown error")
+		return formatErrorBody(sdkErr.Body(), sdkErr.Error())
+	}
+	var apiErr *kestra.ApiError
+	if errors.As(err, &apiErr) {
+		return formatErrorBody(apiErr.Body, apiErr.Error())
 	}
 	return err
+}
+
+// formatErrorBody builds a user-friendly error from a raw API response body,
+// falling back to errMsg when the body carries no usable message.
+func formatErrorBody(body []byte, errMsg string) error {
+	// Try to parse as JSON first
+	if len(body) > 0 {
+		var jsonErr map[string]any
+		if json.Unmarshal(body, &jsonErr) == nil {
+			// Extract message from JSON response
+			if msg, ok := jsonErr["message"].(string); ok && msg != "" {
+				return fmt.Errorf("API error: %s", msg)
+			}
+			if msg, ok := jsonErr["error"].(string); ok && msg != "" {
+				return fmt.Errorf("API error: %s", msg)
+			}
+		}
+	}
+
+	// Check if response is HTML (common for 404s, auth errors, etc.)
+	isHTML := len(body) > 0 && body[0] == '<'
+	if isHTML {
+		// Extract HTTP status from error message if available
+		if errMsg != "" {
+			return fmt.Errorf("API request failed: %s (received HTML response instead of JSON)", errMsg)
+		}
+		return fmt.Errorf("API request failed: received HTML response instead of JSON. Check your host URL and authentication")
+	}
+
+	// For non-HTML/non-JSON responses, show the error message
+	if errMsg != "" {
+		return fmt.Errorf("API error: %s", errMsg)
+	}
+
+	return fmt.Errorf("API error: unknown error")
 }
 
 // tryParseExecutionFromError handles known SDK type mismatch bugs.

--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -159,12 +159,21 @@ func normalizeHost(host string) string {
 // both SDK error types: GenericOpenAPIError from the generated client and
 // ApiError from the hand-written client.
 func formatSDKError(err error) error {
-	if sdkErr, ok := err.(*kestra.GenericOpenAPIError); ok {
+	var sdkErr *kestra.GenericOpenAPIError
+	if errors.As(err, &sdkErr) {
 		return formatErrorBody(sdkErr.Body(), sdkErr.Error())
 	}
 	var apiErr *kestra.ApiError
 	if errors.As(err, &apiErr) {
-		return formatErrorBody(apiErr.Body, apiErr.Error())
+		// Don't use apiErr.Error() as the fallback message: it already embeds
+		// an "API error <code>:" prefix and the raw body, which would leak
+		// back into every formatErrorBody branch (double prefix, full HTML
+		// pages in the hint). Build a short status-based message instead.
+		errMsg := apiErr.Message
+		if errMsg == "" {
+			errMsg = fmt.Sprintf("status %d", apiErr.StatusCode)
+		}
+		return formatErrorBody(apiErr.Body, errMsg)
 	}
 	return err
 }

--- a/src/cli/client_test.go
+++ b/src/cli/client_test.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -57,6 +59,43 @@ func TestTryParseNamespaceListFromError(t *testing.T) {
 	if items[1].ID != "team.beta" || !items[1].Deleted {
 		t.Fatalf("unexpected second item: %+v", items[1])
 	}
+}
+
+func TestFormatSDKError_ApiError(t *testing.T) {
+	t.Run("json message body", func(t *testing.T) {
+		err := formatSDKError(&kestra.ApiError{
+			StatusCode: 404,
+			Body:       []byte(`{"message":"role not found"}`),
+		})
+		if err == nil || err.Error() != "API error: role not found" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("html body", func(t *testing.T) {
+		err := formatSDKError(&kestra.ApiError{
+			StatusCode: 404,
+			Body:       []byte("<html><body>Not Found</body></html>"),
+			Message:    "Not Found",
+		})
+		if err == nil || !strings.Contains(err.Error(), "HTML response") {
+			t.Fatalf("expected HTML hint, got: %v", err)
+		}
+	})
+
+	t.Run("falls back to message", func(t *testing.T) {
+		err := formatSDKError(&kestra.ApiError{StatusCode: 500, Message: "boom"})
+		if err == nil || !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("expected fallback message, got: %v", err)
+		}
+	})
+
+	t.Run("unrelated error passes through", func(t *testing.T) {
+		orig := errors.New("plain")
+		if got := formatSDKError(orig); got != orig {
+			t.Fatalf("expected passthrough, got: %v", got)
+		}
+	})
 }
 
 func TestParseHeaders(t *testing.T) {

--- a/src/cli/client_test.go
+++ b/src/cli/client_test.go
@@ -90,6 +90,36 @@ func TestFormatSDKError_ApiError(t *testing.T) {
 		}
 	})
 
+	t.Run("plain text body has no double prefix", func(t *testing.T) {
+		err := formatSDKError(&kestra.ApiError{
+			StatusCode: 403,
+			Body:       []byte("Forbidden"),
+		})
+		if err == nil || err.Error() != "API error: status 403" {
+			t.Fatalf("expected 'API error: status 403', got: %v", err)
+		}
+	})
+
+	t.Run("empty body and message uses status code", func(t *testing.T) {
+		err := formatSDKError(&kestra.ApiError{StatusCode: 502})
+		if err == nil || err.Error() != "API error: status 502" {
+			t.Fatalf("expected 'API error: status 502', got: %v", err)
+		}
+	})
+
+	t.Run("html body does not leak the page into the hint", func(t *testing.T) {
+		err := formatSDKError(&kestra.ApiError{
+			StatusCode: 401,
+			Body:       []byte("<html><body>big page</body></html>"),
+		})
+		if err == nil || strings.Contains(err.Error(), "big page") {
+			t.Fatalf("expected HTML body to be omitted, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "HTML response") {
+			t.Fatalf("expected HTML hint, got: %v", err)
+		}
+	})
+
 	t.Run("unrelated error passes through", func(t *testing.T) {
 		orig := errors.New("plain")
 		if got := formatSDKError(orig); got != orig {

--- a/src/cli/invitations.go
+++ b/src/cli/invitations.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
-	"time"
 
 	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
 	"github.com/spf13/cobra"
@@ -34,8 +33,8 @@ func newInvitationsListCommand() *cobra.Command {
 	var (
 		email  string
 		status string
-		page   int
-		size   int
+		page   int32
+		size   int32
 		sort   []string
 	)
 
@@ -70,21 +69,17 @@ func newInvitationsListCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&email, "email", "", "Filter invitations by invitee email")
 	cmd.Flags().StringVar(&status, "status", "", "Filter invitations by status (PENDING, ACCEPTED or EXPIRED)")
-	cmd.Flags().IntVar(&page, "page", 1, "Page number")
-	cmd.Flags().IntVar(&size, "size", 100, "Page size")
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
 	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (e.g. 'sentAt:desc', repeatable)")
 
 	return cmd
 }
 
-func runInvitationsList(client *Client, email, status string, page, size int, sort []string, renderer *Renderer) error {
-	var statusFilter *kestra.InvitationInvitationStatus
-	if status != "" {
-		parsed, err := kestra.NewInvitationInvitationStatusFromValue(strings.ToUpper(strings.TrimSpace(status)))
-		if err != nil {
-			return fmt.Errorf("invalid status %q: expected one of %s", status, joinInvitationStatuses())
-		}
-		statusFilter = parsed
+func runInvitationsList(client *Client, email, status string, page, size int32, sort []string, renderer *Renderer) error {
+	statusFilter, err := parseInvitationStatus(status)
+	if err != nil {
+		return err
 	}
 
 	var emailFilter *string
@@ -92,10 +87,15 @@ func runInvitationsList(client *Client, email, status string, page, size int, so
 		emailFilter = &email
 	}
 
+	pageParam, sizeParam := int(page), int(size)
 	resp, err := client.Kestra.Invitations().SearchInvitations(
-		client.Ctx, client.Tenant, &page, &size, sort, emailFilter, statusFilter, nil)
+		client.Ctx, client.Tenant, &pageParam, &sizeParam, sort, emailFilter, statusFilter, nil)
 	if err != nil {
 		return formatSDKError(err)
+	}
+	if resp == nil {
+		// The SDK returns (nil, nil) on a 2xx response with an empty body.
+		resp = &kestra.PagedResultsIAMInvitationControllerApiInvitationDetail{}
 	}
 
 	results := resp.Results
@@ -109,7 +109,7 @@ func runInvitationsList(client *Client, email, status string, page, size int, so
 		for _, inv := range results {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%t\n",
 				inv.GetId(), inv.GetEmail(), inv.GetStatus(),
-				formatInvitationTime(inv.SentAt), formatInvitationTime(inv.ExpiredAt),
+				formatOptionalTime(inv.GetSentAt()), formatOptionalTime(inv.GetExpiredAt()),
 				inv.GetSuperAdmin())
 		}
 		fmt.Fprintf(w, "\nTotal invitations: %d\n", resp.Total)
@@ -155,9 +155,9 @@ func renderInvitationDetail(inv *kestra.IAMInvitationControllerApiInvitationDeta
 		fmt.Fprintf(w, "Email:\t%s\n", inv.GetEmail())
 		fmt.Fprintf(w, "Status:\t%s\n", inv.GetStatus())
 		fmt.Fprintf(w, "Tenant:\t%s\n", inv.GetTenantId())
-		fmt.Fprintf(w, "Sent at:\t%s\n", formatInvitationTime(inv.SentAt))
-		fmt.Fprintf(w, "Expired at:\t%s\n", formatInvitationTime(inv.ExpiredAt))
-		fmt.Fprintf(w, "Accepted at:\t%s\n", formatInvitationTime(inv.AcceptedAt))
+		fmt.Fprintf(w, "Sent at:\t%s\n", formatOptionalTime(inv.GetSentAt()))
+		fmt.Fprintf(w, "Expired at:\t%s\n", formatOptionalTime(inv.GetExpiredAt()))
+		fmt.Fprintf(w, "Accepted at:\t%s\n", formatOptionalTime(inv.GetAcceptedAt()))
 		fmt.Fprintf(w, "Superadmin:\t%t\n", inv.GetSuperAdmin())
 
 		if roles := inv.GetRoles(); len(roles) > 0 {
@@ -232,12 +232,9 @@ of sending an invitation.`,
 }
 
 func runInvitationsCreate(client *Client, email string, roles, groups []string, superAdmin, createUserIfNotExist bool, renderer *Renderer) error {
-	req := kestra.IAMInvitationControllerApiInvitationCreateRequest{Email: email}
+	req := kestra.IAMInvitationControllerApiInvitationCreateRequest{Email: email, Groups: groups}
 	for _, roleID := range roles {
 		req.Roles = append(req.Roles, kestra.IAMInvitationControllerApiInvitationRole{Id: roleID})
-	}
-	if len(groups) > 0 {
-		req.Groups = groups
 	}
 	if superAdmin {
 		req.SuperAdmin = &superAdmin
@@ -311,19 +308,17 @@ func runInvitationsDelete(client *Client, id string, skipConfirm bool, in io.Rea
 		map[string]any{"id": id, "status": "deleted"})
 }
 
-// formatInvitationTime renders an optional timestamp, blank when unset.
-func formatInvitationTime(t *time.Time) string {
-	if t == nil {
-		return ""
+// parseInvitationStatus validates an optional --status value against the SDK
+// enum. An empty input returns (nil, nil) so it can be passed straight to
+// search.
+func parseInvitationStatus(s string) (*kestra.InvitationInvitationStatus, error) {
+	if s == "" {
+		return nil, nil
 	}
-	return t.Format(time.RFC3339)
-}
-
-// joinInvitationStatuses lists the allowed --status values for error messages.
-func joinInvitationStatuses() string {
-	values := make([]string, 0, len(kestra.AllowedInvitationInvitationStatusEnumValues))
-	for _, v := range kestra.AllowedInvitationInvitationStatusEnumValues {
-		values = append(values, string(v))
+	parsed, err := kestra.NewInvitationInvitationStatusFromValue(strings.ToUpper(strings.TrimSpace(s)))
+	if err != nil {
+		return nil, fmt.Errorf("invalid status %q: expected one of %s",
+			s, joinEnumValues(kestra.AllowedInvitationInvitationStatusEnumValues))
 	}
-	return strings.Join(values, ", ")
+	return parsed, nil
 }

--- a/src/cli/invitations.go
+++ b/src/cli/invitations.go
@@ -1,0 +1,329 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/spf13/cobra"
+)
+
+func newInvitationsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "invitations",
+		Short: "Manage IAM invitations (list, get, create, delete)",
+		Long: `Manage user invitations in your Kestra instance.
+
+Invitations are tenant-scoped resources. Managing invitations requires Kestra
+Enterprise Edition.`,
+	}
+
+	cmd.AddCommand(newInvitationsListCommand())
+	cmd.AddCommand(newInvitationsGetCommand())
+	cmd.AddCommand(newInvitationsCreateCommand())
+	cmd.AddCommand(newInvitationsDeleteCommand())
+
+	return cmd
+}
+
+func newInvitationsListCommand() *cobra.Command {
+	var (
+		email  string
+		status string
+		page   int
+		size   int
+		sort   []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List invitations.",
+		Long:  "List all invitations in the active tenant, optionally filtered by --email or --status.",
+		Example: `  # List all invitations
+  kestractl invitations list
+
+  # List pending invitations only
+  kestractl invitations list --status PENDING
+
+  # List invitations sent to an address
+  kestractl invitations list --email jane@example.com
+
+  # List invitations as JSON
+  kestractl invitations list --output json`,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runInvitationsList(client, email, status, page, size, sort, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Filter invitations by invitee email")
+	cmd.Flags().StringVar(&status, "status", "", "Filter invitations by status (PENDING, ACCEPTED or EXPIRED)")
+	cmd.Flags().IntVar(&page, "page", 1, "Page number")
+	cmd.Flags().IntVar(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (e.g. 'sentAt:desc', repeatable)")
+
+	return cmd
+}
+
+func runInvitationsList(client *Client, email, status string, page, size int, sort []string, renderer *Renderer) error {
+	var statusFilter *kestra.InvitationInvitationStatus
+	if status != "" {
+		parsed, err := kestra.NewInvitationInvitationStatusFromValue(strings.ToUpper(strings.TrimSpace(status)))
+		if err != nil {
+			return fmt.Errorf("invalid status %q: expected one of %s", status, joinInvitationStatuses())
+		}
+		statusFilter = parsed
+	}
+
+	var emailFilter *string
+	if email != "" {
+		emailFilter = &email
+	}
+
+	resp, err := client.Kestra.Invitations().SearchInvitations(
+		client.Ctx, client.Tenant, &page, &size, sort, emailFilter, statusFilter, nil)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	results := resp.Results
+	if results == nil {
+		// Render an empty JSON array ([]) rather than null on no results.
+		results = []kestra.IAMInvitationControllerApiInvitationDetail{}
+	}
+
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ID\tEMAIL\tSTATUS\tSENT AT\tEXPIRED AT\tSUPERADMIN")
+		for _, inv := range results {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%t\n",
+				inv.GetId(), inv.GetEmail(), inv.GetStatus(),
+				formatInvitationTime(inv.SentAt), formatInvitationTime(inv.ExpiredAt),
+				inv.GetSuperAdmin())
+		}
+		fmt.Fprintf(w, "\nTotal invitations: %d\n", resp.Total)
+		return nil
+	})
+}
+
+func newInvitationsGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "get <invitation_id>",
+		Short:   "Get invitation details.",
+		Long:    "Retrieve detailed information about a specific invitation, including its status and assigned roles/groups.",
+		Aliases: []string{"show", "describe"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runInvitationsGet(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runInvitationsGet(client *Client, id string, renderer *Renderer) error {
+	inv, err := client.Kestra.Invitations().Invitation(client.Ctx, id, client.Tenant)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderInvitationDetail(inv, renderer)
+}
+
+func renderInvitationDetail(inv *kestra.IAMInvitationControllerApiInvitationDetail, renderer *Renderer) error {
+	return renderer.Render(inv, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "Invitation Details")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ID:\t%s\n", inv.GetId())
+		fmt.Fprintf(w, "Email:\t%s\n", inv.GetEmail())
+		fmt.Fprintf(w, "Status:\t%s\n", inv.GetStatus())
+		fmt.Fprintf(w, "Tenant:\t%s\n", inv.GetTenantId())
+		fmt.Fprintf(w, "Sent at:\t%s\n", formatInvitationTime(inv.SentAt))
+		fmt.Fprintf(w, "Expired at:\t%s\n", formatInvitationTime(inv.ExpiredAt))
+		fmt.Fprintf(w, "Accepted at:\t%s\n", formatInvitationTime(inv.AcceptedAt))
+		fmt.Fprintf(w, "Superadmin:\t%t\n", inv.GetSuperAdmin())
+
+		if roles := inv.GetRoles(); len(roles) > 0 {
+			names := make([]string, 0, len(roles))
+			for _, r := range roles {
+				names = append(names, r.GetName())
+			}
+			fmt.Fprintf(w, "Roles:\t%s\n", strings.Join(names, ", "))
+		}
+		if groups := inv.GetGroups(); len(groups) > 0 {
+			names := make([]string, 0, len(groups))
+			for _, g := range groups {
+				names = append(names, g.GetName())
+			}
+			fmt.Fprintf(w, "Groups:\t%s\n", strings.Join(names, ", "))
+		}
+		if link := inv.GetLink(); link != "" {
+			fmt.Fprintf(w, "Link:\t%s\n", link)
+		}
+		return nil
+	})
+}
+
+func newInvitationsCreateCommand() *cobra.Command {
+	var (
+		email                string
+		roles                []string
+		groups               []string
+		superAdmin           bool
+		createUserIfNotExist bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create an invitation.",
+		Long: `Create and send a user invitation. The --email flag is required.
+
+Roles and groups can be pre-assigned so the invitee receives them upon
+acceptance. If the invitee already has a user account (or with
+--create-user-if-not-exist), the server grants tenant access directly instead
+of sending an invitation.`,
+		Example: `  # Invite a user with a role
+  kestractl invitations create --email jane@example.com --role admin_role_id
+
+  # Invite a user into groups
+  kestractl invitations create --email jane@example.com --group g1 --group g2
+
+  # Grant access directly, creating the user if needed
+  kestractl invitations create --email jane@example.com --create-user-if-not-exist`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runInvitationsCreate(client, email, roles, groups, superAdmin, createUserIfNotExist, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&email, "email", "", "Email address of the invitee")
+	cmd.Flags().StringArrayVar(&roles, "role", nil, "Role ID to pre-assign (repeatable)")
+	cmd.Flags().StringArrayVar(&groups, "group", nil, "Group ID to pre-assign (repeatable)")
+	cmd.Flags().BoolVar(&superAdmin, "superadmin", false, "Grant superadmin to the invitee")
+	cmd.Flags().BoolVar(&createUserIfNotExist, "create-user-if-not-exist", false,
+		"Create the user and grant access directly instead of sending an invitation")
+	_ = cmd.MarkFlagRequired("email")
+
+	return cmd
+}
+
+func runInvitationsCreate(client *Client, email string, roles, groups []string, superAdmin, createUserIfNotExist bool, renderer *Renderer) error {
+	req := kestra.IAMInvitationControllerApiInvitationCreateRequest{Email: email}
+	for _, roleID := range roles {
+		req.Roles = append(req.Roles, kestra.IAMInvitationControllerApiInvitationRole{Id: roleID})
+	}
+	if len(groups) > 0 {
+		req.Groups = groups
+	}
+	if superAdmin {
+		req.SuperAdmin = &superAdmin
+	}
+	if createUserIfNotExist {
+		req.CreateUserIfNotExist = &createUserIfNotExist
+	}
+
+	inv, err := client.Kestra.Invitations().CreateInvitation(client.Ctx, client.Tenant, req)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	// A 204 response (nil detail) means the server granted tenant access
+	// directly — the invitee already had an account or
+	// --create-user-if-not-exist was set — so there is no invitation to show.
+	if inv == nil {
+		return renderStatus(renderer,
+			fmt.Sprintf("Access granted directly to '%s'; no invitation was sent.", email),
+			map[string]any{"email": email, "status": "access_granted"})
+	}
+
+	return renderInvitationDetail(inv, renderer)
+}
+
+func newInvitationsDeleteCommand() *cobra.Command {
+	var skipConfirm bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <invitation_id>",
+		Short:   "Delete an invitation.",
+		Long:    "Delete (revoke) an invitation. Prompts for confirmation unless --yes is provided.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runInvitationsDelete(client, args[0], skipConfirm, cmd.InOrStdin(), renderer)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation prompt")
+
+	return cmd
+}
+
+func runInvitationsDelete(client *Client, id string, skipConfirm bool, in io.Reader, renderer *Renderer) error {
+	if !skipConfirm {
+		// Prompt on stderr so it never pollutes stdout (e.g. --output json).
+		confirmed, err := confirm(in, os.Stderr,
+			fmt.Sprintf("Are you sure you want to delete invitation '%s'? [y/N]: ", id))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return renderStatus(renderer, "Cancelled.", map[string]any{"id": id, "status": "cancelled"})
+		}
+	}
+
+	if err := client.Kestra.Invitations().DeleteInvitation(client.Ctx, id, client.Tenant); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("Invitation '%s' deleted.", id),
+		map[string]any{"id": id, "status": "deleted"})
+}
+
+// formatInvitationTime renders an optional timestamp, blank when unset.
+func formatInvitationTime(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+	return t.Format(time.RFC3339)
+}
+
+// joinInvitationStatuses lists the allowed --status values for error messages.
+func joinInvitationStatuses() string {
+	values := make([]string, 0, len(kestra.AllowedInvitationInvitationStatusEnumValues))
+	for _, v := range kestra.AllowedInvitationInvitationStatusEnumValues {
+		values = append(values, string(v))
+	}
+	return strings.Join(values, ", ")
+}

--- a/src/cli/invitations_test.go
+++ b/src/cli/invitations_test.go
@@ -84,6 +84,22 @@ func TestRunInvitationsList(t *testing.T) {
 	}
 }
 
+func TestRunInvitationsList_EmptyBodyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runInvitationsList(newTestClient(t, server.URL), "", "", 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("expected empty list on empty-body response, got error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Total invitations: 0") {
+		t.Errorf("expected empty list output, got:\n%s", buf.String())
+	}
+}
+
 func TestRunInvitationsList_InvalidStatus(t *testing.T) {
 	hit := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/src/cli/invitations_test.go
+++ b/src/cli/invitations_test.go
@@ -1,0 +1,239 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestInvitationsCommand_Structure(t *testing.T) {
+	cmd := newInvitationsCommand()
+	if cmd.Use != "invitations" {
+		t.Fatalf("expected use 'invitations', got %q", cmd.Use)
+	}
+
+	want := map[string]bool{
+		"list": false, "get": false, "create": false, "delete": false,
+	}
+	for _, sub := range cmd.Commands() {
+		name := strings.Fields(sub.Use)[0]
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestInvitationsCreateCommand_RequiredEmail(t *testing.T) {
+	cmd := newInvitationsCreateCommand()
+	for _, flag := range []string{"email", "role", "group", "superadmin", "create-user-if-not-exist"} {
+		if cmd.Flags().Lookup(flag) == nil {
+			t.Fatalf("expected --%s flag", flag)
+		}
+	}
+	// email is marked required
+	if _, err := executeCommand(cmd); err == nil {
+		t.Fatal("expected error when --email is missing")
+	}
+}
+
+func TestInvitationsDeleteCommand_HasYesFlag(t *testing.T) {
+	cmd := newInvitationsDeleteCommand()
+	f := cmd.Flags().Lookup("yes")
+	if f == nil {
+		t.Fatal("expected --yes flag")
+	}
+	if f.Shorthand != "y" {
+		t.Fatalf("expected -y shorthand, got %q", f.Shorthand)
+	}
+}
+
+func TestRunInvitationsList(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[
+			{"id":"i1","email":"jane@example.com","status":"PENDING","sentAt":"2026-06-01T10:00:00Z","superAdmin":false},
+			{"id":"i2","email":"john@example.com","status":"ACCEPTED","superAdmin":true}
+		],"total":2}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runInvitationsList(newTestClient(t, server.URL), "", "pending", 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runInvitationsList error: %v", err)
+	}
+
+	if !strings.Contains(gotQuery, "status=PENDING") {
+		t.Errorf("expected status=PENDING in query, got %q", gotQuery)
+	}
+	out := buf.String()
+	for _, want := range []string{"jane@example.com", "john@example.com", "PENDING", "ACCEPTED", "Total invitations: 2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunInvitationsList_InvalidStatus(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runInvitationsList(newTestClient(t, server.URL), "", "BOGUS", 1, 100, nil, newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected error for invalid status")
+	}
+	if !strings.Contains(err.Error(), "PENDING") {
+		t.Errorf("expected allowed values in error, got: %v", err)
+	}
+	if hit {
+		t.Error("expected no API request for invalid status")
+	}
+}
+
+func TestRunInvitationsGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"i1","email":"jane@example.com","status":"PENDING",
+			"roles":[{"id":"r1","name":"editor"}],"groups":[{"id":"g1","name":"devs"}],
+			"link":"https://kestra.example.com/invitations/i1"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runInvitationsGet(newTestClient(t, server.URL), "i1", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runInvitationsGet error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"jane@example.com", "PENDING", "editor", "devs", "https://kestra.example.com/invitations/i1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunInvitationsCreate_SendsBody(t *testing.T) {
+	var gotBody map[string]any
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"id":"new","email":"jane@example.com","status":"PENDING"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runInvitationsCreate(newTestClient(t, server.URL), "jane@example.com",
+		[]string{"r1", "r2"}, []string{"g1"}, true, false, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runInvitationsCreate error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotBody["email"] != "jane@example.com" {
+		t.Errorf("expected email in body, got %v", gotBody["email"])
+	}
+	roles, ok := gotBody["roles"].([]any)
+	if !ok || len(roles) != 2 {
+		t.Fatalf("expected 2 roles in body, got %v", gotBody["roles"])
+	}
+	if first, _ := roles[0].(map[string]any); first["id"] != "r1" {
+		t.Errorf("expected first role id 'r1', got %v", roles[0])
+	}
+	groups, ok := gotBody["groups"].([]any)
+	if !ok || len(groups) != 1 || groups[0] != "g1" {
+		t.Errorf("expected groups [g1] in body, got %v", gotBody["groups"])
+	}
+	if gotBody["superAdmin"] != true {
+		t.Errorf("expected superAdmin true in body, got %v", gotBody["superAdmin"])
+	}
+	if _, present := gotBody["createUserIfNotExist"]; present {
+		t.Errorf("expected createUserIfNotExist omitted, got %v", gotBody["createUserIfNotExist"])
+	}
+	if !strings.Contains(buf.String(), "jane@example.com") {
+		t.Errorf("expected invitation detail output, got:\n%s", buf.String())
+	}
+}
+
+func TestRunInvitationsCreate_DirectAccessGrant(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The server answers 204 when access is granted directly (existing
+		// user or createUserIfNotExist) — no invitation detail is returned.
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runInvitationsCreate(newTestClient(t, server.URL), "jane@example.com",
+		nil, nil, false, true, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runInvitationsCreate error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Access granted directly") {
+		t.Errorf("expected direct-access message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunInvitationsDelete_Confirmed(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runInvitationsDelete(newTestClient(t, server.URL), "i1", false, strings.NewReader("y\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runInvitationsDelete error: %v", err)
+	}
+	if !hit {
+		t.Error("expected API request when deletion is confirmed")
+	}
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Errorf("expected deletion message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunInvitationsDelete_CancelMakesNoRequest(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runInvitationsDelete(newTestClient(t, server.URL), "i1", false, strings.NewReader("n\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runInvitationsDelete error: %v", err)
+	}
+	if hit {
+		t.Error("expected no API request when deletion is cancelled")
+	}
+	if !strings.Contains(buf.String(), "Cancelled") {
+		t.Errorf("expected cancellation message, got:\n%s", buf.String())
+	}
+}

--- a/src/cli/nsfiles_test.go
+++ b/src/cli/nsfiles_test.go
@@ -16,6 +16,7 @@ func newTestClient(t *testing.T, serverURL string) *Client {
 	cfg.Servers = kestra.ServerConfigurations{{URL: serverURL}}
 	return &Client{
 		API:    kestra.NewAPIClient(cfg),
+		Kestra: kestra.NewClient(serverURL),
 		Ctx:    context.Background(),
 		Tenant: "main",
 	}

--- a/src/cli/render.go
+++ b/src/cli/render.go
@@ -123,3 +123,13 @@ func validateOutputFormat() error {
 	globalFlags.Output = normalized
 	return nil
 }
+
+// joinEnumValues renders a string-backed enum's allowed values for error
+// messages, e.g. "PENDING, ACCEPTED, EXPIRED".
+func joinEnumValues[T ~string](values []T) string {
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		parts = append(parts, string(v))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -118,6 +118,7 @@ with support for multiple authentication contexts and output formats.`,
 	root.AddCommand(newRolesCommand())
 	root.AddCommand(newServiceAccountsCommand())
 	root.AddCommand(newInvitationsCommand())
+	root.AddCommand(newBindingsCommand())
 
 	return root
 }

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -117,6 +117,7 @@ with support for multiple authentication contexts and output formats.`,
 	root.AddCommand(newGroupsCommand())
 	root.AddCommand(newRolesCommand())
 	root.AddCommand(newServiceAccountsCommand())
+	root.AddCommand(newInvitationsCommand())
 
 	return root
 }


### PR DESCRIPTION
## Summary

Adds two new EE-only IAM command groups, completing part of #12:

- **`kestractl invitations`** — `list` / `get` / `create` / `delete` (closes #61)
- **`kestractl bindings`** — `list` / `get` / `create` / `delete` (closes #60)

Both are backed by the Go SDK **v1.1.0** hand-written client (`KestraClient`), which is the only SDK surface exposing the invitation/binding endpoints. To support this, `Client` now carries both SDK clients built from the same resolved host/auth/headers config:

- `Client.API` — generated-style client (existing commands, unchanged)
- `Client.Kestra` — hand-written client (new IAM commands)

`formatSDKError` handles both SDK error types (`GenericOpenAPIError` and `ApiError`) with the same JSON/HTML body extraction.

## Notable behaviors

- `invitations create` distinguishes the server's 204 **direct-access grant** (invitee already has an account, or `--create-user-if-not-exist`) from a regular 201 invitation, since no invitation is created in that case.
- `--status` / `--type` flags are validated against the SDK enums with the allowed values listed in the error message.
- Empty-body 2xx responses from the hand-written SDK (`(nil, nil)` returns) are guarded everywhere.
- `--page`/`--size`/`--sort`/`--yes`/`--output` follow the conventions of the existing `roles`/`users`/`groups` commands.

## Commits

1. `feat(client)` — dual-client groundwork in `client.go`
2. `feat(iam)` — invitations command group + tests
3. `feat(iam)` — bindings command group + tests
4. `chore` — bump go-sdk to v1.1.0 (published tag)
5. `fix(iam)` — code-review findings (error formatting, nil guards, consistency cleanups)

## Test plan

- [x] `go build ./...` + `go vet ./src/...` clean
- [x] **250 unit tests pass** (`go test ./src/...`), including regression tests for the 204 direct-grant path, empty-body responses, enum validation, and `ApiError` formatting
- [x] Manual QA against a live Kestra EE v1.3.20 instance — full command/result screenshots in the PR comment below

Closes #60
Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)