### PR TITLE
feat(plugins): add --keep-only-last-version flag to plugins download

### DIFF
--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -53,6 +53,7 @@ func newPluginsDownloadCommand() *cobra.Command {
 	var concurrency int
 	var forceRedownload bool
 	var edition string
+	var keepOnlyLastVersion bool
 
 	cmd := &cobra.Command{
 		Use:   "download <version>",
@@ -63,7 +64,7 @@ func newPluginsDownloadCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency, forceRedownload, license)
+			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency, forceRedownload, license, keepOnlyLastVersion)
 		},
 		Annotations: map[string]string{AnnotationOffline: "true"},
 	}
@@ -72,6 +73,7 @@ func newPluginsDownloadCommand() *cobra.Command {
 	cmd.Flags().IntVar(&concurrency, "concurrency", 1, "Number of parallel downloads")
 	cmd.Flags().BoolVar(&forceRedownload, "force-redownload", false, "Re-download plugins even if they already exist and pass checksum verification")
 	cmd.Flags().StringVar(&edition, "edition", "ALL", "Edition to download: ALL, OSS (open-source only), or EE (enterprise only)")
+	cmd.Flags().BoolVar(&keepOnlyLastVersion, "keep-only-last-version", true, "Remove older versions of each plugin from the plugins directory after downloading")
 	return cmd
 }
 
@@ -100,7 +102,7 @@ func resolveVersion(version string) string {
 	}
 }
 
-func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool, license string) error {
+func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool, license string, keepOnlyLastVersion bool) error {
 	kestraVersion = resolveVersion(kestraVersion)
 	fmt.Fprintf(out, "Fetching plugin list for Kestra %s...\n", kestraVersion)
 
@@ -169,10 +171,64 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 	}
 	fmt.Fprintln(out, ".")
 
+	if keepOnlyLastVersion {
+		removed, pruneErr := pruneOldVersions(pluginsDir, plugins)
+		if pruneErr != nil {
+			return pruneErr
+		}
+		if removed > 0 {
+			fmt.Fprintf(out, "Removed %d old version(s) from %s.\n", removed, pluginsDir)
+		}
+	}
+
 	if failed > 0 {
 		return fmt.Errorf("%d plugin(s) failed to download", failed)
 	}
 	return nil
+}
+
+// pruneOldVersions removes JARs in pluginsDir that belong to a plugin in the current list
+// but have a different (older) version than what was just downloaded.
+func pruneOldVersions(pluginsDir string, current []pluginArtifact) (int, error) {
+	currentFiles := make(map[string]struct{}, len(current))
+	for _, p := range current {
+		currentFiles[pluginFileName(p)] = struct{}{}
+	}
+
+	// Build prefixes of the form "<groupId>__<artifactId>__" to identify which dir entries
+	// belong to a known plugin regardless of version.
+	type prefix struct{ s string }
+	prefixes := make([]prefix, 0, len(current))
+	for _, p := range current {
+		groupID := strings.ReplaceAll(p.GroupID, ".", "_")
+		prefixes = append(prefixes, prefix{groupID + "__" + p.ArtifactID + "__"})
+	}
+
+	entries, err := os.ReadDir(pluginsDir)
+	if err != nil {
+		return 0, fmt.Errorf("cannot read plugins directory: %w", err)
+	}
+
+	removed := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".jar") {
+			continue
+		}
+		if _, isCurrent := currentFiles[name]; isCurrent {
+			continue
+		}
+		for _, pfx := range prefixes {
+			if strings.HasPrefix(name, pfx.s) {
+				if err := os.Remove(filepath.Join(pluginsDir, name)); err != nil {
+					return removed, fmt.Errorf("failed to remove old version %q: %w", name, err)
+				}
+				removed++
+				break
+			}
+		}
+	}
+	return removed, nil
 }
 
 func fetchPluginList(kestraVersion string, license string) ([]pluginArtifact, error) {

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -95,7 +95,7 @@ func TestRunPluginsInstall_HappyPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "")
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestRunPluginsInstall_ConcurrentDownloads(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false, "")
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false, "", false)
 	if err != nil {
 		t.Fatalf("unexpected error with concurrency=4: %v", err)
 	}
@@ -156,7 +156,7 @@ func TestRunPluginsInstall_APINotFound(t *testing.T) {
 	newMockServers(t, http.StatusNotFound, `{"message":"version not found"}`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false, "")
+	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false, "", false)
 	if err == nil {
 		t.Fatal("expected error for HTTP 404, got nil")
 	}
@@ -169,7 +169,7 @@ func TestRunPluginsInstall_APIInvalidJSON(t *testing.T) {
 	newMockServers(t, http.StatusOK, `not-json`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "")
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false)
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
@@ -200,7 +200,7 @@ func TestRunPluginsInstall_MavenDownloadFailure(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "")
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false)
 	if err == nil {
 		t.Fatal("expected error when Maven returns 404, got nil")
 	}
@@ -281,10 +281,16 @@ func TestMavenJARURL(t *testing.T) {
 func TestPluginsDownloadCommand_Flags(t *testing.T) {
 	cmd := newPluginsDownloadCommand()
 
-	for _, flag := range []string{"plugins-dir", "concurrency", "force-redownload", "edition"} {
+	for _, flag := range []string{"plugins-dir", "concurrency", "force-redownload", "edition", "keep-only-last-version"} {
 		if cmd.Flags().Lookup(flag) == nil {
 			t.Errorf("expected flag --%s to exist", flag)
 		}
+	}
+
+	// --keep-only-last-version must default to true.
+	f := cmd.Flags().Lookup("keep-only-last-version")
+	if f.DefValue != "true" {
+		t.Errorf("expected --keep-only-last-version default to be true, got %q", f.DefValue)
 	}
 }
 
@@ -334,7 +340,7 @@ func TestRunPluginsInstall_SkipsExistingValidJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, ""); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -362,7 +368,7 @@ func TestRunPluginsInstall_ForceRedownloadsExistingJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true, ""); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true, "", false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -387,7 +393,7 @@ func TestRunPluginsInstall_RedownloadsCorruptedJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, ""); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -525,7 +531,7 @@ func TestRunPluginsInstall_EditionOSS(t *testing.T) {
 	newMockServers(t, http.StatusOK, ossPayload)
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "OPEN_SOURCE"); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "OPEN_SOURCE", false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -546,7 +552,7 @@ func TestRunPluginsInstall_EditionEE(t *testing.T) {
 	newMockServers(t, http.StatusOK, eePayload)
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "ENTERPRISE"); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "ENTERPRISE", false); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -556,5 +562,138 @@ func TestRunPluginsInstall_EditionEE(t *testing.T) {
 	}
 	if !strings.Contains(output, "Downloaded 1") {
 		t.Errorf("expected 'Downloaded 1' in output, got:\n%s", output)
+	}
+}
+
+func TestRunPluginsInstall_KeepOnlyLastVersion_RemovesOldVersions(t *testing.T) {
+	newMockServers(t, http.StatusOK, singlePluginPayload) // serves plugin-kafka 1.6.0
+
+	tmpDir := t.TempDir()
+
+	// Pre-place two old versions of the same plugin in the directory.
+	for _, oldName := range []string{
+		"io_kestra_plugin__plugin-kafka__1_5_0.jar",
+		"io_kestra_plugin__plugin-kafka__1_4_0.jar",
+	} {
+		if err := os.WriteFile(filepath.Join(tmpDir, oldName), []byte(mockJARBody), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+	}
+
+	// Also put an unrelated JAR that must NOT be removed.
+	unrelated := "io_kestra_plugin__plugin-docker__1_3_0.jar"
+	if err := os.WriteFile(filepath.Join(tmpDir, unrelated), []byte(mockJARBody), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", true); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "Removed 2 old version(s)") {
+		t.Errorf("expected 'Removed 2 old version(s)' in output, got:\n%s", output)
+	}
+
+	// Old versions must be gone.
+	for _, oldName := range []string{
+		"io_kestra_plugin__plugin-kafka__1_5_0.jar",
+		"io_kestra_plugin__plugin-kafka__1_4_0.jar",
+	} {
+		if _, err := os.Stat(filepath.Join(tmpDir, oldName)); !os.IsNotExist(err) {
+			t.Errorf("expected old version %s to be removed", oldName)
+		}
+	}
+
+	// Current version must still exist.
+	if _, err := os.Stat(filepath.Join(tmpDir, "io_kestra_plugin__plugin-kafka__1_6_0.jar")); os.IsNotExist(err) {
+		t.Error("expected current version io_kestra_plugin__plugin-kafka__1_6_0.jar to still exist")
+	}
+
+	// Unrelated plugin must still exist.
+	if _, err := os.Stat(filepath.Join(tmpDir, unrelated)); os.IsNotExist(err) {
+		t.Errorf("expected unrelated plugin %s to still exist", unrelated)
+	}
+}
+
+func TestRunPluginsInstall_KeepOnlyLastVersionFalse_LeavesOldVersions(t *testing.T) {
+	newMockServers(t, http.StatusOK, singlePluginPayload)
+
+	tmpDir := t.TempDir()
+
+	oldName := "io_kestra_plugin__plugin-kafka__1_5_0.jar"
+	if err := os.WriteFile(filepath.Join(tmpDir, oldName), []byte(mockJARBody), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Old version must still be present.
+	if _, err := os.Stat(filepath.Join(tmpDir, oldName)); os.IsNotExist(err) {
+		t.Errorf("expected old version %s to remain when --keep-only-last-version=false", oldName)
+	}
+
+	output := out.String()
+	if strings.Contains(output, "Removed") {
+		t.Errorf("did not expect 'Removed' in output when flag is false, got:\n%s", output)
+	}
+}
+
+func TestPruneOldVersions(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	current := []pluginArtifact{
+		{GroupID: "io.kestra.plugin", ArtifactID: "plugin-kafka", Version: "1.6.0"},
+		{GroupID: "io.kestra.plugin", ArtifactID: "plugin-docker", Version: "1.3.0"},
+	}
+
+	// Create current-version files (should be kept).
+	for _, p := range current {
+		if err := os.WriteFile(filepath.Join(tmpDir, pluginFileName(p)), []byte("jar"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+	}
+
+	// Create old-version files (should be removed).
+	oldFiles := []string{
+		"io_kestra_plugin__plugin-kafka__1_5_0.jar",
+		"io_kestra_plugin__plugin-docker__1_2_0.jar",
+	}
+	for _, name := range oldFiles {
+		if err := os.WriteFile(filepath.Join(tmpDir, name), []byte("jar"), 0o644); err != nil {
+			t.Fatalf("setup: %v", err)
+		}
+	}
+
+	// Create a JAR for a plugin not in the current list (should be kept).
+	unknown := "io_kestra_plugin__plugin-unknown__9_9_9.jar"
+	if err := os.WriteFile(filepath.Join(tmpDir, unknown), []byte("jar"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	removed, err := pruneOldVersions(tmpDir, current)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("expected 2 files removed, got %d", removed)
+	}
+
+	for _, name := range oldFiles {
+		if _, err := os.Stat(filepath.Join(tmpDir, name)); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed", name)
+		}
+	}
+	for _, p := range current {
+		if _, err := os.Stat(filepath.Join(tmpDir, pluginFileName(p))); os.IsNotExist(err) {
+			t.Errorf("expected current file %s to remain", pluginFileName(p))
+		}
+	}
+	if _, err := os.Stat(filepath.Join(tmpDir, unknown)); os.IsNotExist(err) {
+		t.Errorf("expected unknown plugin %s to remain", unknown)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `--keep-only-last-version` flag to `plugins download` (defaults to **true**)
- After downloading, scans the plugins directory and removes any JAR that belongs to a known plugin (same `groupId` + `artifactId`) but carries an older version than what was just downloaded
- JARs for plugins **not** in the current download list are left untouched (safe for manually placed or edition-filtered JARs)
- Prints `Removed N old version(s) from <dir>.` in the summary when pruning occurs

## Test plan

- [ ] `TestRunPluginsInstall_KeepOnlyLastVersion_RemovesOldVersions` — two stale versions removed, current and unrelated JARs kept
- [ ] `TestRunPluginsInstall_KeepOnlyLastVersionFalse_LeavesOldVersions` — old versions untouched when flag is false
- [ ] `TestPruneOldVersions` — unit test for the `pruneOldVersions` helper directly
- [ ] `TestPluginsDownloadCommand_Flags` — asserts flag exists and defaults to `true`
- [ ] Full suite: `go test ./src/...` — 253 tests green