### PR TITLE
fix(plugins): skip download when JAR already exists by name

### DIFF
--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"crypto/sha1" //nolint:gosec // SHA-1 is used only for checksum comparison, not cryptographic security
 	"encoding/json"
 	"fmt"
 	"io"
@@ -268,20 +267,7 @@ func downloadJAR(p pluginArtifact, destDir string, forceRedownload bool) (int64,
 
 	if !forceRedownload {
 		if _, err := os.Stat(destPath); err == nil {
-			remoteSHA1, shaErr := fetchMavenSHA1(p)
-			if shaErr == nil {
-				localHash, hashErr := localFileSHA1(destPath)
-				if hashErr == nil && localHash == remoteSHA1 {
-					return 0, true, nil // already up-to-date
-				}
-				// SHA-1 mismatch: file is corrupted or truncated — remove and re-download.
-				_ = os.Remove(destPath)
-			} else {
-				// Can't reach Maven for SHA-1 — fall back to ZIP magic byte check.
-				if isValidZIP(destPath) {
-					return 0, true, nil
-				}
-			}
+			return 0, true, nil
 		}
 	}
 
@@ -307,53 +293,6 @@ func downloadJAR(p pluginArtifact, destDir string, forceRedownload bool) (int64,
 		return 0, false, fmt.Errorf("write failed: %w", err)
 	}
 	return n, false, nil
-}
-
-// fetchMavenSHA1 retrieves the SHA-1 checksum published by Maven Central for the artifact.
-func fetchMavenSHA1(p pluginArtifact) (string, error) {
-	url := mavenJARURL(p) + ".sha1"
-	resp, err := http.Get(url) //nolint:gosec // URL is constructed from trusted API data
-	if err != nil {
-		return "", fmt.Errorf("HTTP request failed: %w", err)
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Maven Central returned HTTP %d for SHA-1", resp.StatusCode)
-	}
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("read failed: %w", err)
-	}
-	// Maven .sha1 files contain the hex digest, optionally followed by whitespace and filename.
-	return strings.Fields(string(body))[0], nil
-}
-
-// localFileSHA1 computes the hex-encoded SHA-1 digest of the file at path.
-func localFileSHA1(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-	h := sha1.New() //nolint:gosec // SHA-1 used only for checksum comparison
-	if _, err := io.Copy(h, f); err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
-}
-
-// isValidZIP checks whether path starts with the ZIP/JAR magic bytes (PK\x03\x04).
-func isValidZIP(path string) bool {
-	f, err := os.Open(path)
-	if err != nil {
-		return false
-	}
-	defer f.Close()
-	var magic [4]byte
-	if _, err := io.ReadFull(f, magic[:]); err != nil {
-		return false
-	}
-	return magic[0] == 'P' && magic[1] == 'K' && magic[2] == 0x03 && magic[3] == 0x04
 }
 
 // mavenJARURL builds the Maven Central download URL for a plugin artifact.

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"bytes"
-	"crypto/sha1" //nolint:gosec
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -42,13 +41,6 @@ const pluginListPayload = `[
 // mockJARBody is the dummy JAR content returned by the mock Maven server.
 const mockJARBody = "PK\x03\x04"
 
-// mockJARSHA1 is the hex SHA-1 of mockJARBody, used by the mock .sha1 endpoint.
-var mockJARSHA1 = func() string {
-	h := sha1.New() //nolint:gosec
-	h.Write([]byte(mockJARBody))
-	return fmt.Sprintf("%x", h.Sum(nil))
-}()
-
 // newMockServers sets up:
 //   - apiServer: returns pluginListPayload for any request
 //   - mavenServer: returns a dummy JAR body for .jar requests and its SHA-1 for .sha1 requests
@@ -64,11 +56,6 @@ func newMockServers(t *testing.T, apiStatus int, apiBody string) (apiServer, mav
 	}))
 
 	mavenServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, ".sha1") {
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, mockJARSHA1)
-			return
-		}
 		w.Header().Set("Content-Type", "application/java-archive")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, mockJARBody)
@@ -378,81 +365,6 @@ func TestRunPluginsInstall_ForceRedownloadsExistingJAR(t *testing.T) {
 	}
 	if !strings.Contains(output, "Downloaded 1") {
 		t.Errorf("expected 'Downloaded 1' with --force-redownload, got:\n%s", output)
-	}
-}
-
-func TestRunPluginsInstall_RedownloadsCorruptedJAR(t *testing.T) {
-	newMockServers(t, http.StatusOK, singlePluginPayload)
-
-	tmpDir := t.TempDir()
-
-	// Pre-create the JAR with corrupt content (SHA-1 will not match).
-	jarPath := filepath.Join(tmpDir, "io_kestra_plugin__plugin-kafka__1_6_0.jar")
-	if err := os.WriteFile(jarPath, []byte("corrupted-data"), 0o644); err != nil {
-		t.Fatalf("failed to create corrupted JAR: %v", err)
-	}
-
-	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	output := out.String()
-	if strings.Contains(output, "already up to date") {
-		t.Errorf("did not expect 'already up to date' for corrupted JAR, got:\n%s", output)
-	}
-	if !strings.Contains(output, "Downloaded 1") {
-		t.Errorf("expected 'Downloaded 1' after re-downloading corrupted JAR, got:\n%s", output)
-	}
-
-	// Verify the file was replaced with valid content.
-	content, err := os.ReadFile(jarPath)
-	if err != nil {
-		t.Fatalf("failed to read JAR after re-download: %v", err)
-	}
-	if string(content) != mockJARBody {
-		t.Errorf("expected JAR to contain mock body after re-download, got: %q", string(content))
-	}
-}
-
-func TestIsValidZIP(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	validPath := filepath.Join(tmpDir, "valid.jar")
-	if err := os.WriteFile(validPath, []byte("PK\x03\x04extra"), 0o644); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-	if !isValidZIP(validPath) {
-		t.Error("expected isValidZIP to return true for valid ZIP magic bytes")
-	}
-
-	invalidPath := filepath.Join(tmpDir, "invalid.jar")
-	if err := os.WriteFile(invalidPath, []byte("not-a-zip"), 0o644); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-	if isValidZIP(invalidPath) {
-		t.Error("expected isValidZIP to return false for non-ZIP content")
-	}
-}
-
-func TestLocalFileSHA1(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "test.jar")
-	content := []byte("hello")
-	if err := os.WriteFile(path, content, 0o644); err != nil {
-		t.Fatalf("setup: %v", err)
-	}
-
-	h := sha1.New() //nolint:gosec
-	h.Write(content)
-	want := fmt.Sprintf("%x", h.Sum(nil))
-
-	got, err := localFileSHA1(path)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if got != want {
-		t.Errorf("localFileSHA1 = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Plugin filenames already encode `groupId`, `artifactId`, and `version` — a file existence check is all that's needed to determine if a plugin is present
- Removes SHA-1 checksum fetching from Maven Central, which was causing 429 rate-limit errors on large plugin sets (183+ requests just to confirm nothing changed)
- Per Maven Central's own documentation, retrying on 429 is an anti-pattern — the right fix is to reduce unnecessary traffic, not work around rate limits

## Test plan

- [ ] `go test ./src/...` passes (250 tests)
- [ ] `plugins download <version>` skips already-downloaded JARs without hitting Maven Central
- [ ] `plugins download <version> --force-redownload` still re-downloads everything