### PR TITLE
feat(plugins): retry on 429 with backoff and add --global-timeout

### DIFF
--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -9,9 +11,18 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/spf13/cobra"
 )
+
+// errRateLimited is returned by downloadJAR when Maven Central responds with 429
+// after all retry attempts are exhausted.
+var errRateLimited = errors.New("rate limited by Maven Central (429)")
+
+// rateLimitWaits defines the back-off delays between successive 429 retries.
+// Exposed as a var so tests can override it to avoid sleeping.
+var rateLimitWaits = []time.Duration{5 * time.Second, 10 * time.Second, 30 * time.Second}
 
 // pluginsAPIBase and pluginsMavenBase are vars so tests can point them at a local httptest server.
 var (
@@ -53,6 +64,7 @@ func newPluginsDownloadCommand() *cobra.Command {
 	var forceRedownload bool
 	var edition string
 	var keepOnlyLastVersion bool
+	var globalTimeout time.Duration
 
 	cmd := &cobra.Command{
 		Use:   "download <version>",
@@ -63,7 +75,7 @@ func newPluginsDownloadCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency, forceRedownload, license, keepOnlyLastVersion)
+			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency, forceRedownload, license, keepOnlyLastVersion, globalTimeout)
 		},
 		Annotations: map[string]string{AnnotationOffline: "true"},
 	}
@@ -73,6 +85,7 @@ func newPluginsDownloadCommand() *cobra.Command {
 	cmd.Flags().BoolVar(&forceRedownload, "force-redownload", false, "Re-download plugins even if they already exist and pass checksum verification")
 	cmd.Flags().StringVar(&edition, "edition", "ALL", "Edition to download: ALL, OSS (open-source only), or EE (enterprise only)")
 	cmd.Flags().BoolVar(&keepOnlyLastVersion, "keep-only-last-version", true, "Remove older versions of each plugin from the plugins directory after downloading")
+	cmd.Flags().DurationVar(&globalTimeout, "global-timeout", 5*time.Minute, "Maximum total time allowed for all downloads")
 	return cmd
 }
 
@@ -101,7 +114,7 @@ func resolveVersion(version string) string {
 	}
 }
 
-func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool, license string, keepOnlyLastVersion bool) error {
+func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool, license string, keepOnlyLastVersion bool, globalTimeout time.Duration) error {
 	kestraVersion = resolveVersion(kestraVersion)
 	fmt.Fprintf(out, "Fetching plugin list for Kestra %s...\n", kestraVersion)
 
@@ -116,8 +129,19 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 		return fmt.Errorf("cannot create plugins directory %q: %w", pluginsDir, err)
 	}
 
+	ctx, cancel := context.WithTimeout(context.Background(), globalTimeout)
+	defer cancel()
+
 	width := len(fmt.Sprintf("%d", len(plugins)))
 	lineFormat := fmt.Sprintf("[%%%dd/%%%dd]", width, width)
+
+	// outMu serializes all writes to out, including retry log lines from goroutines.
+	var outMu sync.Mutex
+	logf := func(format string, args ...any) {
+		outMu.Lock()
+		fmt.Fprintf(out, format, args...)
+		outMu.Unlock()
+	}
 
 	sem := make(chan struct{}, concurrency)
 	results := make(chan downloadResult, len(plugins))
@@ -127,9 +151,14 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 		wg.Add(1)
 		go func(i int, p pluginArtifact) {
 			defer wg.Done()
-			sem <- struct{}{}
+			select {
+			case sem <- struct{}{}:
+			case <-ctx.Done():
+				results <- downloadResult{index: i, plugin: p, err: ctx.Err()}
+				return
+			}
 			defer func() { <-sem }()
-			n, skipped, err := downloadJAR(p, pluginsDir, forceRedownload)
+			n, skipped, err := downloadJAR(ctx, logf, p, pluginsDir, forceRedownload)
 			results <- downloadResult{index: i, plugin: p, bytes: n, err: err, skipped: skipped}
 		}(i, p)
 	}
@@ -139,15 +168,22 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 		close(results)
 	}()
 
-	var mu sync.Mutex
 	downloaded := 0
 	skippedCount := 0
 	failed := 0
+	stoppedEarly := false
 
 	for r := range results {
 		label := fmt.Sprintf("%s:%s:%s", r.plugin.GroupID, r.plugin.ArtifactID, r.plugin.Version)
-		mu.Lock()
-		if r.err != nil {
+		outMu.Lock()
+		if errors.Is(r.err, errRateLimited) {
+			fmt.Fprintf(out, lineFormat+" %s ... FAILED (rate limited — stopping early)\n", r.index+1, len(plugins), label)
+			failed++
+			if !stoppedEarly {
+				stoppedEarly = true
+				cancel()
+			}
+		} else if r.err != nil {
 			fmt.Fprintf(out, lineFormat+" %s ... FAILED (%v)\n", r.index+1, len(plugins), label, r.err)
 			failed++
 		} else if r.skipped {
@@ -157,7 +193,7 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 			fmt.Fprintf(out, lineFormat+" %s ... done (%.1f MB)\n", r.index+1, len(plugins), label, float64(r.bytes)/(1024*1024))
 			downloaded++
 		}
-		mu.Unlock()
+		outMu.Unlock()
 	}
 
 	fmt.Fprintf(out, "\nDownloaded %d", downloaded)
@@ -180,6 +216,9 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 		}
 	}
 
+	if stoppedEarly {
+		return fmt.Errorf("download stopped early: Maven Central is rate limiting — %d plugin(s) failed", failed)
+	}
 	if failed > 0 {
 		return fmt.Errorf("%d plugin(s) failed to download", failed)
 	}
@@ -262,7 +301,7 @@ func pluginFileName(p pluginArtifact) string {
 	return groupID + "__" + p.ArtifactID + "__" + version + ".jar"
 }
 
-func downloadJAR(p pluginArtifact, destDir string, forceRedownload bool) (int64, bool, error) {
+func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifact, destDir string, forceRedownload bool) (int64, bool, error) {
 	destPath := filepath.Join(destDir, pluginFileName(p))
 
 	if !forceRedownload {
@@ -272,27 +311,50 @@ func downloadJAR(p pluginArtifact, destDir string, forceRedownload bool) (int64,
 	}
 
 	url := mavenJARURL(p)
-	resp, err := http.Get(url) //nolint:gosec // URL is constructed from trusted API data
-	if err != nil {
-		return 0, false, fmt.Errorf("HTTP request failed: %w", err)
-	}
-	defer resp.Body.Close()
+	label := fmt.Sprintf("%s:%s:%s", p.GroupID, p.ArtifactID, p.Version)
 
-	if resp.StatusCode != http.StatusOK {
-		return 0, false, fmt.Errorf("Maven Central returned HTTP %d", resp.StatusCode)
-	}
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return 0, false, fmt.Errorf("failed to build request: %w", err)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return 0, false, fmt.Errorf("HTTP request failed: %w", err)
+		}
 
-	f, err := os.Create(destPath)
-	if err != nil {
-		return 0, false, fmt.Errorf("cannot create file: %w", err)
-	}
-	defer f.Close()
+		if resp.StatusCode == http.StatusTooManyRequests {
+			resp.Body.Close()
+			if attempt >= len(rateLimitWaits) {
+				return 0, false, errRateLimited
+			}
+			wait := rateLimitWaits[attempt]
+			logf("  [429] rate limited on %s — waiting %s (retry %d/%d)\n", label, wait, attempt+1, len(rateLimitWaits))
+			select {
+			case <-time.After(wait):
+			case <-ctx.Done():
+				return 0, false, ctx.Err()
+			}
+			continue
+		}
 
-	n, err := io.Copy(f, resp.Body)
-	if err != nil {
-		return 0, false, fmt.Errorf("write failed: %w", err)
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return 0, false, fmt.Errorf("Maven Central returned HTTP %d", resp.StatusCode)
+		}
+
+		f, err := os.Create(destPath)
+		if err != nil {
+			return 0, false, fmt.Errorf("cannot create file: %w", err)
+		}
+		defer f.Close()
+
+		n, err := io.Copy(f, resp.Body)
+		if err != nil {
+			return 0, false, fmt.Errorf("write failed: %w", err)
+		}
+		return n, false, nil
 	}
-	return n, false, nil
 }
 
 // mavenJARURL builds the Maven Central download URL for a plugin artifact.

--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -38,11 +38,12 @@ type pluginArtifact struct {
 }
 
 type downloadResult struct {
-	index   int
-	plugin  pluginArtifact
-	bytes   int64
-	err     error
-	skipped bool
+	index     int
+	plugin    pluginArtifact
+	bytes     int64
+	err       error
+	skipped   bool
+	cancelled bool
 }
 
 func newPluginsCommand() *cobra.Command {
@@ -143,24 +144,34 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 		outMu.Unlock()
 	}
 
-	sem := make(chan struct{}, concurrency)
+	type job struct {
+		index  int
+		plugin pluginArtifact
+	}
+	jobs := make(chan job, len(plugins))
+	for i, p := range plugins {
+		jobs <- job{i, p}
+	}
+	close(jobs)
+
 	results := make(chan downloadResult, len(plugins))
 
 	var wg sync.WaitGroup
-	for i, p := range plugins {
+	for range concurrency {
 		wg.Add(1)
-		go func(i int, p pluginArtifact) {
+		go func() {
 			defer wg.Done()
-			select {
-			case sem <- struct{}{}:
-			case <-ctx.Done():
-				results <- downloadResult{index: i, plugin: p, err: ctx.Err()}
-				return
+			for j := range jobs {
+				select {
+				case <-ctx.Done():
+					results <- downloadResult{index: j.index, plugin: j.plugin, cancelled: true}
+					continue
+				default:
+				}
+				n, skipped, err := downloadJAR(ctx, logf, j.plugin, pluginsDir, forceRedownload)
+				results <- downloadResult{index: j.index, plugin: j.plugin, bytes: n, err: err, skipped: skipped}
 			}
-			defer func() { <-sem }()
-			n, skipped, err := downloadJAR(ctx, logf, p, pluginsDir, forceRedownload)
-			results <- downloadResult{index: i, plugin: p, bytes: n, err: err, skipped: skipped}
-		}(i, p)
+		}()
 	}
 
 	go func() {
@@ -170,13 +181,16 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 
 	downloaded := 0
 	skippedCount := 0
+	cancelledCount := 0
 	failed := 0
 	stoppedEarly := false
 
 	for r := range results {
 		label := fmt.Sprintf("%s:%s:%s", r.plugin.GroupID, r.plugin.ArtifactID, r.plugin.Version)
 		outMu.Lock()
-		if errors.Is(r.err, errRateLimited) {
+		if r.cancelled || errors.Is(r.err, context.Canceled) {
+			cancelledCount++
+		} else if errors.Is(r.err, errRateLimited) {
 			fmt.Fprintf(out, lineFormat+" %s ... FAILED (rate limited — stopping early)\n", r.index+1, len(plugins), label)
 			failed++
 			if !stoppedEarly {
@@ -200,6 +214,9 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 	if skippedCount > 0 {
 		fmt.Fprintf(out, ", skipped %d (already up to date)", skippedCount)
 	}
+	if cancelledCount > 0 {
+		fmt.Fprintf(out, ", %d not started (cancelled)", cancelledCount)
+	}
 	fmt.Fprintf(out, " plugin(s) to %s", pluginsDir)
 	if failed > 0 {
 		fmt.Fprintf(out, ", %d failed", failed)
@@ -217,7 +234,7 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 	}
 
 	if stoppedEarly {
-		return fmt.Errorf("download stopped early: Maven Central is rate limiting — %d plugin(s) failed", failed)
+		return fmt.Errorf("download stopped early: Maven Central is rate limiting — %d failed, %d not started", failed, cancelledCount)
 	}
 	if failed > 0 {
 		return fmt.Errorf("%d plugin(s) failed to download", failed)

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // Real-world payload sampled from
@@ -82,7 +84,7 @@ func TestRunPluginsInstall_HappyPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false)
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -125,7 +127,7 @@ func TestRunPluginsInstall_ConcurrentDownloads(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false, "", false)
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false, "", false, 5*time.Minute)
 	if err != nil {
 		t.Fatalf("unexpected error with concurrency=4: %v", err)
 	}
@@ -143,7 +145,7 @@ func TestRunPluginsInstall_APINotFound(t *testing.T) {
 	newMockServers(t, http.StatusNotFound, `{"message":"version not found"}`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false, "", false)
+	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false, "", false, 5*time.Minute)
 	if err == nil {
 		t.Fatal("expected error for HTTP 404, got nil")
 	}
@@ -156,7 +158,7 @@ func TestRunPluginsInstall_APIInvalidJSON(t *testing.T) {
 	newMockServers(t, http.StatusOK, `not-json`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute)
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
@@ -187,7 +189,7 @@ func TestRunPluginsInstall_MavenDownloadFailure(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute)
 	if err == nil {
 		t.Fatal("expected error when Maven returns 404, got nil")
 	}
@@ -327,7 +329,7 @@ func TestRunPluginsInstall_SkipsExistingValidJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -355,7 +357,7 @@ func TestRunPluginsInstall_ForceRedownloadsExistingJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true, "", false); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true, "", false, 5*time.Minute); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -443,7 +445,7 @@ func TestRunPluginsInstall_EditionOSS(t *testing.T) {
 	newMockServers(t, http.StatusOK, ossPayload)
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "OPEN_SOURCE", false); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "OPEN_SOURCE", false, 5*time.Minute); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -464,7 +466,7 @@ func TestRunPluginsInstall_EditionEE(t *testing.T) {
 	newMockServers(t, http.StatusOK, eePayload)
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "ENTERPRISE", false); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "ENTERPRISE", false, 5*time.Minute); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -499,7 +501,7 @@ func TestRunPluginsInstall_KeepOnlyLastVersion_RemovesOldVersions(t *testing.T) 
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", true); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", true, 5*time.Minute); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -540,7 +542,7 @@ func TestRunPluginsInstall_KeepOnlyLastVersionFalse_LeavesOldVersions(t *testing
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -607,5 +609,96 @@ func TestPruneOldVersions(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(tmpDir, unknown)); os.IsNotExist(err) {
 		t.Errorf("expected unknown plugin %s to remain", unknown)
+	}
+}
+
+func TestRunPluginsInstall_429RetryThenSucceeds(t *testing.T) {
+	// Override waits to zero so the test doesn't actually sleep.
+	orig := rateLimitWaits
+	rateLimitWaits = []time.Duration{0, 0, 0}
+	t.Cleanup(func() { rateLimitWaits = orig })
+
+	var attempts atomic.Int32
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, singlePluginPayload)
+	}))
+	mavenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// First two attempts return 429; third succeeds.
+		if attempts.Add(1) <= 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/java-archive")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, mockJARBody)
+	}))
+	origAPI, origMaven := pluginsAPIBase, pluginsMavenBase
+	pluginsAPIBase, pluginsMavenBase = apiServer.URL, mavenServer.URL
+	t.Cleanup(func() {
+		pluginsAPIBase, pluginsMavenBase = origAPI, origMaven
+		apiServer.Close()
+		mavenServer.Close()
+	})
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "[429]") {
+		t.Errorf("expected '[429]' retry log in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Downloaded 1") {
+		t.Errorf("expected 'Downloaded 1' after retry succeeded, got:\n%s", output)
+	}
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 Maven attempts, got %d", attempts.Load())
+	}
+}
+
+func TestRunPluginsInstall_429ExhaustsRetriesStopsEarly(t *testing.T) {
+	orig := rateLimitWaits
+	rateLimitWaits = []time.Duration{0, 0, 0}
+	t.Cleanup(func() { rateLimitWaits = orig })
+
+	newMockServers(t, http.StatusOK, singlePluginPayload)
+
+	// Override Maven to always return 429.
+	mavenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	origMaven := pluginsMavenBase
+	pluginsMavenBase = mavenServer.URL
+	t.Cleanup(func() {
+		pluginsMavenBase = origMaven
+		mavenServer.Close()
+	})
+
+	var out bytes.Buffer
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute)
+	if err == nil {
+		t.Fatal("expected error when Maven always returns 429")
+	}
+	if !strings.Contains(err.Error(), "stopped early") {
+		t.Errorf("expected 'stopped early' in error, got: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "rate limited — stopping early") {
+		t.Errorf("expected early-stop message in output, got:\n%s", output)
+	}
+}
+
+func TestPluginsDownloadCommand_GlobalTimeoutFlag(t *testing.T) {
+	cmd := newPluginsDownloadCommand()
+	f := cmd.Flags().Lookup("global-timeout")
+	if f == nil {
+		t.Fatal("expected --global-timeout flag to exist")
+	}
+	if f.DefValue != "5m0s" {
+		t.Errorf("expected --global-timeout default to be 5m0s, got %q", f.DefValue)
 	}
 }


### PR DESCRIPTION
## Summary

- On a 429 from Maven Central, waits and retries the plugin up to 3 times: 5s → 10s → 30s
- Logs each 429 and the wait duration so the user knows what's happening
- If still rate-limited after all retries, stops the entire download early (rather than hammering Maven further)
- Adds `--global-timeout` (default `5m`) to cap total download time; all waits respect it so the timeout is never exceeded silently

## Behaviour

```
  [429] rate limited on io.kestra.plugin:plugin-kafka:1.6.0 — waiting 5s (retry 1/3)
  [429] rate limited on io.kestra.plugin:plugin-kafka:1.6.0 — waiting 10s (retry 2/3)
[ 1/ 1] io.kestra.plugin:plugin-kafka:1.6.0 ... done (12.3 MB)   ← succeeded on 3rd try
```

If all 3 retries fail:
```
[ 1/ 1] io.kestra.plugin:plugin-kafka:1.6.0 ... FAILED (rate limited — stopping early)
Error: download stopped early: Maven Central is rate limiting — 1 plugin(s) failed
```

## Test plan

- [ ] `go test ./src/...` passes (253 tests)
- [ ] `TestRunPluginsInstall_429RetryThenSucceeds` — mock returns 429 twice then succeeds; verifies 3 Maven attempts and retry log lines
- [ ] `TestRunPluginsInstall_429ExhaustsRetriesStopsEarly` — mock always returns 429; verifies early-stop error and message
- [ ] `TestPluginsDownloadCommand_GlobalTimeoutFlag` — verifies flag exists with 5m default