### PR TITLE
feat(plugins): add --maven-repository, --maven-username, --maven-password flags

### DIFF
--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -18,7 +18,7 @@ import (
 
 // errRateLimited is returned by downloadJAR when Maven Central responds with 429
 // after all retry attempts are exhausted.
-var errRateLimited = errors.New("rate limited by Maven Central (429)")
+var errRateLimited = errors.New("rate limited by repository (429)")
 
 // rateLimitWaits defines the back-off delays between successive 429 retries.
 // Exposed as a var so tests can override it to avoid sleeping.
@@ -66,17 +66,50 @@ func newPluginsDownloadCommand() *cobra.Command {
 	var edition string
 	var keepOnlyLastVersion bool
 	var globalTimeout time.Duration
+	var mavenRepository string
+	var mavenUsername string
+	var mavenPassword string
 
 	cmd := &cobra.Command{
 		Use:   "download <version>",
-		Short: "Download all plugins for a given Kestra version from Maven Central",
-		Args:  cobra.ExactArgs(1),
+		Short: "Download all plugins for a given Kestra version from a Maven repository",
+		Long: `Download all plugins for a given Kestra version from a Maven repository.
+
+By default plugins are fetched from Maven Central. Use --maven-repository to
+point at a custom registry (mirror, internal Nexus/Artifactory, etc.).
+
+Authentication:
+
+  Basic auth (--maven-username / --maven-password):
+    kestractl plugins download 1.3.9 \
+      --maven-repository https://nexus.example.com/repository/maven-central \
+      --maven-username myuser \
+      --maven-password mypassword
+
+  Bearer token (--header):
+    kestractl plugins download 1.3.9 \
+      --maven-repository https://nexus.example.com/repository/maven-central \
+      --header "Authorization:Bearer <token>"
+
+  GCP Artifact Registry — service account key (GOOGLE_APPLICATION_CREDENTIALS set):
+    kestractl plugins download 1.3.9 \
+      --maven-repository https://europe-west1-maven.pkg.dev/my-project/my-repo \
+      --maven-username _json_key \
+      --maven-password "$(cat $GOOGLE_APPLICATION_CREDENTIALS)"
+
+  GCP Artifact Registry — gcloud access token:
+    kestractl plugins download 1.3.9 \
+      --maven-repository https://europe-west1-maven.pkg.dev/my-project/my-repo \
+      --maven-username oauth2accesstoken \
+      --maven-password "$(gcloud auth print-access-token)"`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			license, err := editionToLicense(edition)
 			if err != nil {
 				return err
 			}
-			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency, forceRedownload, license, keepOnlyLastVersion, globalTimeout)
+			headers, _ := cmd.Root().PersistentFlags().GetStringArray(FlagHeader)
+			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency, forceRedownload, license, keepOnlyLastVersion, globalTimeout, mavenRepository, mavenUsername, mavenPassword, headers)
 		},
 		Annotations: map[string]string{AnnotationOffline: "true"},
 	}
@@ -87,6 +120,9 @@ func newPluginsDownloadCommand() *cobra.Command {
 	cmd.Flags().StringVar(&edition, "edition", "ALL", "Edition to download: ALL, OSS (open-source only), or EE (enterprise only)")
 	cmd.Flags().BoolVar(&keepOnlyLastVersion, "keep-only-last-version", true, "Remove older versions of each plugin from the plugins directory after downloading")
 	cmd.Flags().DurationVar(&globalTimeout, "global-timeout", 5*time.Minute, "Maximum total time allowed for all downloads")
+	cmd.Flags().StringVar(&mavenRepository, "maven-repository", "", "Custom Maven repository base URL (defaults to Maven Central)")
+	cmd.Flags().StringVar(&mavenUsername, "maven-username", "", "Username for Maven repository basic authentication")
+	cmd.Flags().StringVar(&mavenPassword, "maven-password", "", "Password for Maven repository basic authentication")
 	return cmd
 }
 
@@ -115,9 +151,19 @@ func resolveVersion(version string) string {
 	}
 }
 
-func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool, license string, keepOnlyLastVersion bool, globalTimeout time.Duration) error {
+func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool, license string, keepOnlyLastVersion bool, globalTimeout time.Duration, mavenRepository string, mavenUsername string, mavenPassword string, headers []string) error {
 	kestraVersion = resolveVersion(kestraVersion)
 	fmt.Fprintf(out, "Fetching plugin list for Kestra %s...\n", kestraVersion)
+
+	effectiveMavenBase := pluginsMavenBase
+	if mavenRepository != "" {
+		effectiveMavenBase = mavenRepository
+	}
+
+	parsedHeaders, err := parseHeaders(headers)
+	if err != nil {
+		return fmt.Errorf("invalid --header value: %w", err)
+	}
 
 	plugins, err := fetchPluginList(kestraVersion, license)
 	if err != nil {
@@ -168,7 +214,7 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 					continue
 				default:
 				}
-				n, skipped, err := downloadJAR(ctx, logf, j.plugin, pluginsDir, forceRedownload)
+				n, skipped, err := downloadJAR(ctx, logf, j.plugin, pluginsDir, forceRedownload, effectiveMavenBase, mavenUsername, mavenPassword, parsedHeaders)
 				results <- downloadResult{index: j.index, plugin: j.plugin, bytes: n, err: err, skipped: skipped}
 			}
 		}()
@@ -191,7 +237,7 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 		if r.cancelled || errors.Is(r.err, context.Canceled) {
 			cancelledCount++
 		} else if errors.Is(r.err, errRateLimited) {
-			fmt.Fprintf(out, lineFormat+" %s ... FAILED (rate limited — stopping early)\n", r.index+1, len(plugins), label)
+			fmt.Fprintf(out, lineFormat+" %s ... FAILED (rate limited by repository — stopping early)\n", r.index+1, len(plugins), label)
 			failed++
 			if !stoppedEarly {
 				stoppedEarly = true
@@ -234,7 +280,7 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 	}
 
 	if stoppedEarly {
-		return fmt.Errorf("download stopped early: Maven Central is rate limiting — %d failed, %d not started", failed, cancelledCount)
+		return fmt.Errorf("download stopped early: repository is rate limiting — %d failed, %d not started", failed, cancelledCount)
 	}
 	if failed > 0 {
 		return fmt.Errorf("%d plugin(s) failed to download", failed)
@@ -318,7 +364,7 @@ func pluginFileName(p pluginArtifact) string {
 	return groupID + "__" + p.ArtifactID + "__" + version + ".jar"
 }
 
-func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifact, destDir string, forceRedownload bool) (int64, bool, error) {
+func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifact, destDir string, forceRedownload bool, mavenBase string, mavenUsername string, mavenPassword string, headers map[string]string) (int64, bool, error) {
 	destPath := filepath.Join(destDir, pluginFileName(p))
 
 	if !forceRedownload {
@@ -327,13 +373,19 @@ func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifac
 		}
 	}
 
-	url := mavenJARURL(p)
+	url := mavenJARURL(p, mavenBase)
 	label := fmt.Sprintf("%s:%s:%s", p.GroupID, p.ArtifactID, p.Version)
 
 	for attempt := 0; ; attempt++ {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 		if err != nil {
 			return 0, false, fmt.Errorf("failed to build request: %w", err)
+		}
+		for k, v := range headers {
+			req.Header.Set(k, v)
+		}
+		if mavenUsername != "" || mavenPassword != "" {
+			req.SetBasicAuth(mavenUsername, mavenPassword)
 		}
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
@@ -357,7 +409,7 @@ func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifac
 
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			return 0, false, fmt.Errorf("Maven Central returned HTTP %d", resp.StatusCode)
+			return 0, false, fmt.Errorf("repository returned HTTP %d", resp.StatusCode)
 		}
 
 		f, err := os.Create(destPath)
@@ -374,9 +426,9 @@ func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifac
 	}
 }
 
-// mavenJARURL builds the Maven Central download URL for a plugin artifact.
-func mavenJARURL(p pluginArtifact) string {
+// mavenJARURL builds the Maven repository download URL for a plugin artifact.
+func mavenJARURL(p pluginArtifact, base string) string {
 	groupPath := strings.ReplaceAll(p.GroupID, ".", "/")
 	return fmt.Sprintf("%s/%s/%s/%s/%s-%s.jar",
-		pluginsMavenBase, groupPath, p.ArtifactID, p.Version, p.ArtifactID, p.Version)
+		base, groupPath, p.ArtifactID, p.Version, p.ArtifactID, p.Version)
 }

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -84,7 +84,7 @@ func TestRunPluginsInstall_HappyPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute)
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute, "", "", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -127,7 +127,7 @@ func TestRunPluginsInstall_ConcurrentDownloads(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false, "", false, 5*time.Minute)
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false, "", false, 5*time.Minute, "", "", "", nil)
 	if err != nil {
 		t.Fatalf("unexpected error with concurrency=4: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestRunPluginsInstall_APINotFound(t *testing.T) {
 	newMockServers(t, http.StatusNotFound, `{"message":"version not found"}`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false, "", false, 5*time.Minute)
+	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil)
 	if err == nil {
 		t.Fatal("expected error for HTTP 404, got nil")
 	}
@@ -158,7 +158,7 @@ func TestRunPluginsInstall_APIInvalidJSON(t *testing.T) {
 	newMockServers(t, http.StatusOK, `not-json`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil)
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
@@ -189,7 +189,7 @@ func TestRunPluginsInstall_MavenDownloadFailure(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil)
 	if err == nil {
 		t.Fatal("expected error when Maven returns 404, got nil")
 	}
@@ -237,9 +237,7 @@ func TestPluginFileName(t *testing.T) {
 }
 
 func TestMavenJARURL(t *testing.T) {
-	origMaven := pluginsMavenBase
-	pluginsMavenBase = "https://repo1.maven.org/maven2"
-	defer func() { pluginsMavenBase = origMaven }()
+	const base = "https://repo1.maven.org/maven2"
 
 	tests := []struct {
 		plugin  pluginArtifact
@@ -260,7 +258,7 @@ func TestMavenJARURL(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := mavenJARURL(tt.plugin)
+		got := mavenJARURL(tt.plugin, base)
 		if got != tt.wantURL {
 			t.Errorf("mavenJARURL(%+v)\n  got:  %s\n  want: %s", tt.plugin, got, tt.wantURL)
 		}
@@ -329,7 +327,7 @@ func TestRunPluginsInstall_SkipsExistingValidJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute, "", "", "", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -357,7 +355,7 @@ func TestRunPluginsInstall_ForceRedownloadsExistingJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true, "", false, 5*time.Minute); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true, "", false, 5*time.Minute, "", "", "", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -445,7 +443,7 @@ func TestRunPluginsInstall_EditionOSS(t *testing.T) {
 	newMockServers(t, http.StatusOK, ossPayload)
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "OPEN_SOURCE", false, 5*time.Minute); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "OPEN_SOURCE", false, 5*time.Minute, "", "", "", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -466,7 +464,7 @@ func TestRunPluginsInstall_EditionEE(t *testing.T) {
 	newMockServers(t, http.StatusOK, eePayload)
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "ENTERPRISE", false, 5*time.Minute); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "ENTERPRISE", false, 5*time.Minute, "", "", "", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -501,7 +499,7 @@ func TestRunPluginsInstall_KeepOnlyLastVersion_RemovesOldVersions(t *testing.T) 
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", true, 5*time.Minute); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", true, 5*time.Minute, "", "", "", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -542,7 +540,7 @@ func TestRunPluginsInstall_KeepOnlyLastVersionFalse_LeavesOldVersions(t *testing
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute, "", "", "", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -643,7 +641,7 @@ func TestRunPluginsInstall_429RetryThenSucceeds(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -678,7 +676,7 @@ func TestRunPluginsInstall_429ExhaustsRetriesStopsEarly(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil)
 	if err == nil {
 		t.Fatal("expected error when Maven always returns 429")
 	}
@@ -687,7 +685,7 @@ func TestRunPluginsInstall_429ExhaustsRetriesStopsEarly(t *testing.T) {
 	}
 
 	output := out.String()
-	if !strings.Contains(output, "rate limited — stopping early") {
+	if !strings.Contains(output, "rate limited by repository — stopping early") {
 		t.Errorf("expected early-stop message in output, got:\n%s", output)
 	}
 }
@@ -700,5 +698,90 @@ func TestPluginsDownloadCommand_GlobalTimeoutFlag(t *testing.T) {
 	}
 	if f.DefValue != "5m0s" {
 		t.Errorf("expected --global-timeout default to be 5m0s, got %q", f.DefValue)
+	}
+}
+
+func TestPluginsDownloadCommand_MavenRepositoryFlags(t *testing.T) {
+	cmd := newPluginsDownloadCommand()
+
+	for _, name := range []string{"maven-repository", "maven-username", "maven-password"} {
+		f := cmd.Flags().Lookup(name)
+		if f == nil {
+			t.Errorf("expected --%s flag to exist", name)
+			continue
+		}
+		if f.DefValue != "" {
+			t.Errorf("expected --%s default to be empty, got %q", name, f.DefValue)
+		}
+	}
+}
+
+func TestRunPluginsInstall_CustomMavenRepository(t *testing.T) {
+	// Set up a custom Maven server that records the host it was called on.
+	var capturedHost string
+	customMaven := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHost = r.Host
+		w.Header().Set("Content-Type", "application/java-archive")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, mockJARBody)
+	}))
+	t.Cleanup(customMaven.Close)
+
+	// API server uses the global override so newMockServers handles cleanup for it.
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, singlePluginPayload)
+	}))
+	t.Cleanup(apiServer.Close)
+
+	origAPI := pluginsAPIBase
+	pluginsAPIBase = apiServer.URL
+	t.Cleanup(func() { pluginsAPIBase = origAPI })
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, customMaven.URL, "", "", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedHost == "" {
+		t.Error("expected custom Maven server to be called, but it was not")
+	}
+	if !strings.Contains(out.String(), "Downloaded 1") {
+		t.Errorf("expected 'Downloaded 1' in output, got:\n%s", out.String())
+	}
+}
+
+func TestRunPluginsInstall_MavenBasicAuth(t *testing.T) {
+	var capturedAuth string
+	customMaven := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/java-archive")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, mockJARBody)
+	}))
+	t.Cleanup(customMaven.Close)
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, singlePluginPayload)
+	}))
+	t.Cleanup(apiServer.Close)
+
+	origAPI := pluginsAPIBase
+	pluginsAPIBase = apiServer.URL
+	t.Cleanup(func() { pluginsAPIBase = origAPI })
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, customMaven.URL, "alice", "s3cr3t", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if capturedAuth == "" {
+		t.Fatal("expected Authorization header to be set, got none")
+	}
+	if !strings.HasPrefix(capturedAuth, "Basic ") {
+		t.Errorf("expected Basic auth header, got: %s", capturedAuth)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `--maven-repository` flag to point `plugins download` at a custom Maven repository instead of Maven Central (useful for air-gapped environments, internal mirrors, or authenticated registries)
- Adds `--maven-username` / `--maven-password` flags for Basic Auth against the repository
- Fixes `--header` being silently ignored for `plugins download` (it was only populated via `initializeConfig`, which is skipped for offline commands) — now reads directly from root persistent flags in `RunE`
- De-hardcodes "Maven Central" from error messages so they stay accurate when a custom repository URL is in use

## Test plan

- [ ] `go test ./src/...` passes (256 tests)
- [ ] `TestPluginsDownloadCommand_MavenRepositoryFlags` — verifies all three flags exist with empty defaults
- [ ] `TestRunPluginsInstall_CustomMavenRepository` — verifies downloads hit the custom server URL
- [ ] `TestRunPluginsInstall_MavenBasicAuth` — verifies `Authorization: Basic …` header is sent when username/password are provided
- [ ] Live QA against a GCP Artifact Registry remote Maven repository using `--maven-username oauth2accesstoken --maven-password $(gcloud auth print-access-token)` — 183 OSS plugins downloaded successfully