### PR TITLE
feat(plugins): add plugins list command

### DIFF
--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -70,11 +70,19 @@ func newPluginsDownloadCommand() *cobra.Command {
 	var mavenRepository string
 	var mavenUsername string
 	var mavenPassword string
+	var pluginsList []string
 
 	cmd := &cobra.Command{
-		Use:   "download <version>",
+		Use:   "download [version]",
 		Short: "Download all plugins for a given Kestra version from a Maven repository",
 		Long: `Download all plugins for a given Kestra version from a Maven repository.
+
+By default the plugin list is fetched from the Kestra API for the given version.
+Alternatively, pass an explicit list of plugins with --plugins, in which case the
+version argument is optional and the API is not called. The --plugins format matches
+the output of "kestractl plugins list", making it easy to pipe the two commands:
+
+  kestractl plugins download --plugins "$(kestractl plugins list 1.3.9 --edition OSS)"
 
 By default plugins are fetched from Maven Central. Use --maven-repository to
 point at a custom registry (mirror, internal Nexus/Artifactory, etc.).
@@ -103,14 +111,34 @@ Authentication:
       --maven-repository https://europe-west1-maven.pkg.dev/my-project/my-repo \
       --maven-username oauth2accesstoken \
       --maven-password "$(gcloud auth print-access-token)"`,
-		Args: cobra.ExactArgs(1),
+		Args: func(cmd *cobra.Command, args []string) error {
+			hasPlugins, _ := cmd.Flags().GetStringArray("plugins")
+			if len(hasPlugins) == 0 && len(args) == 0 {
+				return fmt.Errorf("requires a version argument when --plugins is not set")
+			}
+			if len(args) > 1 {
+				return fmt.Errorf("accepts at most 1 arg, received %d", len(args))
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			license, err := editionToLicense(edition)
 			if err != nil {
 				return err
 			}
+			var explicit []pluginArtifact
+			if len(pluginsList) > 0 {
+				explicit, err = parsePluginCoordinates(pluginsList)
+				if err != nil {
+					return err
+				}
+			}
+			version := ""
+			if len(args) > 0 {
+				version = args[0]
+			}
 			headers, _ := cmd.Root().PersistentFlags().GetStringArray(FlagHeader)
-			return runPluginsInstall(cmd.OutOrStdout(), args[0], pluginsDir, concurrency, forceRedownload, license, keepOnlyLastVersion, globalTimeout, mavenRepository, mavenUsername, mavenPassword, headers)
+			return runPluginsInstall(cmd.OutOrStdout(), version, pluginsDir, concurrency, forceRedownload, license, keepOnlyLastVersion, globalTimeout, mavenRepository, mavenUsername, mavenPassword, headers, explicit)
 		},
 		Annotations: map[string]string{AnnotationOffline: "true"},
 	}
@@ -124,6 +152,7 @@ Authentication:
 	cmd.Flags().StringVar(&mavenRepository, "maven-repository", "", "Custom Maven repository base URL (defaults to Maven Central)")
 	cmd.Flags().StringVar(&mavenUsername, "maven-username", "", "Username for Maven repository basic authentication")
 	cmd.Flags().StringVar(&mavenPassword, "maven-password", "", "Password for Maven repository basic authentication")
+	cmd.Flags().StringArrayVar(&pluginsList, "plugins", nil, "Explicit list of plugins to download as groupId:artifactId:version (space-separated or repeated flag; bypasses API lookup)")
 	return cmd
 }
 
@@ -208,10 +237,7 @@ func resolveVersion(version string) string {
 	}
 }
 
-func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool, license string, keepOnlyLastVersion bool, globalTimeout time.Duration, mavenRepository string, mavenUsername string, mavenPassword string, headers []string) error {
-	kestraVersion = resolveVersion(kestraVersion)
-	fmt.Fprintf(out, "Fetching plugin list for Kestra %s...\n", kestraVersion)
-
+func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, concurrency int, forceRedownload bool, license string, keepOnlyLastVersion bool, globalTimeout time.Duration, mavenRepository string, mavenUsername string, mavenPassword string, headers []string, explicitPlugins []pluginArtifact) error {
 	effectiveMavenBase := pluginsMavenBase
 	if mavenRepository != "" {
 		effectiveMavenBase = mavenRepository
@@ -222,12 +248,19 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 		return fmt.Errorf("invalid --header value: %w", err)
 	}
 
-	plugins, err := fetchPluginList(kestraVersion, license)
-	if err != nil {
-		return err
+	var plugins []pluginArtifact
+	if len(explicitPlugins) > 0 {
+		plugins = explicitPlugins
+		fmt.Fprintf(out, "Downloading %d plugin(s)...\n\n", len(plugins))
+	} else {
+		kestraVersion = resolveVersion(kestraVersion)
+		fmt.Fprintf(out, "Fetching plugin list for Kestra %s...\n", kestraVersion)
+		plugins, err = fetchPluginList(kestraVersion, license)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "Found %d plugins.\n\n", len(plugins))
 	}
-
-	fmt.Fprintf(out, "Found %d plugins.\n\n", len(plugins))
 
 	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
 		return fmt.Errorf("cannot create plugins directory %q: %w", pluginsDir, err)
@@ -410,6 +443,26 @@ func fetchPluginList(kestraVersion string, license string) ([]pluginArtifact, er
 		return nil, fmt.Errorf("failed to parse plugin list: %w", err)
 	}
 	return plugins, nil
+}
+
+// parsePluginCoordinates parses a list of strings — each may be a single
+// "groupId:artifactId:version" coordinate or a space-separated list of them
+// (matching the output of "kestractl plugins list") — into pluginArtifact values.
+func parsePluginCoordinates(values []string) ([]pluginArtifact, error) {
+	var result []pluginArtifact
+	for _, v := range values {
+		for _, coord := range strings.Fields(v) {
+			parts := strings.SplitN(coord, ":", 3)
+			if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+				return nil, fmt.Errorf("invalid plugin coordinate %q: expected groupId:artifactId:version", coord)
+			}
+			result = append(result, pluginArtifact{GroupID: parts[0], ArtifactID: parts[1], Version: parts[2]})
+		}
+	}
+	if len(result) == 0 {
+		return nil, fmt.Errorf("--plugins was set but no valid coordinates were found")
+	}
+	return result, nil
 }
 
 // pluginFileName returns the Kestra-compatible filename for a plugin artifact.

--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -56,6 +56,7 @@ func newPluginsCommand() *cobra.Command {
 		Annotations: map[string]string{AnnotationOffline: "true"},
 	}
 	cmd.AddCommand(newPluginsDownloadCommand())
+	cmd.AddCommand(newPluginsListCommand())
 	return cmd
 }
 
@@ -124,6 +125,62 @@ Authentication:
 	cmd.Flags().StringVar(&mavenUsername, "maven-username", "", "Username for Maven repository basic authentication")
 	cmd.Flags().StringVar(&mavenPassword, "maven-password", "", "Password for Maven repository basic authentication")
 	return cmd
+}
+
+func newPluginsListCommand() *cobra.Command {
+	var edition string
+
+	cmd := &cobra.Command{
+		Use:   "list <version>",
+		Short: "List all compatible plugins for a given Kestra version",
+		Long: `List all compatible plugins for a given Kestra version.
+
+Output format matches the legacy npx @kestra-io/kestra-devtools getCompatiblePlugins
+command: a single space-separated line of groupId:artifactId:version coordinates.
+
+With --output json the full plugin metadata (groupId, artifactId, license, version)
+is printed as a JSON array.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
+			license, err := editionToLicense(edition)
+			if err != nil {
+				return err
+			}
+			return runPluginsList(cmd.OutOrStdout(), args[0], license, globalFlags.Output)
+		},
+		Annotations: map[string]string{AnnotationOffline: "true"},
+	}
+
+	cmd.Flags().StringVar(&edition, "edition", "ALL", "Edition to list: ALL, OSS (open-source only), or EE (enterprise only)")
+	return cmd
+}
+
+func runPluginsList(out io.Writer, kestraVersion string, license string, outputFormat string) error {
+	kestraVersion = resolveVersion(kestraVersion)
+
+	plugins, err := fetchPluginList(kestraVersion, license)
+	if err != nil {
+		return err
+	}
+
+	if outputFormat == "json" {
+		data, err := json.Marshal(plugins)
+		if err != nil {
+			return fmt.Errorf("failed to encode plugin list: %w", err)
+		}
+		fmt.Fprintln(out, string(data))
+		return nil
+	}
+
+	coords := make([]string, len(plugins))
+	for i, p := range plugins {
+		coords[i] = p.GroupID + ":" + p.ArtifactID + ":" + p.Version
+	}
+	fmt.Fprintln(out, strings.Join(coords, " "))
+	return nil
 }
 
 // editionToLicense maps the user-facing --edition value to the API license query param.

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -85,7 +85,7 @@ func TestRunPluginsInstall_HappyPath(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute, "", "", "", nil)
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute, "", "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -128,7 +128,7 @@ func TestRunPluginsInstall_ConcurrentDownloads(t *testing.T) {
 	tmpDir := t.TempDir()
 	var out bytes.Buffer
 
-	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false, "", false, 5*time.Minute, "", "", "", nil)
+	err := runPluginsInstall(&out, "1.3.9", tmpDir, 4, false, "", false, 5*time.Minute, "", "", "", nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error with concurrency=4: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestRunPluginsInstall_APINotFound(t *testing.T) {
 	newMockServers(t, http.StatusNotFound, `{"message":"version not found"}`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil)
+	err := runPluginsInstall(&out, "99.99.99", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error for HTTP 404, got nil")
 	}
@@ -159,7 +159,7 @@ func TestRunPluginsInstall_APIInvalidJSON(t *testing.T) {
 	newMockServers(t, http.StatusOK, `not-json`)
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error for invalid JSON, got nil")
 	}
@@ -190,7 +190,7 @@ func TestRunPluginsInstall_MavenDownloadFailure(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error when Maven returns 404, got nil")
 	}
@@ -308,7 +308,7 @@ func TestPluginsDownloadCommand_RequiresVersion(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when version argument is missing")
 	}
-	if !strings.Contains(err.Error(), "accepts 1 arg") {
+	if !strings.Contains(err.Error(), "version argument") {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -328,7 +328,7 @@ func TestRunPluginsInstall_SkipsExistingValidJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute, "", "", "", nil); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute, "", "", "", nil, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -356,7 +356,7 @@ func TestRunPluginsInstall_ForceRedownloadsExistingJAR(t *testing.T) {
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true, "", false, 5*time.Minute, "", "", "", nil); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, true, "", false, 5*time.Minute, "", "", "", nil, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -444,7 +444,7 @@ func TestRunPluginsInstall_EditionOSS(t *testing.T) {
 	newMockServers(t, http.StatusOK, ossPayload)
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "OPEN_SOURCE", false, 5*time.Minute, "", "", "", nil); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "OPEN_SOURCE", false, 5*time.Minute, "", "", "", nil, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -465,7 +465,7 @@ func TestRunPluginsInstall_EditionEE(t *testing.T) {
 	newMockServers(t, http.StatusOK, eePayload)
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "ENTERPRISE", false, 5*time.Minute, "", "", "", nil); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "ENTERPRISE", false, 5*time.Minute, "", "", "", nil, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -500,7 +500,7 @@ func TestRunPluginsInstall_KeepOnlyLastVersion_RemovesOldVersions(t *testing.T) 
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", true, 5*time.Minute, "", "", "", nil); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", true, 5*time.Minute, "", "", "", nil, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -541,7 +541,7 @@ func TestRunPluginsInstall_KeepOnlyLastVersionFalse_LeavesOldVersions(t *testing
 	}
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute, "", "", "", nil); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", tmpDir, 1, false, "", false, 5*time.Minute, "", "", "", nil, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -642,7 +642,7 @@ func TestRunPluginsInstall_429RetryThenSucceeds(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -677,7 +677,7 @@ func TestRunPluginsInstall_429ExhaustsRetriesStopsEarly(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil)
+	err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil, nil)
 	if err == nil {
 		t.Fatal("expected error when Maven always returns 429")
 	}
@@ -741,7 +741,7 @@ func TestRunPluginsInstall_CustomMavenRepository(t *testing.T) {
 	t.Cleanup(func() { pluginsAPIBase = origAPI })
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, customMaven.URL, "", "", nil); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, customMaven.URL, "", "", nil, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -775,7 +775,7 @@ func TestRunPluginsInstall_MavenBasicAuth(t *testing.T) {
 	t.Cleanup(func() { pluginsAPIBase = origAPI })
 
 	var out bytes.Buffer
-	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, customMaven.URL, "alice", "s3cr3t", nil); err != nil {
+	if err := runPluginsInstall(&out, "1.3.9", t.TempDir(), 1, false, "", false, 5*time.Minute, customMaven.URL, "alice", "s3cr3t", nil, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -852,6 +852,118 @@ func TestRunPluginsList_APIError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "HTTP 404") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestParsePluginCoordinates(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		want    []pluginArtifact
+		wantErr bool
+	}{
+		{
+			name:  "single coordinate",
+			input: []string{"io.kestra.plugin:plugin-kafka:1.6.0"},
+			want:  []pluginArtifact{{GroupID: "io.kestra.plugin", ArtifactID: "plugin-kafka", Version: "1.6.0"}},
+		},
+		{
+			name:  "space-separated (plugins list output)",
+			input: []string{"io.kestra.plugin:plugin-kafka:1.6.0 io.kestra.plugin:plugin-docker:1.3.0"},
+			want: []pluginArtifact{
+				{GroupID: "io.kestra.plugin", ArtifactID: "plugin-kafka", Version: "1.6.0"},
+				{GroupID: "io.kestra.plugin", ArtifactID: "plugin-docker", Version: "1.3.0"},
+			},
+		},
+		{
+			name:  "repeated flag values",
+			input: []string{"io.kestra.plugin:plugin-kafka:1.6.0", "io.kestra.plugin:plugin-docker:1.3.0"},
+			want: []pluginArtifact{
+				{GroupID: "io.kestra.plugin", ArtifactID: "plugin-kafka", Version: "1.6.0"},
+				{GroupID: "io.kestra.plugin", ArtifactID: "plugin-docker", Version: "1.3.0"},
+			},
+		},
+		{
+			name:    "missing version",
+			input:   []string{"io.kestra.plugin:plugin-kafka"},
+			wantErr: true,
+		},
+		{
+			name:    "empty string",
+			input:   []string{""},
+			wantErr: true,
+		},
+		{
+			name:    "malformed coordinate",
+			input:   []string{"notacoordinate"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePluginCoordinates(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d artifacts, want %d", len(got), len(tt.want))
+			}
+			for i, p := range got {
+				if p.GroupID != tt.want[i].GroupID || p.ArtifactID != tt.want[i].ArtifactID || p.Version != tt.want[i].Version {
+					t.Errorf("artifact[%d] = %+v, want %+v", i, p, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRunPluginsInstall_ExplicitPlugins(t *testing.T) {
+	_, mavenServer := newMockServers(t, http.StatusOK, pluginListPayload)
+
+	// Capture which paths the maven server was asked for.
+	var requestedPaths []string
+	mavenServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/java-archive")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, mockJARBody)
+	})
+
+	explicit := []pluginArtifact{
+		{GroupID: "io.kestra.plugin", ArtifactID: "plugin-kafka", Version: "1.6.0"},
+		{GroupID: "io.kestra.plugin", ArtifactID: "plugin-docker", Version: "1.3.0"},
+	}
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "", t.TempDir(), 1, false, "", false, 5*time.Minute, "", "", "", nil, explicit); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := out.String()
+
+	// Should not hit the API — no "Fetching plugin list" message.
+	if strings.Contains(output, "Fetching plugin list") {
+		t.Errorf("did not expect API fetch when explicit plugins provided, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Downloaded 2") {
+		t.Errorf("expected 'Downloaded 2' in output, got:\n%s", output)
+	}
+	// Only 2 Maven requests, not 22.
+	if len(requestedPaths) != 2 {
+		t.Errorf("expected 2 Maven requests, got %d", len(requestedPaths))
+	}
+}
+
+func TestPluginsDownloadCommand_PluginsFlag(t *testing.T) {
+	cmd := newPluginsDownloadCommand()
+	if cmd.Flags().Lookup("plugins") == nil {
+		t.Error("expected --plugins flag to exist")
 	}
 }
 

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -783,5 +784,83 @@ func TestRunPluginsInstall_MavenBasicAuth(t *testing.T) {
 	}
 	if !strings.HasPrefix(capturedAuth, "Basic ") {
 		t.Errorf("expected Basic auth header, got: %s", capturedAuth)
+	}
+}
+
+func TestRunPluginsList_DefaultOutput(t *testing.T) {
+	newMockServers(t, http.StatusOK, pluginListPayload)
+
+	var out bytes.Buffer
+	if err := runPluginsList(&out, "1.3.9", "", "table"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := strings.TrimSpace(out.String())
+
+	// Output must be a single line.
+	if strings.Contains(output, "\n") {
+		t.Errorf("expected single-line output, got multiple lines:\n%s", output)
+	}
+
+	// Each entry must be groupId:artifactId:version.
+	entries := strings.Split(output, " ")
+	if len(entries) != 22 {
+		t.Errorf("expected 22 space-separated entries, got %d", len(entries))
+	}
+	for _, e := range entries {
+		parts := strings.Split(e, ":")
+		if len(parts) != 3 {
+			t.Errorf("expected groupId:artifactId:version format, got %q", e)
+		}
+	}
+
+	// Spot-check a known entry.
+	if !strings.Contains(output, "io.kestra.plugin:plugin-kafka:1.6.0") {
+		t.Errorf("expected io.kestra.plugin:plugin-kafka:1.6.0 in output, got:\n%s", output)
+	}
+}
+
+func TestRunPluginsList_JSONOutput(t *testing.T) {
+	newMockServers(t, http.StatusOK, pluginListPayload)
+
+	var out bytes.Buffer
+	if err := runPluginsList(&out, "1.3.9", "", "json"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var plugins []pluginArtifact
+	if err := json.NewDecoder(&out).Decode(&plugins); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if len(plugins) != 22 {
+		t.Errorf("expected 22 plugins in JSON, got %d", len(plugins))
+	}
+	// Spot-check fields are populated.
+	p := plugins[0]
+	if p.GroupID == "" || p.ArtifactID == "" || p.Version == "" {
+		t.Errorf("expected all fields populated, got %+v", p)
+	}
+}
+
+func TestRunPluginsList_APIError(t *testing.T) {
+	newMockServers(t, http.StatusNotFound, `{"message":"version not found"}`)
+
+	var out bytes.Buffer
+	err := runPluginsList(&out, "99.99.99", "", "table")
+	if err == nil {
+		t.Fatal("expected error for HTTP 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPluginsListCommand_Flags(t *testing.T) {
+	cmd := newPluginsListCommand()
+	if cmd.Flags().Lookup("edition") == nil {
+		t.Error("expected --edition flag to exist")
+	}
+	if _, err := executeCommand(cmd); err == nil {
+		t.Error("expected error when version argument is missing")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds \`kestractl plugins list <version>\` as a drop-in replacement for \`npx --yes @kestra-io/kestra-devtools getCompatiblePlugins\`
- Adds \`--plugins\` flag to \`plugins download\` to bypass the API lookup and download an explicit set of plugins — designed to be piped from \`plugins list\`

## \`plugins list\`

```bash
# Default output: single space-separated line of groupId:artifactId:version
kestractl plugins list 1.3.9

# JSON output
kestractl plugins list 1.3.9 --output json

# Filter by edition
kestractl plugins list 1.3.9 --edition OSS
```

Output format matches the legacy npx command exactly — existing scripts work unchanged.

## \`plugins download --plugins\`

```bash
# Explicit coordinates (single flag, space-separated)
kestractl plugins download \
  --plugins "io.kestra.plugin:plugin-kafka:1.6.0 io.kestra.plugin:plugin-docker:1.5.0"

# Repeated flag
kestractl plugins download \
  --plugins "io.kestra.plugin:plugin-kafka:1.6.0" \
  --plugins "io.kestra.plugin:plugin-docker:1.5.0"

# Piped from plugins list (version arg optional when --plugins is set)
kestractl plugins download \
  --plugins "$(kestractl plugins list 1.3.9 --edition OSS)"
```

When \`--plugins\` is provided the Kestra API is not called and the version argument is optional.

## Test plan

- [ ] \`go test ./src/...\` passes (269 tests)
- [ ] \`TestRunPluginsList_DefaultOutput\` — single-line space-separated output, correct format
- [ ] \`TestRunPluginsList_JSONOutput\` — valid JSON array with all fields populated
- [ ] \`TestRunPluginsList_APIError\` — HTTP 404 surfaces cleanly
- [ ] \`TestParsePluginCoordinates\` — single coord, space-separated list, repeated flags, error cases
- [ ] \`TestRunPluginsInstall_ExplicitPlugins\` — API not called, only 2 Maven requests for 2 explicit plugins
- [ ] \`TestPluginsDownloadCommand_PluginsFlag\` — flag exists on command
- [ ] Live QA: \`plugins list 1.3.9\` output matches \`npx @kestra-io/kestra-devtools getCompatiblePlugins 1.3.9\`
- [ ] Live QA: \`v1.3.9\` and \`1.3.9\` return identical plugin lists
- [ ] Live QA: \`--plugins\` with piped input downloads only the specified plugins