### PR TITLE
feat(plugins): bootstrap core plugins for remote workers via --from-config

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,15 @@ kestractl plugins download 1.3.9 --concurrency 4
 
 # `develop` and `latest` are aliases for the in-development version
 kestractl plugins download develop
+
+# Bootstrap a standalone/remote worker: download only the "core" plugins required
+# by a Kestra configuration — internal storage, secret manager, and the
+# queue/repository backend. Bundled backends (local storage, JDBC, Kafka) are
+# skipped; enterprise backends need --edition ALL (the default) or EE.
+kestractl plugins download 1.3.9 --from-config /etc/kestra/application.yaml
+
+# Preview the core plugins a config needs without downloading (pipes into download)
+kestractl plugins list 1.3.9 --from-config /etc/kestra/application.yaml
 ```
 
 ### Workers

--- a/src/cli/bootstrap.go
+++ b/src/cli/bootstrap.go
@@ -149,8 +149,13 @@ func requiredArtifactIDs(cfg kestraConfig) ([]string, error) {
 // resolveCorePlugins fetches the compatibility list for the given version and
 // returns the pluginArtifact entries matching the required artifactIds, pinning
 // each to the version the API reports for that Kestra release.
-func resolveCorePlugins(kestraVersion string, license string, artifactIDs []string) ([]pluginArtifact, error) {
-	plugins, err := fetchPluginList(kestraVersion, license)
+//
+// It always queries the full catalog (no edition/license filter): the config
+// has already pinned the exact set of plugins, and a typical Enterprise worker
+// mixes an open-source storage plugin with an enterprise secret manager, so any
+// license filter would drop one side of that pair.
+func resolveCorePlugins(kestraVersion string, artifactIDs []string) ([]pluginArtifact, error) {
+	plugins, err := fetchPluginList(kestraVersion, "")
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +177,7 @@ func resolveCorePlugins(kestraVersion string, license string, artifactIDs []stri
 		}
 	}
 	if len(missing) > 0 {
-		return nil, fmt.Errorf("core plugin(s) not available for Kestra %s: %s — enterprise plugins require --edition ALL or EE",
+		return nil, fmt.Errorf("core plugin(s) not available for Kestra %s: %s — check the version exists and the configured backend is correct",
 			kestraVersion, strings.Join(missing, ", "))
 	}
 	return result, nil
@@ -181,7 +186,8 @@ func resolveCorePlugins(kestraVersion string, license string, artifactIDs []stri
 // corePluginsFromConfig is the end-to-end helper shared by "plugins list" and
 // "plugins download": it parses the config file(s), maps the configured
 // backends to plugin coordinates, and pins them to the given Kestra version.
-func corePluginsFromConfig(configPaths []string, kestraVersion string, license string) ([]pluginArtifact, error) {
+// Resolution ignores edition: the config already determines the exact set.
+func corePluginsFromConfig(configPaths []string, kestraVersion string) ([]pluginArtifact, error) {
 	cfg, err := loadKestraConfig(configPaths)
 	if err != nil {
 		return nil, err
@@ -193,7 +199,7 @@ func corePluginsFromConfig(configPaths []string, kestraVersion string, license s
 	if len(ids) == 0 {
 		return nil, nil
 	}
-	return resolveCorePlugins(kestraVersion, license, ids)
+	return resolveCorePlugins(kestraVersion, ids)
 }
 
 func sortedKeys(m map[string]string) []string {

--- a/src/cli/bootstrap.go
+++ b/src/cli/bootstrap.go
@@ -1,0 +1,206 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// builtinType is the sentinel value used in the *TypeToArtifact maps below to
+// mean "this backend is bundled in the Kestra distribution — there is no plugin
+// to download". It is distinct from an unknown type, which is an error.
+const builtinType = ""
+
+// storageTypeToArtifact maps a kestra.storage.type discriminator to the Maven
+// artifactId of the plugin that provides it. Values are sourced from the Kestra
+// runtime & storage configuration documentation.
+var storageTypeToArtifact = map[string]string{
+	"local":      builtinType,
+	"s3":         "storage-s3",
+	"gcs":        "storage-gcs",
+	"azure":      "storage-azure",
+	"minio":      "storage-minio",
+	"seaweedfs":  "storage-seaweedfs",
+	"cloudflare": "storage-cloudflare",
+}
+
+// secretTypeToArtifact maps a kestra.secret.type discriminator to the secret
+// manager plugin artifactId. The jdbc and elasticsearch backends are bundled.
+var secretTypeToArtifact = map[string]string{
+	"jdbc":                  builtinType,
+	"elasticsearch":         builtinType,
+	"vault":                 "secret-vault",
+	"aws-secret-manager":    "secret-aws",
+	"azure-key-vault":       "secret-azure",
+	"google-secret-manager": "secret-googlecloud",
+	"cyberark":              "secret-cyberark",
+	"doppler":               "secret-doppler",
+	"1password":             "secret-1password",
+	"beyondtrust":           "secret-beyondtrust",
+	"delinea":               "secret-delinea",
+}
+
+// queueTypeToArtifact maps a kestra.queue.type discriminator to a plugin
+// artifactId. All currently supported queue backends (JDBC variants and the
+// EE Kafka queue) are bundled in the distribution, so none require a plugin.
+var queueTypeToArtifact = map[string]string{
+	"memory":   builtinType,
+	"h2":       builtinType,
+	"postgres": builtinType,
+	"mysql":    builtinType,
+	"kafka":    builtinType, // bundled in the Kestra EE distribution
+}
+
+// repositoryTypeToArtifact maps a kestra.repository.type discriminator to a
+// plugin artifactId. JDBC variants are bundled; the EE search backends ship as
+// plugins.
+var repositoryTypeToArtifact = map[string]string{
+	"memory":        builtinType,
+	"h2":            builtinType,
+	"postgres":      builtinType,
+	"mysql":         builtinType,
+	"elasticsearch": "plugin-ee-elasticsearch",
+	"opensearch":    "plugin-ee-opensearch",
+}
+
+// kestraConfig is the minimal subset of a Kestra application.yaml needed to
+// determine the core plugins required to start a component.
+type kestraConfig struct {
+	Kestra struct {
+		Storage    typedBackend `yaml:"storage"`
+		Secret     typedBackend `yaml:"secret"`
+		Queue      typedBackend `yaml:"queue"`
+		Repository typedBackend `yaml:"repository"`
+	} `yaml:"kestra"`
+}
+
+type typedBackend struct {
+	Type string `yaml:"type"`
+}
+
+// loadKestraConfig reads and merges one or more Kestra configuration files.
+// Only the four core discriminators are read; for each, the last file that sets
+// a non-empty value wins, matching Micronaut's "later source overrides earlier"
+// precedence for these scalar properties.
+func loadKestraConfig(paths []string) (kestraConfig, error) {
+	var merged kestraConfig
+	for _, p := range paths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return kestraConfig{}, fmt.Errorf("cannot read config file %q: %w", p, err)
+		}
+		var c kestraConfig
+		if err := yaml.Unmarshal(data, &c); err != nil {
+			return kestraConfig{}, fmt.Errorf("cannot parse config file %q: %w", p, err)
+		}
+		if c.Kestra.Storage.Type != "" {
+			merged.Kestra.Storage.Type = c.Kestra.Storage.Type
+		}
+		if c.Kestra.Secret.Type != "" {
+			merged.Kestra.Secret.Type = c.Kestra.Secret.Type
+		}
+		if c.Kestra.Queue.Type != "" {
+			merged.Kestra.Queue.Type = c.Kestra.Queue.Type
+		}
+		if c.Kestra.Repository.Type != "" {
+			merged.Kestra.Repository.Type = c.Kestra.Repository.Type
+		}
+	}
+	return merged, nil
+}
+
+// requiredArtifactIDs inspects a parsed Kestra config and returns the plugin
+// artifactIds required to start, skipping bundled backends. An unrecognized
+// type value is an error so a typo or a new backend surfaces loudly rather than
+// silently resolving to "no plugins".
+func requiredArtifactIDs(cfg kestraConfig) ([]string, error) {
+	categories := []struct {
+		label   string
+		typeVal string
+		mapping map[string]string
+	}{
+		{"storage", cfg.Kestra.Storage.Type, storageTypeToArtifact},
+		{"secret", cfg.Kestra.Secret.Type, secretTypeToArtifact},
+		{"queue", cfg.Kestra.Queue.Type, queueTypeToArtifact},
+		{"repository", cfg.Kestra.Repository.Type, repositoryTypeToArtifact},
+	}
+
+	var ids []string
+	for _, c := range categories {
+		if c.typeVal == "" {
+			continue
+		}
+		artifact, ok := c.mapping[strings.ToLower(c.typeVal)]
+		if !ok {
+			return nil, fmt.Errorf("unknown kestra.%s.type %q — no known core plugin mapping (supported: %s)",
+				c.label, c.typeVal, strings.Join(sortedKeys(c.mapping), ", "))
+		}
+		if artifact == builtinType {
+			continue
+		}
+		ids = append(ids, artifact)
+	}
+	return ids, nil
+}
+
+// resolveCorePlugins fetches the compatibility list for the given version and
+// returns the pluginArtifact entries matching the required artifactIds, pinning
+// each to the version the API reports for that Kestra release.
+func resolveCorePlugins(kestraVersion string, license string, artifactIDs []string) ([]pluginArtifact, error) {
+	plugins, err := fetchPluginList(kestraVersion, license)
+	if err != nil {
+		return nil, err
+	}
+
+	byID := make(map[string]pluginArtifact, len(plugins))
+	for _, p := range plugins {
+		if _, exists := byID[p.ArtifactID]; !exists {
+			byID[p.ArtifactID] = p
+		}
+	}
+
+	var result []pluginArtifact
+	var missing []string
+	for _, id := range artifactIDs {
+		if p, ok := byID[id]; ok {
+			result = append(result, p)
+		} else {
+			missing = append(missing, id)
+		}
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("core plugin(s) not available for Kestra %s: %s — enterprise plugins require --edition ALL or EE",
+			kestraVersion, strings.Join(missing, ", "))
+	}
+	return result, nil
+}
+
+// corePluginsFromConfig is the end-to-end helper shared by "plugins list" and
+// "plugins download": it parses the config file(s), maps the configured
+// backends to plugin coordinates, and pins them to the given Kestra version.
+func corePluginsFromConfig(configPaths []string, kestraVersion string, license string) ([]pluginArtifact, error) {
+	cfg, err := loadKestraConfig(configPaths)
+	if err != nil {
+		return nil, err
+	}
+	ids, err := requiredArtifactIDs(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	return resolveCorePlugins(kestraVersion, license, ids)
+}
+
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/src/cli/bootstrap_test.go
+++ b/src/cli/bootstrap_test.go
@@ -1,0 +1,294 @@
+package cli
+
+import (
+	"bytes"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func writeConfig(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write config %q: %v", name, err)
+	}
+	return path
+}
+
+func TestRequiredArtifactIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  kestraConfig
+		want []string
+	}{
+		{
+			name: "storage and secret",
+			cfg: configWith(map[string]string{
+				"storage": "s3",
+				"secret":  "vault",
+			}),
+			want: []string{"storage-s3", "secret-vault"},
+		},
+		{
+			name: "bundled backends produce nothing",
+			cfg: configWith(map[string]string{
+				"storage":    "local",
+				"secret":     "jdbc",
+				"queue":      "postgres",
+				"repository": "postgres",
+			}),
+			want: nil,
+		},
+		{
+			name: "kafka queue is bundled, elasticsearch repository is a plugin",
+			cfg: configWith(map[string]string{
+				"queue":      "kafka",
+				"repository": "elasticsearch",
+			}),
+			want: []string{"plugin-ee-elasticsearch"},
+		},
+		{
+			name: "multi-word secret discriminators",
+			cfg: configWith(map[string]string{
+				"secret": "google-secret-manager",
+			}),
+			want: []string{"secret-googlecloud"},
+		},
+		{
+			name: "type matching is case-insensitive",
+			cfg: configWith(map[string]string{
+				"storage": "GCS",
+			}),
+			want: []string{"storage-gcs"},
+		},
+		{
+			name: "all four categories",
+			cfg: configWith(map[string]string{
+				"storage":    "azure",
+				"secret":     "azure-key-vault",
+				"queue":      "kafka",
+				"repository": "opensearch",
+			}),
+			want: []string{"storage-azure", "secret-azure", "plugin-ee-opensearch"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := requiredArtifactIDs(tt.cfg)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !equalUnordered(got, tt.want) {
+				t.Errorf("requiredArtifactIDs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRequiredArtifactIDs_UnknownType(t *testing.T) {
+	cfg := configWith(map[string]string{"storage": "ftp"})
+	_, err := requiredArtifactIDs(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown storage type, got nil")
+	}
+	if !strings.Contains(err.Error(), "kestra.storage.type") || !strings.Contains(err.Error(), "ftp") {
+		t.Errorf("error should name the offending key and value, got: %v", err)
+	}
+	// The error should list supported types to guide the user.
+	if !strings.Contains(err.Error(), "s3") {
+		t.Errorf("error should list supported types, got: %v", err)
+	}
+}
+
+func TestLoadKestraConfig_Merge(t *testing.T) {
+	base := writeConfig(t, "application.yaml", `
+kestra:
+  storage:
+    type: local
+  secret:
+    type: jdbc
+`)
+	override := writeConfig(t, "override.yaml", `
+kestra:
+  storage:
+    type: s3
+`)
+
+	cfg, err := loadKestraConfig([]string{base, override})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Kestra.Storage.Type != "s3" {
+		t.Errorf("storage type = %q, want s3 (override should win)", cfg.Kestra.Storage.Type)
+	}
+	if cfg.Kestra.Secret.Type != "jdbc" {
+		t.Errorf("secret type = %q, want jdbc (base should be preserved)", cfg.Kestra.Secret.Type)
+	}
+}
+
+func TestLoadKestraConfig_MissingFile(t *testing.T) {
+	_, err := loadKestraConfig([]string{filepath.Join(t.TempDir(), "nope.yaml")})
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot read config file") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestLoadKestraConfig_InvalidYAML(t *testing.T) {
+	path := writeConfig(t, "bad.yaml", "kestra:\n  storage:\n   type: : :")
+	_, err := loadKestraConfig([]string{path})
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot parse config file") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestCorePluginsFromConfig_ResolvesCoordinates(t *testing.T) {
+	newMockServers(t, http.StatusOK, pluginListPayloadCore)
+
+	path := writeConfig(t, "application.yaml", `
+kestra:
+  storage:
+    type: s3
+  secret:
+    type: vault
+  queue:
+    type: postgres
+  repository:
+    type: postgres
+`)
+
+	plugins, err := corePluginsFromConfig([]string{path}, "1.3.9", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := make(map[string]string)
+	for _, p := range plugins {
+		got[p.ArtifactID] = p.GroupID + ":" + p.ArtifactID + ":" + p.Version
+	}
+	if got["storage-s3"] != "io.kestra.storage:storage-s3:1.3.5" {
+		t.Errorf("storage-s3 coordinate = %q", got["storage-s3"])
+	}
+	if got["secret-vault"] != "io.kestra.ee.secret:secret-vault:1.3.9" {
+		t.Errorf("secret-vault coordinate = %q", got["secret-vault"])
+	}
+	if len(plugins) != 2 {
+		t.Errorf("expected exactly 2 core plugins (postgres queue/repo are bundled), got %d: %v", len(plugins), got)
+	}
+}
+
+func TestCorePluginsFromConfig_AllBundled(t *testing.T) {
+	newMockServers(t, http.StatusOK, pluginListPayloadCore)
+
+	path := writeConfig(t, "application.yaml", `
+kestra:
+  storage:
+    type: local
+  queue:
+    type: h2
+  repository:
+    type: h2
+`)
+
+	plugins, err := corePluginsFromConfig([]string{path}, "1.3.9", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(plugins) != 0 {
+		t.Errorf("expected no plugins when all backends are bundled, got %d", len(plugins))
+	}
+}
+
+func TestCorePluginsFromConfig_PluginMissingFromAPI(t *testing.T) {
+	// API list omits storage-s3, so resolution must fail loudly.
+	newMockServers(t, http.StatusOK, `[
+  {"groupId":"io.kestra.ee.secret","artifactId":"secret-vault","license":"ENTERPRISE","version":"1.3.9"}
+]`)
+
+	path := writeConfig(t, "application.yaml", `
+kestra:
+  storage:
+    type: s3
+`)
+
+	_, err := corePluginsFromConfig([]string{path}, "1.3.9", "")
+	if err == nil {
+		t.Fatal("expected error when a required plugin is absent from the API list, got nil")
+	}
+	if !strings.Contains(err.Error(), "storage-s3") || !strings.Contains(err.Error(), "edition") {
+		t.Errorf("error should name the missing plugin and hint at --edition, got: %v", err)
+	}
+}
+
+func TestRunPluginsList_FromConfig(t *testing.T) {
+	newMockServers(t, http.StatusOK, pluginListPayloadCore)
+
+	path := writeConfig(t, "application.yaml", `
+kestra:
+  storage:
+    type: gcs
+  secret:
+    type: vault
+`)
+
+	var out bytes.Buffer
+	if err := runPluginsList(&out, "1.3.9", "", "table", []string{path}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	line := strings.TrimSpace(out.String())
+	coords := strings.Fields(line)
+	sort.Strings(coords)
+	want := []string{"io.kestra.ee.secret:secret-vault:1.3.9", "io.kestra.storage:storage-gcs:1.1.4"}
+	if !equalUnordered(coords, want) {
+		t.Errorf("list --from-config output = %v, want %v", coords, want)
+	}
+}
+
+// configWith builds a kestraConfig from a category->type map for table tests.
+func configWith(types map[string]string) kestraConfig {
+	var cfg kestraConfig
+	cfg.Kestra.Storage.Type = types["storage"]
+	cfg.Kestra.Secret.Type = types["secret"]
+	cfg.Kestra.Queue.Type = types["queue"]
+	cfg.Kestra.Repository.Type = types["repository"]
+	return cfg
+}
+
+func equalUnordered(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	ac := append([]string(nil), a...)
+	bc := append([]string(nil), b...)
+	sort.Strings(ac)
+	sort.Strings(bc)
+	for i := range ac {
+		if ac[i] != bc[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// pluginListPayloadCore is a compatibility-API payload containing the core
+// storage/secret/repository backends exercised by the bootstrap tests.
+const pluginListPayloadCore = `[
+  {"groupId":"io.kestra.storage","artifactId":"storage-s3","license":"OPEN_SOURCE","version":"1.3.5"},
+  {"groupId":"io.kestra.storage","artifactId":"storage-gcs","license":"OPEN_SOURCE","version":"1.1.4"},
+  {"groupId":"io.kestra.storage","artifactId":"storage-azure","license":"OPEN_SOURCE","version":"1.2.0"},
+  {"groupId":"io.kestra.ee.secret","artifactId":"secret-vault","license":"ENTERPRISE","version":"1.3.9"},
+  {"groupId":"io.kestra.ee.secret","artifactId":"secret-azure","license":"ENTERPRISE","version":"1.3.9"},
+  {"groupId":"io.kestra.plugin.ee","artifactId":"plugin-ee-elasticsearch","license":"ENTERPRISE","version":"1.3.9"},
+  {"groupId":"io.kestra.plugin.ee","artifactId":"plugin-ee-opensearch","license":"ENTERPRISE","version":"1.3.9"},
+  {"groupId":"io.kestra.plugin","artifactId":"plugin-jdbc-postgres","license":"OPEN_SOURCE","version":"1.10.1"}
+]`

--- a/src/cli/bootstrap_test.go
+++ b/src/cli/bootstrap_test.go
@@ -167,7 +167,7 @@ kestra:
     type: postgres
 `)
 
-	plugins, err := corePluginsFromConfig([]string{path}, "1.3.9", "")
+	plugins, err := corePluginsFromConfig([]string{path}, "1.3.9")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -200,7 +200,7 @@ kestra:
     type: h2
 `)
 
-	plugins, err := corePluginsFromConfig([]string{path}, "1.3.9", "")
+	plugins, err := corePluginsFromConfig([]string{path}, "1.3.9")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -221,12 +221,12 @@ kestra:
     type: s3
 `)
 
-	_, err := corePluginsFromConfig([]string{path}, "1.3.9", "")
+	_, err := corePluginsFromConfig([]string{path}, "1.3.9")
 	if err == nil {
 		t.Fatal("expected error when a required plugin is absent from the API list, got nil")
 	}
-	if !strings.Contains(err.Error(), "storage-s3") || !strings.Contains(err.Error(), "edition") {
-		t.Errorf("error should name the missing plugin and hint at --edition, got: %v", err)
+	if !strings.Contains(err.Error(), "storage-s3") {
+		t.Errorf("error should name the missing plugin, got: %v", err)
 	}
 }
 
@@ -251,6 +251,51 @@ kestra:
 	want := []string{"io.kestra.ee.secret:secret-vault:1.3.9", "io.kestra.storage:storage-gcs:1.1.4"}
 	if !equalUnordered(coords, want) {
 		t.Errorf("list --from-config output = %v, want %v", coords, want)
+	}
+}
+
+func TestPluginsDownloadCommand_FromConfigAllBundled(t *testing.T) {
+	// An all-bundled config resolves to zero plugins. The command must report
+	// "nothing to download" and must NOT fall through to downloading the entire
+	// catalog. This path never touches the network, so no mock server is needed.
+	path := writeConfig(t, "application.yaml", `
+kestra:
+  storage:
+    type: local
+  queue:
+    type: postgres
+  repository:
+    type: postgres
+`)
+
+	cmd := newPluginsDownloadCommand()
+	out, err := executeCommand(cmd, "1.3.9", "--from-config", path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "No core plugins required") {
+		t.Errorf("expected 'No core plugins required' message, got:\n%s", out)
+	}
+	if strings.Contains(out, "Fetching plugin list") || strings.Contains(out, "Found ") {
+		t.Errorf("must not fall through to full-catalog download, got:\n%s", out)
+	}
+}
+
+func TestPluginsDownloadCommand_FromConfigPluginsMutuallyExclusive(t *testing.T) {
+	cmd := newPluginsDownloadCommand()
+	_, err := executeCommand(cmd, "1.3.9", "--from-config", "/tmp/x.yaml", "--plugins", "g:a:v")
+	if err == nil {
+		t.Fatal("expected error when --from-config and --plugins are both set")
+	}
+	if !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPluginsDownloadCommand_FromConfigFlag(t *testing.T) {
+	cmd := newPluginsDownloadCommand()
+	if cmd.Flags().Lookup("from-config") == nil {
+		t.Error("expected --from-config flag to exist on download")
 	}
 }
 

--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -139,10 +139,17 @@ Authentication:
 			case len(pluginsList) > 0:
 				explicit, err = parsePluginCoordinates(pluginsList)
 			case len(configPaths) > 0:
-				explicit, err = corePluginsFromConfig(configPaths, resolveVersion(version), license)
+				explicit, err = corePluginsFromConfig(configPaths, resolveVersion(version))
 			}
 			if err != nil {
 				return err
+			}
+			// When --from-config resolves to no plugins (every configured backend is
+			// bundled in Kestra), stop here: an empty explicit list would otherwise
+			// fall through to downloading the entire catalog.
+			if len(configPaths) > 0 && len(explicit) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No core plugins required by the provided configuration (all configured backends are bundled in Kestra).")
+				return nil
 			}
 			headers, _ := cmd.Root().PersistentFlags().GetStringArray(FlagHeader)
 			return runPluginsInstall(cmd.OutOrStdout(), version, pluginsDir, concurrency, forceRedownload, license, keepOnlyLastVersion, globalTimeout, mavenRepository, mavenUsername, mavenPassword, headers, explicit)
@@ -183,10 +190,15 @@ With --from-config, the list is restricted to the "core" plugins required to sta
 Kestra with the given configuration — the internal storage backend, the secret
 manager, and the queue/repository backend. This is the set a standalone worker
 needs before its task plugins. Bundled backends (local storage, JDBC, Kafka) emit
-no plugin. The output pipes directly into "plugins download --plugins":
+no plugin, and --edition is ignored (the exact set is taken from the config). The
+output pipes directly into "plugins download --plugins":
 
   kestractl plugins download 1.3.9 \
-    --plugins "$(kestractl plugins list 1.3.9 --from-config /etc/kestra/application.yaml)"`,
+    --plugins "$(kestractl plugins list 1.3.9 --from-config /etc/kestra/application.yaml)"
+
+Note: enterprise backends (external secret managers, Elasticsearch/OpenSearch)
+are not published to Maven Central — pass --maven-repository (and credentials)
+pointing at Kestra's plugin registry to download them.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateOutputFormat(); err != nil {
@@ -212,7 +224,7 @@ func runPluginsList(out io.Writer, kestraVersion string, license string, outputF
 	var plugins []pluginArtifact
 	var err error
 	if len(configPaths) > 0 {
-		plugins, err = corePluginsFromConfig(configPaths, kestraVersion, license)
+		plugins, err = corePluginsFromConfig(configPaths, kestraVersion)
 	} else {
 		plugins, err = fetchPluginList(kestraVersion, license)
 	}

--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -71,6 +71,7 @@ func newPluginsDownloadCommand() *cobra.Command {
 	var mavenUsername string
 	var mavenPassword string
 	var pluginsList []string
+	var configPaths []string
 
 	cmd := &cobra.Command{
 		Use:   "download [version]",
@@ -114,7 +115,7 @@ Authentication:
 		Args: func(cmd *cobra.Command, args []string) error {
 			hasPlugins, _ := cmd.Flags().GetStringArray("plugins")
 			if len(hasPlugins) == 0 && len(args) == 0 {
-				return fmt.Errorf("requires a version argument when --plugins is not set")
+				return fmt.Errorf("requires a version argument (the version is only optional when --plugins is set)")
 			}
 			if len(args) > 1 {
 				return fmt.Errorf("accepts at most 1 arg, received %d", len(args))
@@ -126,16 +127,22 @@ Authentication:
 			if err != nil {
 				return err
 			}
-			var explicit []pluginArtifact
-			if len(pluginsList) > 0 {
-				explicit, err = parsePluginCoordinates(pluginsList)
-				if err != nil {
-					return err
-				}
+			if len(pluginsList) > 0 && len(configPaths) > 0 {
+				return fmt.Errorf("--plugins and --from-config are mutually exclusive")
 			}
 			version := ""
 			if len(args) > 0 {
 				version = args[0]
+			}
+			var explicit []pluginArtifact
+			switch {
+			case len(pluginsList) > 0:
+				explicit, err = parsePluginCoordinates(pluginsList)
+			case len(configPaths) > 0:
+				explicit, err = corePluginsFromConfig(configPaths, resolveVersion(version), license)
+			}
+			if err != nil {
+				return err
 			}
 			headers, _ := cmd.Root().PersistentFlags().GetStringArray(FlagHeader)
 			return runPluginsInstall(cmd.OutOrStdout(), version, pluginsDir, concurrency, forceRedownload, license, keepOnlyLastVersion, globalTimeout, mavenRepository, mavenUsername, mavenPassword, headers, explicit)
@@ -153,11 +160,13 @@ Authentication:
 	cmd.Flags().StringVar(&mavenUsername, "maven-username", "", "Username for Maven repository basic authentication")
 	cmd.Flags().StringVar(&mavenPassword, "maven-password", "", "Password for Maven repository basic authentication")
 	cmd.Flags().StringArrayVar(&pluginsList, "plugins", nil, "Explicit list of plugins to download as groupId:artifactId:version (space-separated or repeated flag; bypasses API lookup)")
+	cmd.Flags().StringArrayVar(&configPaths, "from-config", nil, "Download only the core plugins (storage, secret manager, queue/repository backend) required by one or more Kestra configuration files; requires a version argument")
 	return cmd
 }
 
 func newPluginsListCommand() *cobra.Command {
 	var edition string
+	var configPaths []string
 
 	cmd := &cobra.Command{
 		Use:   "list <version>",
@@ -168,7 +177,16 @@ Output format matches the legacy npx @kestra-io/kestra-devtools getCompatiblePlu
 command: a single space-separated line of groupId:artifactId:version coordinates.
 
 With --output json the full plugin metadata (groupId, artifactId, license, version)
-is printed as a JSON array.`,
+is printed as a JSON array.
+
+With --from-config, the list is restricted to the "core" plugins required to start
+Kestra with the given configuration — the internal storage backend, the secret
+manager, and the queue/repository backend. This is the set a standalone worker
+needs before its task plugins. Bundled backends (local storage, JDBC, Kafka) emit
+no plugin. The output pipes directly into "plugins download --plugins":
+
+  kestractl plugins download 1.3.9 \
+    --plugins "$(kestractl plugins list 1.3.9 --from-config /etc/kestra/application.yaml)"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateOutputFormat(); err != nil {
@@ -178,19 +196,26 @@ is printed as a JSON array.`,
 			if err != nil {
 				return err
 			}
-			return runPluginsList(cmd.OutOrStdout(), args[0], license, globalFlags.Output)
+			return runPluginsList(cmd.OutOrStdout(), args[0], license, globalFlags.Output, configPaths)
 		},
 		Annotations: map[string]string{AnnotationOffline: "true"},
 	}
 
 	cmd.Flags().StringVar(&edition, "edition", "ALL", "Edition to list: ALL, OSS (open-source only), or EE (enterprise only)")
+	cmd.Flags().StringArrayVar(&configPaths, "from-config", nil, "Derive the required core plugins (storage, secret manager, queue/repository backend) from one or more Kestra configuration files")
 	return cmd
 }
 
-func runPluginsList(out io.Writer, kestraVersion string, license string, outputFormat string) error {
+func runPluginsList(out io.Writer, kestraVersion string, license string, outputFormat string, configPaths []string) error {
 	kestraVersion = resolveVersion(kestraVersion)
 
-	plugins, err := fetchPluginList(kestraVersion, license)
+	var plugins []pluginArtifact
+	var err error
+	if len(configPaths) > 0 {
+		plugins, err = corePluginsFromConfig(configPaths, kestraVersion, license)
+	} else {
+		plugins, err = fetchPluginList(kestraVersion, license)
+	}
 	if err != nil {
 		return err
 	}

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -791,7 +791,7 @@ func TestRunPluginsList_DefaultOutput(t *testing.T) {
 	newMockServers(t, http.StatusOK, pluginListPayload)
 
 	var out bytes.Buffer
-	if err := runPluginsList(&out, "1.3.9", "", "table"); err != nil {
+	if err := runPluginsList(&out, "1.3.9", "", "table", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -824,7 +824,7 @@ func TestRunPluginsList_JSONOutput(t *testing.T) {
 	newMockServers(t, http.StatusOK, pluginListPayload)
 
 	var out bytes.Buffer
-	if err := runPluginsList(&out, "1.3.9", "", "json"); err != nil {
+	if err := runPluginsList(&out, "1.3.9", "", "json", nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -846,7 +846,7 @@ func TestRunPluginsList_APIError(t *testing.T) {
 	newMockServers(t, http.StatusNotFound, `{"message":"version not found"}`)
 
 	var out bytes.Buffer
-	err := runPluginsList(&out, "99.99.99", "", "table")
+	err := runPluginsList(&out, "99.99.99", "", "table", nil)
 	if err == nil {
 		t.Fatal("expected error for HTTP 404, got nil")
 	}


### PR DESCRIPTION
## What

Adds a `--from-config` flag to `plugins download` and `plugins list` that derives the **core** plugins a standalone/remote worker needs to start, directly from one or more Kestra configuration files:

- internal storage backend (`kestra.storage.type`)
- secret manager (`kestra.secret.type`)
- queue/repository backend (`kestra.queue.type` / `kestra.repository.type`)

This is the minimum infrastructure plugin set a binary-only worker needs before its task plugins — the gap described in the issue, where these "core" plugins are not well documented and customers have to figure them out manually.

```bash
# Download just the core plugins a config requires
kestractl plugins download 1.3.9 --from-config /etc/kestra/application.yaml

# Or preview them (pipes into download)
kestractl plugins list 1.3.9 --from-config /etc/kestra/application.yaml
```

## How

- New `src/cli/bootstrap.go`: curated `(category, type) → artifactId` maps, with discriminator strings taken from the Kestra runtime/storage and secrets-manager docs (e.g. `aws-secret-manager → secret-aws`, `google-secret-manager → secret-googlecloud`, `repository.type: elasticsearch → plugin-ee-elasticsearch`).
- Bundled backends (`local` storage, JDBC, `kafka` queue) map to a sentinel and are skipped — no plugin emitted.
- Unknown types **error loudly** with the supported list, so a typo or a new backend surfaces instead of silently resolving to "no plugins".
- Multi-file merge (last non-empty type wins, matching Micronaut precedence for these scalars).
- Coordinates + versions resolved against the existing compatibility API (`fetchPluginList`) and fed into the existing `runPluginsInstall` path — **no new download/retry/prune code**.
- `--from-config` and `--plugins` are mutually exclusive; a version argument is required.

## Tests

- New `bootstrap_test.go`: config parsing (merge, missing file, invalid YAML), the mapping table incl. case-insensitivity, multi-word discriminators, bundled-skip, unknown-type error, missing-from-API error, and `list --from-config` via an `httptest` mock.
- Full suite green (284 tests).
- Smoke-tested against the live `api.kestra.io` compatibility API.

## Note for reviewers

Kafka queue is treated as **bundled** (no `plugin-ee-kafka` exists in the compatibility API); Elasticsearch/OpenSearch repository are treated as plugins. If the EE Kafka runner is actually a separate downloadable artifact, it's a one-line table edit in `bootstrap.go`.

Closes kestra-io/kestra-ee#5343

🤖 Generated with [Claude Code](https://claude.com/claude-code)