### PR TITLE
ci: trigger release on v-prefixed tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,7 @@ name: Release
 on:
   push:
     tags:
-      # NOTE: tag format here is bare (e.g. 1.3.0), whereas
-      # terraform-provider-kestra uses a "v" prefix (v1.3.0). To unify the
-      # release workflow across repos later, settle on one convention.
-      - "*"
+      - "v*"
 
 permissions:
   contents: write


### PR DESCRIPTION
## What
Switch the release trigger to v-prefixed tags (`v1.3.0`), tightening the glob from `"*"` to `"v*"`. Same change as #74, applied to this release branch.

## Why
Unifies the tag/release convention across repos — terraform-provider-kestra already uses `v`-prefixed tags. Also avoids firing a release on any non-version tag.

## Code impact
None. GoReleaser strips the leading `v` for `{{.Version}}`, so version output and artifact names are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)