### PR TITLE
feat: expand Kestra SDK command coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,6 +629,22 @@ kestractl assets create --name my-asset --file asset.csv
 
 # Delete an asset (alias: rm)
 kestractl assets delete <id>
+
+# Show an asset's dependency graph (alias: deps)
+kestractl assets dependencies <id> --expand-all --output json
+
+# Bulk-delete assets by IDs or by query filters
+kestractl assets delete-by-ids id1 id2 id3
+kestractl assets delete-by-query --namespace my.namespace
+kestractl assets delete-by-query --filter NAMESPACE:EQUALS:my.namespace --purge
+
+# Inspect and manage lineage events (alias: lineage)
+kestractl assets lineage-events list --output json
+kestractl assets lineage-events delete-by-query --namespace my.namespace
+
+# Inspect and manage asset usages (alias: usage)
+kestractl assets usages list --output json
+kestractl assets usages delete-by-query --namespace my.namespace
 ```
 
 ### Blueprints

--- a/README.md
+++ b/README.md
@@ -760,6 +760,10 @@ kestractl users change-my-password --old-password 'OldPass!' --new-password 'N3w
 kestractl users set-super-admin <user_id> --superadmin
 kestractl users set-super-admin <user_id> --superadmin=false
 
+# Mark a user as restricted, or lift the restriction (targeted PATCH)
+kestractl users set-restricted <user_id> --restricted=true
+kestractl users set-restricted <user_id> --restricted=false
+
 # Delete an auth method for a user
 kestractl users delete-auth-method <user_id> BASIC_AUTH
 

--- a/README.md
+++ b/README.md
@@ -543,6 +543,24 @@ kestractl dashboards update <id> --file my-dashboard.yaml
 
 # Delete a dashboard (alias: rm)
 kestractl dashboards delete <id>
+
+# Show the tenant's default dashboard settings
+kestractl dashboards defaults
+
+# Validate a dashboard or a single chart definition
+kestractl dashboards validate --file my-dashboard.yaml
+kestractl dashboards validate-chart --file my-chart.yaml
+
+# Preview a chart's data without saving it
+kestractl dashboards preview-chart --file my-chart.yaml --output json
+
+# Fetch the data for a chart of an existing dashboard
+kestractl dashboards chart-data <dashboard-id> <chart-id>
+kestractl dashboards chart-data <dashboard-id> <chart-id> --file filters.yaml --output json
+
+# Export chart data as CSV (to stdout or --output-file)
+kestractl dashboards export-chart-csv --file my-chart.yaml --output-file chart.csv
+kestractl dashboards export-chart-data-csv <dashboard-id> <chart-id> --output-file chart.csv
 ```
 
 ### Apps (Enterprise Edition)

--- a/README.md
+++ b/README.md
@@ -575,6 +575,25 @@ kestractl apps export --output-file apps.zip
 
 # Import apps from a ZIP archive
 kestractl apps import apps.zip
+
+# Bulk enable / disable / delete multiple apps
+kestractl apps bulk-enable  uid-1 uid-2 uid-3
+kestractl apps bulk-disable uid-1 uid-2 uid-3
+kestractl apps bulk-delete  uid-1 uid-2 --yes
+
+# List all tags used across apps
+kestractl apps tags
+
+# Search apps from the catalog
+kestractl apps catalog
+kestractl apps catalog --query reporting --output json
+
+# Inspect files produced by an app execution view
+kestractl apps file-meta    <view-id> --path /path/to/file
+kestractl apps file-preview <view-id> --path /path/to/file --max-rows 50
+
+# Download logs for an app execution
+kestractl apps logs <view-id> --min-level ERROR --output-file app.log
 ```
 
 ### Assets (Enterprise Edition)

--- a/README.md
+++ b/README.md
@@ -626,12 +626,26 @@ kestractl blueprints community get <id>
 # Get the flow source of a community blueprint
 kestractl blueprints community source <id>
 
+# Get the topology graph of a community blueprint
+kestractl blueprints community graph <id> --output json
+
 # Manage internal flow blueprints (Enterprise Edition)
 kestractl blueprints flow list
 kestractl blueprints flow get <id>
-kestractl blueprints flow create --file blueprint.yaml
-kestractl blueprints flow update <id> --file blueprint.yaml
+kestractl blueprints flow get <id> --legacy   # use the legacy /blueprints/flow/{id} endpoint
+kestractl blueprints flow create --title "My Blueprint" --source-file blueprint.yaml --tag etl
+kestractl blueprints flow update <id> --title "My Blueprint" --source-file blueprint.yaml
 kestractl blueprints flow delete <id>
+
+# Generate a flow source from a flow blueprint template
+kestractl blueprints flow use-template <id> --input env=prod --input region=eu
+
+# Manage internal/custom blueprints (Enterprise Edition)
+kestractl blueprints custom get <id>
+kestractl blueprints custom source <id>
+kestractl blueprints custom create --title "My Blueprint" --source-file blueprint.yaml
+kestractl blueprints custom update <id> --title "My Blueprint" --source-file blueprint.yaml
+kestractl blueprints custom delete <id>
 ```
 
 ### Test Suites (Enterprise Edition)

--- a/README.md
+++ b/README.md
@@ -206,6 +206,9 @@ kestractl flows bulk-update --file flows.yaml
 # Generate the graph topology from a flow source file
 kestractl flows generate-graph-from-source --file flow.yaml
 
+# Show the graph topology of an existing flow (optionally a specific revision)
+kestractl flows graph my.namespace my-flow --revision 3 --output json
+
 # List available expressions for a flow
 kestractl flows expressions --namespace my.namespace --flow my-flow
 

--- a/README.md
+++ b/README.md
@@ -305,8 +305,10 @@ kestractl executions update-status-by-query --namespace my.namespace --new-statu
 # Filter by any field with --filter FIELD:OPERATION:VALUE (e.g. STATE:EQUALS:SUCCESS)
 kestractl executions kill-by-query --filter STATE:EQUALS:RUNNING
 
-# Trigger an execution via webhook
+# Trigger an execution via webhook (--method GET|POST|PUT, --path appends a URL suffix)
 kestractl executions trigger-webhook my.namespace my-flow my-webhook-key
+kestractl executions trigger-webhook my.namespace my-flow my-webhook-key --method POST
+kestractl executions trigger-webhook my.namespace my-flow my-webhook-key --method PUT --path extra/segment
 
 # Flow graph and info
 kestractl executions flow-graph 2TLGqHrXC9k8BczKJe5djX

--- a/src/cli/apps.go
+++ b/src/cli/apps.go
@@ -29,6 +29,14 @@ Apps are low-code interfaces built on top of flows. Requires Kestra Enterprise E
 	cmd.AddCommand(newAppsDisableCommand())
 	cmd.AddCommand(newAppsExportCommand())
 	cmd.AddCommand(newAppsImportCommand())
+	cmd.AddCommand(newAppsBulkDeleteCommand())
+	cmd.AddCommand(newAppsBulkEnableCommand())
+	cmd.AddCommand(newAppsBulkDisableCommand())
+	cmd.AddCommand(newAppsTagsCommand())
+	cmd.AddCommand(newAppsCatalogCommand())
+	cmd.AddCommand(newAppsFileMetaCommand())
+	cmd.AddCommand(newAppsFilePreviewCommand())
+	cmd.AddCommand(newAppsLogsCommand())
 
 	return cmd
 }
@@ -456,4 +464,426 @@ func runAppsImport(client *Client, filePath string, renderer *Renderer) error {
 		}
 		return nil
 	})
+}
+
+// --- Bulk operations ---------------------------------------------------------
+
+func newAppsBulkDeleteCommand() *cobra.Command {
+	var skipConfirm bool
+
+	cmd := &cobra.Command{
+		Use:   "bulk-delete <uid> [<uid>...]",
+		Short: "Delete multiple apps in a single request.",
+		Args:  cobra.MinimumNArgs(1),
+		Example: `  kestractl apps bulk-delete uid-1 uid-2 uid-3
+  kestractl apps bulk-delete uid-1 uid-2 --yes`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAppsBulkDelete(client, args, skipConfirm, cmd.InOrStdin(), renderer)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation prompt")
+	return cmd
+}
+
+func runAppsBulkDelete(client *Client, uids []string, skipConfirm bool, in io.Reader, renderer *Renderer) error {
+	if !skipConfirm {
+		confirmed, err := confirm(in, os.Stderr,
+			fmt.Sprintf("Are you sure you want to delete %d app(s)? [y/N]: ", len(uids)))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return renderStatus(renderer, "Cancelled.", map[string]any{"status": "cancelled"})
+		}
+	}
+
+	req := kestra.NewAppsControllerApiBulkOperationRequest()
+	req.SetUids(uids)
+
+	resp, err := client.Kestra.Apps().BulkDeleteApps(client.Ctx, client.Tenant, req)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderBulkAppsResult(renderer, resp, fmt.Sprintf("%d app(s) deleted.", len(uids)))
+}
+
+func newAppsBulkEnableCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "bulk-enable <uid> [<uid>...]",
+		Short:   "Enable multiple apps in a single request.",
+		Args:    cobra.MinimumNArgs(1),
+		Example: `  kestractl apps bulk-enable uid-1 uid-2 uid-3`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAppsBulkToggle(client, args, true, renderer)
+		},
+	}
+	return cmd
+}
+
+func newAppsBulkDisableCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "bulk-disable <uid> [<uid>...]",
+		Short:   "Disable multiple apps in a single request.",
+		Args:    cobra.MinimumNArgs(1),
+		Example: `  kestractl apps bulk-disable uid-1 uid-2 uid-3`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAppsBulkToggle(client, args, false, renderer)
+		},
+	}
+	return cmd
+}
+
+func runAppsBulkToggle(client *Client, uids []string, enable bool, renderer *Renderer) error {
+	req := kestra.NewAppsControllerApiBulkOperationRequest()
+	req.SetUids(uids)
+
+	var (
+		resp map[string]interface{}
+		err  error
+	)
+	if enable {
+		resp, err = client.Kestra.Apps().BulkEnableApps(client.Ctx, client.Tenant, req)
+	} else {
+		resp, err = client.Kestra.Apps().BulkDisableApps(client.Ctx, client.Tenant, req)
+	}
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	action := "disabled"
+	if enable {
+		action = "enabled"
+	}
+	return renderBulkAppsResult(renderer, resp, fmt.Sprintf("%d app(s) %s.", len(uids), action))
+}
+
+// renderBulkAppsResult renders the generic map returned by the bulk app
+// endpoints: a human-readable summary for table output, the raw payload for JSON.
+func renderBulkAppsResult(renderer *Renderer, resp map[string]interface{}, message string) error {
+	if renderer.IsJSON() {
+		if resp == nil {
+			resp = map[string]interface{}{}
+		}
+		return renderer.RenderJSON(resp)
+	}
+	return renderer.Render(resp, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, message)
+		return nil
+	})
+}
+
+// --- Tags & catalog ----------------------------------------------------------
+
+func newAppsTagsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "tags",
+		Short:   "List all tags used across apps.",
+		Example: `  kestractl apps tags`,
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAppsTags(client, renderer)
+		},
+	}
+	return cmd
+}
+
+func runAppsTags(client *Client, renderer *Renderer) error {
+	resp, err := client.Kestra.Apps().ListTags(client.Ctx, client.Tenant)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	tags := []string{}
+	if resp != nil {
+		tags = resp.GetTags()
+	}
+
+	return renderer.Render(tags, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "TAG")
+		for _, t := range tags {
+			fmt.Fprintln(w, t)
+		}
+		fmt.Fprintf(w, "\nTotal tags: %d\n", len(tags))
+		return nil
+	})
+}
+
+func newAppsCatalogCommand() *cobra.Command {
+	var (
+		query string
+		page  int32
+		size  int32
+	)
+
+	cmd := &cobra.Command{
+		Use:   "catalog",
+		Short: "Search apps available in the catalog.",
+		Example: `  kestractl apps catalog
+  kestractl apps catalog --query reporting --output json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAppsCatalog(client, query, page, size, renderer)
+		},
+	}
+
+	cmd.Flags().StringVarP(&query, "query", "q", "", "Filter by query string")
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
+	return cmd
+}
+
+func runAppsCatalog(client *Client, query string, page, size int32, renderer *Renderer) error {
+	pageInt, sizeInt := int(page), int(size)
+
+	var filters []kestra.SearchFilter
+	if query != "" {
+		filters = append(filters, kestra.SearchFilter{
+			Field:     kestra.FilterQuery,
+			Operation: kestra.OpEquals,
+			Value:     query,
+		})
+	}
+
+	resp, err := client.Kestra.Apps().SearchAppsFromCatalog(client.Ctx, client.Tenant, &pageInt, &sizeInt, filters)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	if resp == nil {
+		resp = &kestra.PagedResultsAppsControllerApiAppCatalogItem{}
+	}
+
+	results := resp.GetResults()
+	if results == nil {
+		results = []kestra.AppsControllerApiAppCatalogItem{}
+	}
+
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "UID\tNAME\tTYPE\tTAGS\tDESCRIPTION")
+		for _, c := range results {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				c.GetUid(), c.GetName(), c.GetType(),
+				strings.Join(c.GetTags(), ","), c.GetDescription())
+		}
+		fmt.Fprintf(w, "\nTotal catalog apps: %d\n", resp.GetTotal())
+		return nil
+	})
+}
+
+// --- App execution view (files & logs) ---------------------------------------
+
+func newAppsFileMetaCommand() *cobra.Command {
+	var path string
+
+	cmd := &cobra.Command{
+		Use:   "file-meta <id>",
+		Short: "Get metadata for a file produced by an app execution.",
+		Long:  "Get metadata (e.g. size) for a file referenced by an app execution view.",
+		Args:  cobra.ExactArgs(1),
+		Example: `  kestractl apps file-meta <view-id> --path /path/to/file`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if path == "" {
+				return fmt.Errorf("--path is required")
+			}
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAppsFileMeta(client, args[0], path, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "Internal storage path of the file (required)")
+	return cmd
+}
+
+func runAppsFileMeta(client *Client, id, path string, renderer *Renderer) error {
+	meta, err := client.Kestra.Apps().FileMetaFromAppExecution(client.Ctx, id, client.Tenant, path)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderer.Render(meta, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "File Metadata")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "Path:\t%s\n", path)
+		if meta != nil {
+			fmt.Fprintf(w, "Size:\t%d\n", meta.GetSize())
+		}
+		return nil
+	})
+}
+
+func newAppsFilePreviewCommand() *cobra.Command {
+	var (
+		path     string
+		maxRows  int
+		encoding string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "file-preview <id>",
+		Short: "Preview a file produced by an app execution.",
+		Long:  "Preview the content of a file referenced by an app execution view.",
+		Args:  cobra.ExactArgs(1),
+		Example: `  kestractl apps file-preview <view-id> --path /path/to/file
+  kestractl apps file-preview <view-id> --path /path/to/file --max-rows 50`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if path == "" {
+				return fmt.Errorf("--path is required")
+			}
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			var maxRowsPtr *int
+			if cmd.Flags().Changed("max-rows") {
+				maxRowsPtr = &maxRows
+			}
+			var encodingPtr *string
+			if encoding != "" {
+				encodingPtr = &encoding
+			}
+			return runAppsFilePreview(client, args[0], path, maxRowsPtr, encodingPtr, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&path, "path", "", "Internal storage path of the file (required)")
+	cmd.Flags().IntVar(&maxRows, "max-rows", 0, "Maximum number of rows to preview")
+	cmd.Flags().StringVar(&encoding, "encoding", "", "File encoding (e.g. UTF-8)")
+	return cmd
+}
+
+func runAppsFilePreview(client *Client, id, path string, maxRows *int, encoding *string, renderer *Renderer) error {
+	preview, err := client.Kestra.Apps().FilePreviewFromAppExecution(client.Ctx, id, client.Tenant, path, maxRows, encoding)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	if preview == nil {
+		preview = map[string]interface{}{}
+	}
+
+	return renderer.Render(preview, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, toPrettyString(preview))
+		return nil
+	})
+}
+
+func newAppsLogsCommand() *cobra.Command {
+	var (
+		executionID string
+		minLevel    string
+		taskIDs     []string
+		outputFile  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "logs <id>",
+		Short: "Download logs for an app execution.",
+		Long: `Download the logs produced by an app execution view as plain text.
+
+By default the logs are streamed to stdout. Use --output-file to write them
+to a file instead.`,
+		Args: cobra.ExactArgs(1),
+		Example: `  kestractl apps logs <view-id>
+  kestractl apps logs <view-id> --execution-id <exec-id> --min-level ERROR
+  kestractl apps logs <view-id> --output-file app.log`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			var execPtr *string
+			if executionID != "" {
+				execPtr = &executionID
+			}
+			var levelPtr *string
+			if minLevel != "" {
+				upper := strings.ToUpper(minLevel)
+				levelPtr = &upper
+			}
+			return runAppsLogs(client, args[0], execPtr, levelPtr, taskIDs, outputFile, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().StringVar(&executionID, "execution-id", "", "Filter logs by app execution ID")
+	cmd.Flags().StringVar(&minLevel, "min-level", "", "Minimum log level (e.g. TRACE, DEBUG, INFO, WARN, ERROR)")
+	cmd.Flags().StringArrayVar(&taskIDs, "task-id", nil, "Filter logs by task ID (repeatable)")
+	cmd.Flags().StringVarP(&outputFile, "output-file", "f", "", "Write logs to this file instead of stdout")
+	return cmd
+}
+
+func runAppsLogs(client *Client, id string, executionID, minLevel *string, taskIDs []string, outputFile string, out io.Writer) error {
+	file, err := client.Kestra.Apps().LogsFromAppExecution(client.Ctx, id, client.Tenant, executionID, minLevel, taskIDs)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	defer cleanupNamespaceTempFile(file)
+
+	dst := out
+	if outputFile != "" {
+		f, err := os.Create(outputFile)
+		if err != nil {
+			return fmt.Errorf("failed to create output file %q: %w", outputFile, err)
+		}
+		defer f.Close()
+		dst = f
+	}
+
+	if _, err := io.Copy(dst, file); err != nil {
+		return fmt.Errorf("failed to write logs: %w", err)
+	}
+	if outputFile != "" {
+		fmt.Fprintf(out, "Logs for app execution '%s' written to %s\n", id, outputFile)
+	}
+	return nil
 }

--- a/src/cli/apps_test.go
+++ b/src/cli/apps_test.go
@@ -392,6 +392,256 @@ func TestRunAppsImport_WithErrors(t *testing.T) {
 	}
 }
 
+func TestAppsCommand_Structure_NewSubcommands(t *testing.T) {
+	cmd := newAppsCommand()
+	subNames := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	for _, want := range []string{"bulk-delete", "bulk-enable", "bulk-disable", "tags", "catalog", "file-meta", "file-preview", "logs"} {
+		if !subNames[want] {
+			t.Errorf("expected subcommand %q to exist", want)
+		}
+	}
+}
+
+func TestRunAppsBulkDelete_Confirmed(t *testing.T) {
+	var gotBody []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":2}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAppsBulkDelete(newTestClient(t, server.URL), []string{"uid-1", "uid-2"}, false, strings.NewReader("y\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAppsBulkDelete error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "2 app(s) deleted") {
+		t.Errorf("expected deletion message, got:\n%s", buf.String())
+	}
+	if !strings.Contains(string(gotBody), "uid-1") || !strings.Contains(string(gotBody), "uid-2") {
+		t.Errorf("expected uids in request body, got: %s", gotBody)
+	}
+}
+
+func TestRunAppsBulkDelete_Cancelled(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAppsBulkDelete(newTestClient(t, server.URL), []string{"uid-1"}, false, strings.NewReader("n\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAppsBulkDelete error: %v", err)
+	}
+	if hit {
+		t.Error("expected no API request when cancelled")
+	}
+	if !strings.Contains(buf.String(), "Cancelled") {
+		t.Errorf("expected cancellation message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunAppsBulkToggle_Enable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/apps/enable") {
+			t.Errorf("expected enable path, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":3}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAppsBulkToggle(newTestClient(t, server.URL), []string{"a", "b", "c"}, true, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAppsBulkToggle error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "3 app(s) enabled") {
+		t.Errorf("expected enabled message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunAppsBulkToggle_Disable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/apps/disable") {
+			t.Errorf("expected disable path, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAppsBulkToggle(newTestClient(t, server.URL), []string{"a"}, false, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAppsBulkToggle error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "1 app(s) disabled") {
+		t.Errorf("expected disabled message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunAppsTags(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tags":["prod","reporting","internal"]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAppsTags(newTestClient(t, server.URL), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAppsTags error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"prod", "reporting", "internal", "Total tags: 3"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunAppsCatalog(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[
+			{"uid":"cat-1","name":"Reporting","type":"DASHBOARD","tags":["analytics"],"description":"A report app"}
+		],"total":1}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAppsCatalog(newTestClient(t, server.URL), "report", 1, 100, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAppsCatalog error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"cat-1", "Reporting", "DASHBOARD", "analytics", "Total catalog apps: 1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunAppsFileMeta(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("path"); got != "/my/file.csv" {
+			t.Errorf("expected path query, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"size":2048}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAppsFileMeta(newTestClient(t, server.URL), "view-1", "/my/file.csv", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAppsFileMeta error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"/my/file.csv", "2048"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAppsFileMetaCommand_NoPath(t *testing.T) {
+	cmd := newAppsFileMetaCommand()
+	_, err := executeCommand(cmd, "view-1")
+	if err == nil {
+		t.Fatal("expected error when --path is missing")
+	}
+	if !strings.Contains(err.Error(), "--path is required") {
+		t.Fatalf("expected --path error, got: %v", err)
+	}
+}
+
+func TestRunAppsFilePreview(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("maxRows"); got != "10" {
+			t.Errorf("expected maxRows=10, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"type":"csv","content":["a","b"]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	maxRows := 10
+	err := runAppsFilePreview(newTestClient(t, server.URL), "view-1", "/my/file.csv", &maxRows, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAppsFilePreview error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "csv") {
+		t.Errorf("expected preview content, got:\n%s", buf.String())
+	}
+}
+
+func TestRunAppsLogs_ToStdout(t *testing.T) {
+	logContent := "2024-01-01 INFO some log line\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("minLevel"); got != "ERROR" {
+			t.Errorf("expected minLevel=ERROR, got %q", got)
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(logContent))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	level := "ERROR"
+	err := runAppsLogs(newTestClient(t, server.URL), "view-1", nil, &level, nil, "", &buf)
+	if err != nil {
+		t.Fatalf("runAppsLogs error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "some log line") {
+		t.Errorf("expected log content, got:\n%s", buf.String())
+	}
+}
+
+func TestRunAppsLogs_ToFile(t *testing.T) {
+	logContent := "log file content\n"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(logContent))
+	}))
+	t.Cleanup(server.Close)
+
+	tmpFile, err := os.CreateTemp("", "app-logs-*.log")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
+
+	var buf bytes.Buffer
+	err = runAppsLogs(newTestClient(t, server.URL), "view-1", nil, nil, nil, tmpFile.Name(), &buf)
+	if err != nil {
+		t.Fatalf("runAppsLogs error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "written to") {
+		t.Errorf("expected written message, got:\n%s", buf.String())
+	}
+	written, _ := os.ReadFile(tmpFile.Name())
+	if !strings.Contains(string(written), "log file content") {
+		t.Errorf("file content mismatch: %s", written)
+	}
+}
+
 func TestAppsListCommand_ClientError(t *testing.T) {
 	original := newClientFunc
 	newClientFunc = func() (*Client, error) {

--- a/src/cli/assets.go
+++ b/src/cli/assets.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"text/tabwriter"
 
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
 	"github.com/spf13/cobra"
 )
 
@@ -22,6 +23,11 @@ Assets are data-catalog entities tracked for lineage and dependency analysis. Re
 	cmd.AddCommand(newAssetsGetCommand())
 	cmd.AddCommand(newAssetsCreateCommand())
 	cmd.AddCommand(newAssetsDeleteCommand())
+	cmd.AddCommand(newAssetsDependenciesCommand())
+	cmd.AddCommand(newAssetsDeleteByIdsCommand())
+	cmd.AddCommand(newAssetsDeleteByQueryCommand())
+	cmd.AddCommand(newAssetsLineageEventsCommand())
+	cmd.AddCommand(newAssetsUsagesCommand())
 
 	return cmd
 }
@@ -211,4 +217,325 @@ func runAssetsDelete(client *Client, id string, skipConfirm bool, in io.Reader, 
 
 	return renderStatus(renderer, fmt.Sprintf("Asset '%s' deleted.", id),
 		map[string]any{"id": id, "status": "deleted"})
+}
+
+func newAssetsDependenciesCommand() *cobra.Command {
+	var (
+		destinationOnly bool
+		expandAll       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:     "dependencies <id>",
+		Short:   "Show the dependency graph of an asset.",
+		Aliases: []string{"deps"},
+		Args:    cobra.ExactArgs(1),
+		Example: `  kestractl assets dependencies <id>
+  kestractl assets dependencies <id> --expand-all --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAssetsDependencies(client, args[0], destinationOnly, expandAll, renderer)
+		},
+	}
+
+	cmd.Flags().BoolVar(&destinationOnly, "destination-only", false, "Only include downstream (destination) dependencies")
+	cmd.Flags().BoolVar(&expandAll, "expand-all", false, "Expand all transitive dependencies")
+	return cmd
+}
+
+func runAssetsDependencies(client *Client, id string, destinationOnly, expandAll bool, renderer *Renderer) error {
+	graph, err := client.Kestra.Assets().AssetDependencies(client.Ctx, id, client.Tenant, &destinationOnly, &expandAll)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderer.Render(graph, func(w *tabwriter.Writer) error {
+		nodes := graph.GetNodes()
+		edges := graph.GetEdges()
+		fmt.Fprintln(w, "UID\tNAMESPACE\tTYPE")
+		for _, n := range nodes {
+			fmt.Fprintf(w, "%s\t%s\t%v\n", n.GetUid(), n.GetNamespace(), n.GetType())
+		}
+		fmt.Fprintf(w, "\nNodes: %d, Edges: %d\n", len(nodes), len(edges))
+		fmt.Fprintln(w, "Use --output json to see the full graph.")
+		return nil
+	})
+}
+
+func newAssetsDeleteByIdsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete-by-ids <id> [<id>...]",
+		Short: "Delete multiple assets by their IDs.",
+		Args:  cobra.MinimumNArgs(1),
+		Example: `  kestractl assets delete-by-ids id1 id2 id3
+  kestractl assets delete-by-ids id1 id2 --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAssetsDeleteByIds(client, args, renderer)
+		},
+	}
+	return cmd
+}
+
+func runAssetsDeleteByIds(client *Client, ids []string, renderer *Renderer) error {
+	resp, err := client.Kestra.Assets().DeleteAssetsByIds(client.Ctx, client.Tenant, ids)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderAssetsBulkResponse(resp, renderer)
+}
+
+func newAssetsDeleteByQueryCommand() *cobra.Command {
+	var (
+		filterFlags byQueryFilterFlags
+		purge       bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "delete-by-query",
+		Short: "Delete assets matching query filters.",
+		Example: `  kestractl assets delete-by-query --namespace my.namespace
+  kestractl assets delete-by-query --filter NAMESPACE:EQUALS:my.namespace --purge`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			filters, err := filterFlags.resolve()
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAssetsDeleteByQuery(client, filters, purge, renderer)
+		},
+	}
+
+	addByQueryFilterFlags(cmd, &filterFlags)
+	cmd.Flags().BoolVar(&purge, "purge", false, "Permanently purge the matched assets instead of soft-deleting")
+	return cmd
+}
+
+func runAssetsDeleteByQuery(client *Client, filters []kestra.QueryFilter, purge bool, renderer *Renderer) error {
+	resp, err := client.Kestra.Assets().DeleteAssetsByQuery(client.Ctx, client.Tenant, queryFiltersToSearchFilters(filters), &purge)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	return renderAssetsBulkResponse(resp, renderer)
+}
+
+func renderAssetsBulkResponse(resp *kestra.BulkResponse, renderer *Renderer) error {
+	count := resp.GetCount()
+	return renderer.Render(map[string]any{"count": count}, func(w *tabwriter.Writer) error {
+		fmt.Fprintf(w, "%d asset(s) affected.\n", count)
+		return nil
+	})
+}
+
+func newAssetsLineageEventsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "lineage-events",
+		Short:   "Inspect and manage asset lineage events.",
+		Aliases: []string{"lineage"},
+	}
+	cmd.AddCommand(newAssetsLineageEventsListCommand())
+	cmd.AddCommand(newAssetsLineageEventsDeleteByQueryCommand())
+	return cmd
+}
+
+func newAssetsLineageEventsListCommand() *cobra.Command {
+	var (
+		page int32
+		size int32
+		sort []string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List asset lineage events.",
+		Aliases: []string{"ls"},
+		Example: `  kestractl assets lineage-events list
+  kestractl assets lineage-events list --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAssetsLineageEventsList(client, page, size, sort, renderer)
+		},
+	}
+
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (repeatable)")
+	return cmd
+}
+
+func runAssetsLineageEventsList(client *Client, page, size int32, sort []string, renderer *Renderer) error {
+	pageInt, sizeInt := int(page), int(size)
+
+	resp, err := client.Kestra.Assets().SearchAssetLineageEvents(client.Ctx, client.Tenant, &pageInt, &sizeInt, sort, nil)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	results := resp.GetResults()
+
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "UID\tNAMESPACE\tFLOW\tEXECUTION\tSTATE")
+		for _, e := range results {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				e.GetUid(), e.GetNamespace(), e.GetFlowId(), e.GetExecutionId(), e.GetState())
+		}
+		fmt.Fprintf(w, "\nTotal lineage events: %d\n", resp.GetTotal())
+		return nil
+	})
+}
+
+func newAssetsLineageEventsDeleteByQueryCommand() *cobra.Command {
+	var filterFlags byQueryFilterFlags
+
+	cmd := &cobra.Command{
+		Use:     "delete-by-query",
+		Short:   "Delete asset lineage events matching query filters.",
+		Example: `  kestractl assets lineage-events delete-by-query --namespace my.namespace`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			filters, err := filterFlags.resolve()
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			resp, err := client.Kestra.Assets().DeleteAssetLineageEventsByQuery(client.Ctx, client.Tenant, queryFiltersToSearchFilters(filters))
+			if err != nil {
+				return formatSDKError(err)
+			}
+			return renderAssetsBulkResponse(resp, renderer)
+		},
+	}
+
+	addByQueryFilterFlags(cmd, &filterFlags)
+	return cmd
+}
+
+func newAssetsUsagesCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "usages",
+		Short:   "Inspect and manage asset usages.",
+		Aliases: []string{"usage"},
+	}
+	cmd.AddCommand(newAssetsUsagesListCommand())
+	cmd.AddCommand(newAssetsUsagesDeleteByQueryCommand())
+	return cmd
+}
+
+func newAssetsUsagesListCommand() *cobra.Command {
+	var (
+		page int32
+		size int32
+		sort []string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List asset usages.",
+		Aliases: []string{"ls"},
+		Example: `  kestractl assets usages list
+  kestractl assets usages list --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runAssetsUsagesList(client, page, size, sort, renderer)
+		},
+	}
+
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (repeatable)")
+	return cmd
+}
+
+func runAssetsUsagesList(client *Client, page, size int32, sort []string, renderer *Renderer) error {
+	pageInt, sizeInt := int(page), int(size)
+
+	resp, err := client.Kestra.Assets().SearchAssetUsages(client.Ctx, client.Tenant, &pageInt, &sizeInt, sort, nil)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	results := resp.GetResults()
+
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ASSET ID\tNAMESPACE\tFLOW\tEXECUTION\tTASK")
+		for _, u := range results {
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n",
+				u.GetAssetId(), u.GetNamespace(), u.GetFlowId(), u.GetExecutionId(), u.GetTaskId())
+		}
+		fmt.Fprintf(w, "\nTotal usages: %d\n", resp.GetTotal())
+		return nil
+	})
+}
+
+func newAssetsUsagesDeleteByQueryCommand() *cobra.Command {
+	var filterFlags byQueryFilterFlags
+
+	cmd := &cobra.Command{
+		Use:     "delete-by-query",
+		Short:   "Delete asset usages matching query filters.",
+		Example: `  kestractl assets usages delete-by-query --namespace my.namespace`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			filters, err := filterFlags.resolve()
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			resp, err := client.Kestra.Assets().DeleteAssetUsagesByQuery(client.Ctx, client.Tenant, queryFiltersToSearchFilters(filters))
+			if err != nil {
+				return formatSDKError(err)
+			}
+			return renderAssetsBulkResponse(resp, renderer)
+		},
+	}
+
+	addByQueryFilterFlags(cmd, &filterFlags)
+	return cmd
 }

--- a/src/cli/assets_test.go
+++ b/src/cli/assets_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestAssetsCommand_Structure(t *testing.T) {
@@ -16,10 +18,203 @@ func TestAssetsCommand_Structure(t *testing.T) {
 	for _, sub := range cmd.Commands() {
 		subNames[sub.Name()] = true
 	}
-	for _, want := range []string{"list", "get", "create", "delete"} {
+	for _, want := range []string{
+		"list", "get", "create", "delete",
+		"dependencies", "delete-by-ids", "delete-by-query",
+		"lineage-events", "usages",
+	} {
 		if !subNames[want] {
 			t.Errorf("expected subcommand %q to exist", want)
 		}
+	}
+}
+
+func TestAssetsSubgroups_Structure(t *testing.T) {
+	for _, tc := range []struct {
+		group *cobra.Command
+		want  []string
+	}{
+		{newAssetsLineageEventsCommand(), []string{"list", "delete-by-query"}},
+		{newAssetsUsagesCommand(), []string{"list", "delete-by-query"}},
+	} {
+		subNames := make(map[string]bool)
+		for _, sub := range tc.group.Commands() {
+			subNames[sub.Name()] = true
+		}
+		for _, want := range tc.want {
+			if !subNames[want] {
+				t.Errorf("%s: expected subcommand %q", tc.group.Name(), want)
+			}
+		}
+	}
+}
+
+func TestRunAssetsDependencies(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/assets/asset1/dependencies") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"nodes":[
+			{"uid":"n1","namespace":"prod","type":"ASSET"},
+			{"uid":"n2","namespace":"dev","type":"FLOW"}
+		],"edges":[{"source":"n1","target":"n2"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAssetsDependencies(newTestClient(t, server.URL), "asset1", false, false, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAssetsDependencies error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"n1", "n2", "Nodes: 2, Edges: 1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunAssetsDeleteByIds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/assets/by-ids") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":3}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAssetsDeleteByIds(newTestClient(t, server.URL), []string{"a", "b", "c"}, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAssetsDeleteByIds error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "3 asset(s) affected") {
+		t.Errorf("expected bulk count, got:\n%s", buf.String())
+	}
+}
+
+func TestRunAssetsDeleteByQuery(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/assets/by-query") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":5}`))
+	}))
+	t.Cleanup(server.Close)
+
+	filters, err := parseQueryFilters("prod", nil)
+	if err != nil {
+		t.Fatalf("parseQueryFilters error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err = runAssetsDeleteByQuery(newTestClient(t, server.URL), filters, false, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAssetsDeleteByQuery error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "5 asset(s) affected") {
+		t.Errorf("expected bulk count, got:\n%s", buf.String())
+	}
+}
+
+func TestAssetsDeleteByQueryCommand_NoFilter(t *testing.T) {
+	original := newClientFunc
+	newClientFunc = func() (*Client, error) {
+		t.Fatal("client should not be created without a filter")
+		return nil, nil
+	}
+	defer func() { newClientFunc = original }()
+
+	cmd := newAssetsDeleteByQueryCommand()
+	_, err := executeCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error when no selection filter is provided")
+	}
+	if !strings.Contains(err.Error(), "selection filter is required") {
+		t.Fatalf("expected filter-required error, got: %v", err)
+	}
+}
+
+func TestRunAssetsLineageEventsList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/assets/lineage-events/search") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[
+			{"uid":"e1","namespace":"prod","flowId":"f1","executionId":"x1","state":"SUCCESS"}
+		],"total":1}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAssetsLineageEventsList(newTestClient(t, server.URL), 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAssetsLineageEventsList error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"e1", "prod", "f1", "SUCCESS", "Total lineage events: 1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunAssetsUsagesList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/assets/usages/search") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[
+			{"assetId":"a1","namespace":"prod","flowId":"f1","executionId":"x1","taskId":"t1"}
+		],"total":1}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runAssetsUsagesList(newTestClient(t, server.URL), 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runAssetsUsagesList error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"a1", "prod", "f1", "t1", "Total usages: 1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAssetsLineageEventsDeleteByQuery_Command(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/assets/lineage-events/by-query") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":2}`))
+	}))
+	t.Cleanup(server.Close)
+
+	original := newClientFunc
+	newClientFunc = func() (*Client, error) { return newTestClient(t, server.URL), nil }
+	defer func() { newClientFunc = original }()
+
+	cmd := newAssetsLineageEventsDeleteByQueryCommand()
+	out, err := executeCommand(cmd, "--namespace", "prod")
+	if err != nil {
+		t.Fatalf("execute error: %v", err)
+	}
+	if !strings.Contains(out, "2 asset(s) affected") {
+		t.Errorf("expected bulk count, got:\n%s", out)
 	}
 }
 

--- a/src/cli/blueprints.go
+++ b/src/cli/blueprints.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -22,6 +23,7 @@ Flow blueprints are custom templates stored in your tenant.`,
 
 	cmd.AddCommand(newBlueprintsCommunityCommand())
 	cmd.AddCommand(newBlueprintsFlowCommand())
+	cmd.AddCommand(newBlueprintsCustomCommand())
 
 	return cmd
 }
@@ -36,7 +38,49 @@ func newBlueprintsCommunityCommand() *cobra.Command {
 	cmd.AddCommand(newBlueprintsCommunitySearchCommand())
 	cmd.AddCommand(newBlueprintsCommunityGetCommand())
 	cmd.AddCommand(newBlueprintsCommunitySourceCommand())
+	cmd.AddCommand(newBlueprintsCommunityGraphCommand())
 	return cmd
+}
+
+func newBlueprintsCommunityGraphCommand() *cobra.Command {
+	var kind string
+
+	cmd := &cobra.Command{
+		Use:   "graph <id>",
+		Short: "Get the topology graph of a community blueprint.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runBlueprintsCommunityGraph(client, args[0], kind, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&kind, "kind", "FLOW", "Blueprint kind (e.g. FLOW)")
+	return cmd
+}
+
+func runBlueprintsCommunityGraph(client *Client, id, kind string, renderer *Renderer) error {
+	graph, err := client.Kestra.Blueprints().BlueprintGraph(client.Ctx, id, kind, client.Tenant)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderer.Render(graph, func(w *tabwriter.Writer) error {
+		nodes, _ := graph["nodes"].([]interface{})
+		edges, _ := graph["edges"].([]interface{})
+		fmt.Fprintln(w, "KEY\tVALUE")
+		fmt.Fprintf(w, "Nodes\t%d\n", len(nodes))
+		fmt.Fprintf(w, "Edges\t%d\n", len(edges))
+		fmt.Fprintln(w, "\nUse --output json to see the full graph.")
+		return nil
+	})
 }
 
 func newBlueprintsCommunitySearchCommand() *cobra.Command {
@@ -186,6 +230,7 @@ func newBlueprintsFlowCommand() *cobra.Command {
 	cmd.AddCommand(newBlueprintsFlowCreateCommand())
 	cmd.AddCommand(newBlueprintsFlowUpdateCommand())
 	cmd.AddCommand(newBlueprintsFlowDeleteCommand())
+	cmd.AddCommand(newBlueprintsFlowUseTemplateCommand())
 	return cmd
 }
 
@@ -253,6 +298,8 @@ func runBlueprintsFlowList(client *Client, query string, tags []string, page, si
 }
 
 func newBlueprintsFlowGetCommand() *cobra.Command {
+	var legacy bool
+
 	cmd := &cobra.Command{
 		Use:     "get <id>",
 		Short:   "Get a flow blueprint.",
@@ -267,14 +314,19 @@ func newBlueprintsFlowGetCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runBlueprintsFlowGet(client, args[0], renderer)
+			return runBlueprintsFlowGet(client, args[0], legacy, renderer)
 		},
 	}
+	cmd.Flags().BoolVar(&legacy, "legacy", false, "Use the legacy /blueprints/flow/{id} endpoint")
 	return cmd
 }
 
-func runBlueprintsFlowGet(client *Client, id string, renderer *Renderer) error {
-	b, err := client.Kestra.Blueprints().FlowBlueprintById(client.Ctx, id, client.Tenant)
+func runBlueprintsFlowGet(client *Client, id string, legacy bool, renderer *Renderer) error {
+	getFn := client.Kestra.Blueprints().FlowBlueprintById
+	if legacy {
+		getFn = client.Kestra.Blueprints().FlowBlueprint
+	}
+	b, err := getFn(client.Ctx, id, client.Tenant)
 	if err != nil {
 		return formatSDKError(err)
 	}
@@ -372,9 +424,9 @@ func newBlueprintsFlowUpdateCommand() *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "update <id>",
-		Short: "Update a flow blueprint.",
-		Args:  cobra.ExactArgs(1),
+		Use:     "update <id>",
+		Short:   "Update a flow blueprint.",
+		Args:    cobra.ExactArgs(1),
 		Example: `  kestractl blueprints flow update <id> --title "Updated Blueprint" --source-file flow.yml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if title == "" {
@@ -455,6 +507,320 @@ func newBlueprintsFlowDeleteCommand() *cobra.Command {
 
 func runBlueprintsFlowDelete(client *Client, id string, renderer *Renderer) error {
 	if err := client.Kestra.Blueprints().DeleteFlowBlueprints(client.Ctx, id, client.Tenant); err != nil {
+		return formatSDKError(err)
+	}
+	return renderStatus(renderer, fmt.Sprintf("Blueprint '%s' deleted.", id),
+		map[string]any{"id": id, "status": "deleted"})
+}
+
+func newBlueprintsFlowUseTemplateCommand() *cobra.Command {
+	var inputs []string
+
+	cmd := &cobra.Command{
+		Use:   "use-template <id>",
+		Short: "Generate a flow source from a flow blueprint template.",
+		Args:  cobra.ExactArgs(1),
+		Example: `  kestractl blueprints flow use-template <id>
+  kestractl blueprints flow use-template <id> --input env=prod --input region=eu`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runBlueprintsFlowUseTemplate(client, args[0], inputs, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().StringArrayVar(&inputs, "input", nil, "Template argument as key=value (repeatable)")
+	return cmd
+}
+
+func runBlueprintsFlowUseTemplate(client *Client, id string, inputs []string, out io.Writer) error {
+	args, err := parseBlueprintInputs(inputs)
+	if err != nil {
+		return err
+	}
+
+	req := kestra.NewBlueprintControllerUseBlueprintTemplateRequest()
+	if len(args) > 0 {
+		req.TemplateArgumentsInputs = args
+	}
+
+	resp, err := client.Kestra.Blueprints().UseBlueprintTemplate(client.Ctx, id, client.Tenant, req)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	_, err = fmt.Fprint(out, resp.GetGeneratedFlowSource())
+	return err
+}
+
+func parseBlueprintInputs(inputs []string) (map[string]interface{}, error) {
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]interface{}, len(inputs))
+	for _, in := range inputs {
+		parts := strings.SplitN(in, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return nil, fmt.Errorf("invalid --input %q: expected key=value", in)
+		}
+		out[parts[0]] = parts[1]
+	}
+	return out, nil
+}
+
+// custom (internal) blueprint sub-group
+
+func newBlueprintsCustomCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "custom",
+		Short: "Manage internal (custom) blueprints.",
+		Long: `Manage internal/custom blueprints.
+
+These are tenant-stored blueprints served from the /blueprints/custom endpoints.
+Use "kestractl blueprints flow list" to search them.`,
+	}
+	cmd.AddCommand(newBlueprintsCustomGetCommand())
+	cmd.AddCommand(newBlueprintsCustomSourceCommand())
+	cmd.AddCommand(newBlueprintsCustomCreateCommand())
+	cmd.AddCommand(newBlueprintsCustomUpdateCommand())
+	cmd.AddCommand(newBlueprintsCustomDeleteCommand())
+	return cmd
+}
+
+func newBlueprintsCustomGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "get <id>",
+		Short:   "Get an internal blueprint.",
+		Aliases: []string{"show", "describe"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runBlueprintsCustomGet(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runBlueprintsCustomGet(client *Client, id string, renderer *Renderer) error {
+	b, err := client.Kestra.Blueprints().InternalBlueprint(client.Ctx, id, client.Tenant)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderer.Render(b, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "Blueprint Details")
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "ID:\t%s\n", b.GetId())
+		fmt.Fprintf(w, "Title:\t%s\n", b.GetTitle())
+		if desc := b.GetDescription(); desc != "" {
+			fmt.Fprintf(w, "Description:\t%s\n", desc)
+		}
+		if tags := b.GetTags(); len(tags) > 0 {
+			fmt.Fprintf(w, "Tags:\t%s\n", strings.Join(tags, ", "))
+		}
+		return nil
+	})
+}
+
+func newBlueprintsCustomSourceCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "source <id>",
+		Short: "Print the YAML source of an internal blueprint.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runBlueprintsCustomSource(client, args[0], cmd.OutOrStdout())
+		},
+	}
+	return cmd
+}
+
+// runBlueprintsCustomSource prints the YAML source of an internal blueprint.
+//
+// The dedicated /blueprints/custom/{id}/source endpoint only honors an
+// "Accept: */*" header and returns 401 for the SDK's hardcoded text/plain
+// Accept, so we read the source field from the full blueprint object instead.
+func runBlueprintsCustomSource(client *Client, id string, out io.Writer) error {
+	b, err := client.Kestra.Blueprints().InternalBlueprint(client.Ctx, id, client.Tenant)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	_, err = fmt.Fprint(out, b.GetSource())
+	return err
+}
+
+func newBlueprintsCustomCreateCommand() *cobra.Command {
+	var (
+		title       string
+		description string
+		sourceFile  string
+		tags        []string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "create",
+		Short:   "Create a new internal blueprint.",
+		Example: `  kestractl blueprints custom create --title "My Blueprint" --source-file flow.yml`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if title == "" {
+				return fmt.Errorf("--title is required")
+			}
+			if sourceFile == "" {
+				return fmt.Errorf("--source-file is required")
+			}
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runBlueprintsCustomCreate(client, title, description, sourceFile, tags, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "Blueprint title (required)")
+	cmd.Flags().StringVar(&description, "description", "", "Blueprint description")
+	cmd.Flags().StringVar(&sourceFile, "source-file", "", "Path to the YAML flow source file (required)")
+	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable)")
+
+	return cmd
+}
+
+func runBlueprintsCustomCreate(client *Client, title, description, sourceFile string, tags []string, renderer *Renderer) error {
+	src, err := os.ReadFile(sourceFile)
+	if err != nil {
+		return fmt.Errorf("failed to read source file: %w", err)
+	}
+
+	req := &kestra.BlueprintControllerFlowBlueprintCreateOrUpdate{
+		Title:  title,
+		Source: string(src),
+	}
+	if description != "" {
+		req.Description = &description
+	}
+	if len(tags) > 0 {
+		req.Tags = tags
+	}
+
+	b, err := client.Kestra.Blueprints().CreateInternalBlueprints(client.Ctx, client.Tenant, req)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderer.Render(b, func(w *tabwriter.Writer) error {
+		fmt.Fprintf(w, "Blueprint created successfully.\n\nID:\t%s\nTitle:\t%s\n",
+			b.GetId(), b.GetTitle())
+		return nil
+	})
+}
+
+func newBlueprintsCustomUpdateCommand() *cobra.Command {
+	var (
+		title       string
+		description string
+		sourceFile  string
+		tags        []string
+	)
+
+	cmd := &cobra.Command{
+		Use:     "update <id>",
+		Short:   "Update an internal blueprint.",
+		Args:    cobra.ExactArgs(1),
+		Example: `  kestractl blueprints custom update <id> --title "Updated" --source-file flow.yml`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if title == "" {
+				return fmt.Errorf("--title is required")
+			}
+			if sourceFile == "" {
+				return fmt.Errorf("--source-file is required")
+			}
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runBlueprintsCustomUpdate(client, args[0], title, description, sourceFile, tags, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "Blueprint title (required)")
+	cmd.Flags().StringVar(&description, "description", "", "Blueprint description")
+	cmd.Flags().StringVar(&sourceFile, "source-file", "", "Path to the YAML flow source file (required)")
+	cmd.Flags().StringArrayVar(&tags, "tag", nil, "Tag (repeatable)")
+
+	return cmd
+}
+
+func runBlueprintsCustomUpdate(client *Client, id, title, description, sourceFile string, tags []string, renderer *Renderer) error {
+	src, err := os.ReadFile(sourceFile)
+	if err != nil {
+		return fmt.Errorf("failed to read source file: %w", err)
+	}
+
+	req := &kestra.BlueprintControllerFlowBlueprintCreateOrUpdate{
+		Title:  title,
+		Source: string(src),
+	}
+	if description != "" {
+		req.Description = &description
+	}
+	if len(tags) > 0 {
+		req.Tags = tags
+	}
+
+	b, err := client.Kestra.Blueprints().UpdateInternalBlueprints(client.Ctx, id, client.Tenant, req)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderer.Render(b, func(w *tabwriter.Writer) error {
+		fmt.Fprintf(w, "Blueprint updated successfully.\n\nID:\t%s\nTitle:\t%s\n",
+			b.GetId(), b.GetTitle())
+		return nil
+	})
+}
+
+func newBlueprintsCustomDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete <id>",
+		Short:   "Delete an internal blueprint.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runBlueprintsCustomDelete(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runBlueprintsCustomDelete(client *Client, id string, renderer *Renderer) error {
+	if err := client.Kestra.Blueprints().DeleteInternalBlueprints(client.Ctx, id, client.Tenant); err != nil {
 		return formatSDKError(err)
 	}
 	return renderStatus(renderer, fmt.Sprintf("Blueprint '%s' deleted.", id),

--- a/src/cli/blueprints_test.go
+++ b/src/cli/blueprints_test.go
@@ -43,10 +43,219 @@ func TestBlueprintsFlowCommand_Structure(t *testing.T) {
 	for _, sub := range cmd.Commands() {
 		subNames[sub.Name()] = true
 	}
-	for _, want := range []string{"list", "get", "create", "update", "delete"} {
+	for _, want := range []string{"list", "get", "create", "update", "delete", "use-template"} {
 		if !subNames[want] {
 			t.Errorf("expected subcommand %q to exist", want)
 		}
+	}
+}
+
+func TestBlueprintsCustomCommand_Structure(t *testing.T) {
+	cmd := newBlueprintsCustomCommand()
+	subNames := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		subNames[sub.Name()] = true
+	}
+	for _, want := range []string{"get", "source", "create", "update", "delete"} {
+		if !subNames[want] {
+			t.Errorf("expected subcommand %q to exist", want)
+		}
+	}
+}
+
+func TestRunBlueprintsCommunityGraph(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/graph") {
+			t.Errorf("expected /graph path, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"nodes":[{"uid":"a"},{"uid":"b"}],"edges":[{"source":"a","target":"b"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBlueprintsCommunityGraph(newTestClient(t, server.URL), "bp1", "FLOW", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBlueprintsCommunityGraph error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"Nodes", "2", "Edges", "1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunBlueprintsFlowGet_Legacy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/blueprints/flow/") || strings.Contains(r.URL.Path, "/blueprints/flows/") {
+			t.Errorf("expected legacy /blueprints/flow/ path, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"fb1","title":"Legacy Blueprint"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBlueprintsFlowGet(newTestClient(t, server.URL), "fb1", true, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBlueprintsFlowGet (legacy) error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Legacy Blueprint") {
+		t.Errorf("output missing legacy title:\n%s", buf.String())
+	}
+}
+
+func TestRunBlueprintsFlowUseTemplate(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/use-template") {
+			t.Errorf("expected /use-template path, got %s", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"generatedFlowSource":"id: myflow\nnamespace: prod"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBlueprintsFlowUseTemplate(newTestClient(t, server.URL), "fb1", []string{"env=prod"}, &buf)
+	if err != nil {
+		t.Fatalf("runBlueprintsFlowUseTemplate error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "id: myflow") {
+		t.Errorf("output missing generated flow source:\n%s", buf.String())
+	}
+	args, ok := gotBody["templateArgumentsInputs"].(map[string]any)
+	if !ok || args["env"] != "prod" {
+		t.Errorf("expected templateArgumentsInputs env=prod in body, got: %v", gotBody)
+	}
+}
+
+func TestParseBlueprintInputs(t *testing.T) {
+	got, err := parseBlueprintInputs([]string{"a=1", "b=hello=world"})
+	if err != nil {
+		t.Fatalf("parseBlueprintInputs error: %v", err)
+	}
+	if got["a"] != "1" || got["b"] != "hello=world" {
+		t.Errorf("unexpected parse result: %v", got)
+	}
+	if _, err := parseBlueprintInputs([]string{"noequals"}); err == nil {
+		t.Error("expected error for input without '='")
+	}
+}
+
+func TestRunBlueprintsCustomGet(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/blueprints/custom/") {
+			t.Errorf("expected /blueprints/custom/ path, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"cb1","title":"Custom Blueprint","description":"internal","tags":["x"]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBlueprintsCustomGet(newTestClient(t, server.URL), "cb1", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBlueprintsCustomGet error: %v", err)
+	}
+	for _, want := range []string{"cb1", "Custom Blueprint", "internal"} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("output missing %q:\n%s", want, buf.String())
+		}
+	}
+}
+
+func TestRunBlueprintsCustomSource(t *testing.T) {
+	// The source must be read from the full blueprint object (GET
+	// /blueprints/custom/{id}), not the /source sub-endpoint, which the SDK
+	// cannot reach due to its hardcoded Accept header.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/source") {
+			t.Errorf("must not call the /source sub-endpoint, got %s", r.URL.Path)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/blueprints/custom/cb1") {
+			t.Errorf("expected /blueprints/custom/cb1 path, got %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"cb1","title":"Custom Blueprint","source":"id: myflow\nnamespace: prod"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBlueprintsCustomSource(newTestClient(t, server.URL), "cb1", &buf)
+	if err != nil {
+		t.Fatalf("runBlueprintsCustomSource error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "id: myflow") {
+		t.Errorf("output missing blueprint source:\n%s", buf.String())
+	}
+}
+
+func TestRunBlueprintsCustomCreate(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/blueprints/custom") {
+			t.Errorf("expected /blueprints/custom path, got %s", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"cb1","title":"Custom Blueprint"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	f, err := os.CreateTemp("", "flow-*.yml")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	defer os.Remove(f.Name())
+	_, _ = f.WriteString("id: myflow\nnamespace: prod")
+	f.Close()
+
+	var buf bytes.Buffer
+	err = runBlueprintsCustomCreate(newTestClient(t, server.URL), "Custom Blueprint", "", f.Name(), nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBlueprintsCustomCreate error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "created") {
+		t.Errorf("expected creation message, got:\n%s", buf.String())
+	}
+	if gotBody["title"] != "Custom Blueprint" {
+		t.Errorf("expected title in request body, got: %v", gotBody)
+	}
+}
+
+func TestRunBlueprintsCustomDelete(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/blueprints/custom/") {
+			t.Errorf("expected /blueprints/custom/ path, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runBlueprintsCustomDelete(newTestClient(t, server.URL), "cb1", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runBlueprintsCustomDelete error: %v", err)
+	}
+	if !hit {
+		t.Error("expected API request")
+	}
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Errorf("expected deletion message, got:\n%s", buf.String())
 	}
 }
 
@@ -163,7 +372,7 @@ func TestRunBlueprintsFlowGet(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	var buf bytes.Buffer
-	err := runBlueprintsFlowGet(newTestClient(t, server.URL), "fb1", newTableRenderer(&buf))
+	err := runBlueprintsFlowGet(newTestClient(t, server.URL), "fb1", false, newTableRenderer(&buf))
 	if err != nil {
 		t.Fatalf("runBlueprintsFlowGet error: %v", err)
 	}

--- a/src/cli/dashboards.go
+++ b/src/cli/dashboards.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"text/tabwriter"
 
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func newDashboardsCommand() *cobra.Command {
@@ -23,6 +25,13 @@ Dashboards provide configurable views of execution metrics and flow data. Requir
 	cmd.AddCommand(newDashboardsCreateCommand())
 	cmd.AddCommand(newDashboardsUpdateCommand())
 	cmd.AddCommand(newDashboardsDeleteCommand())
+	cmd.AddCommand(newDashboardsDefaultsCommand())
+	cmd.AddCommand(newDashboardsValidateCommand())
+	cmd.AddCommand(newDashboardsValidateChartCommand())
+	cmd.AddCommand(newDashboardsPreviewChartCommand())
+	cmd.AddCommand(newDashboardsChartDataCommand())
+	cmd.AddCommand(newDashboardsExportChartCSVCommand())
+	cmd.AddCommand(newDashboardsExportChartDataCSVCommand())
 
 	return cmd
 }
@@ -177,9 +186,9 @@ func newDashboardsUpdateCommand() *cobra.Command {
 	var filePath string
 
 	cmd := &cobra.Command{
-		Use:   "update <id>",
-		Short: "Update an existing dashboard from a YAML file.",
-		Args:  cobra.ExactArgs(1),
+		Use:     "update <id>",
+		Short:   "Update an existing dashboard from a YAML file.",
+		Args:    cobra.ExactArgs(1),
 		Example: `  kestractl dashboards update <id> --file my-dashboard.yml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if filePath == "" {
@@ -262,4 +271,363 @@ func runDashboardsDelete(client *Client, id string, skipConfirm bool, in io.Read
 
 	return renderStatus(renderer, fmt.Sprintf("Dashboard '%s' deleted.", id),
 		map[string]any{"id": id, "status": "deleted"})
+}
+
+func newDashboardsDefaultsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "defaults",
+		Short: "Show the tenant's default dashboard settings.",
+		Long:  "Show which dashboards are configured as defaults for the home, flow overview, and namespace overview views.",
+		Example: `  kestractl dashboards defaults
+  kestractl dashboards defaults --output json`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runDashboardsDefaults(client, renderer)
+		},
+	}
+	return cmd
+}
+
+func runDashboardsDefaults(client *Client, renderer *Renderer) error {
+	settings, err := client.Kestra.Dashboards().DefaultDashboards(client.Ctx, client.Tenant)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderer.Render(settings, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "VIEW\tDASHBOARD")
+		fmt.Fprintf(w, "Home\t%s\n", orNone(settings.GetDefaultHomeDashboard()))
+		fmt.Fprintf(w, "Flow overview\t%s\n", orNone(settings.GetDefaultFlowOverviewDashboard()))
+		fmt.Fprintf(w, "Namespace overview\t%s\n", orNone(settings.GetDefaultNamespaceOverviewDashboard()))
+		return nil
+	})
+}
+
+func orNone(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	return s
+}
+
+func newDashboardsValidateCommand() *cobra.Command {
+	var filePath string
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate a dashboard definition from a YAML file.",
+		Example: `  kestractl dashboards validate --file my-dashboard.yml
+  kestractl dashboards validate --file my-dashboard.yml --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if filePath == "" {
+				return fmt.Errorf("--file is required")
+			}
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runDashboardsValidate(client, filePath, renderer)
+		},
+	}
+
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the YAML dashboard definition file (required)")
+	return cmd
+}
+
+func runDashboardsValidate(client *Client, filePath string, renderer *Renderer) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	result, err := client.Kestra.Dashboards().ValidateDashboard(client.Ctx, client.Tenant, string(data))
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderValidateConstraintViolation(result, renderer)
+}
+
+func newDashboardsValidateChartCommand() *cobra.Command {
+	var filePath string
+
+	cmd := &cobra.Command{
+		Use:   "validate-chart",
+		Short: "Validate a single chart definition from a YAML file.",
+		Example: `  kestractl dashboards validate-chart --file my-chart.yml
+  kestractl dashboards validate-chart --file my-chart.yml --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if filePath == "" {
+				return fmt.Errorf("--file is required")
+			}
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runDashboardsValidateChart(client, filePath, renderer)
+		},
+	}
+
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the YAML chart definition file (required)")
+	return cmd
+}
+
+func runDashboardsValidateChart(client *Client, filePath string, renderer *Renderer) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	result, err := client.Kestra.Dashboards().ValidateChart(client.Ctx, client.Tenant, string(data))
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderValidateConstraintViolation(result, renderer)
+}
+
+func newDashboardsPreviewChartCommand() *cobra.Command {
+	var filePath string
+
+	cmd := &cobra.Command{
+		Use:   "preview-chart",
+		Short: "Preview the data for a chart definition without saving it.",
+		Long:  "Send a chart definition to the server and return the resulting data, without persisting a dashboard. The file is the same chart definition accepted by 'validate-chart'.",
+		Example: `  kestractl dashboards preview-chart --file my-chart.yml
+  kestractl dashboards preview-chart --file my-chart.yml --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if filePath == "" {
+				return fmt.Errorf("--file is required")
+			}
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runDashboardsPreviewChart(client, filePath, renderer)
+		},
+	}
+
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the YAML chart definition file (required)")
+	return cmd
+}
+
+// readChartPreviewRequest reads a chart definition file and wraps it into the
+// preview-request body the server expects. The "chart" field is a string
+// holding the raw chart definition (the same format 'validate-chart' accepts),
+// not a nested object.
+func readChartPreviewRequest(filePath string) (map[string]interface{}, error) {
+	chart, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+	return map[string]interface{}{"chart": string(chart)}, nil
+}
+
+func runDashboardsPreviewChart(client *Client, filePath string, renderer *Renderer) error {
+	request, err := readChartPreviewRequest(filePath)
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Kestra.Dashboards().PreviewChart(client.Ctx, client.Tenant, request)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderChartData(resp, renderer)
+}
+
+func newDashboardsChartDataCommand() *cobra.Command {
+	var filePath string
+
+	cmd := &cobra.Command{
+		Use:   "chart-data <dashboard-id> <chart-id>",
+		Short: "Fetch the data for a chart of an existing dashboard.",
+		Args:  cobra.ExactArgs(2),
+		Example: `  kestractl dashboards chart-data my-dashboard my-chart
+  kestractl dashboards chart-data my-dashboard my-chart --file filters.yml --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runDashboardsChartData(client, args[0], args[1], filePath, renderer)
+		},
+	}
+
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to a YAML file with chart filters (optional)")
+	return cmd
+}
+
+func runDashboardsChartData(client *Client, dashboardID, chartID, filePath string, renderer *Renderer) error {
+	// The endpoint requires a (possibly empty) filters body; default to an empty
+	// object so --file stays optional.
+	filters := map[string]interface{}{}
+	if filePath != "" {
+		body, err := readYAMLBody(filePath)
+		if err != nil {
+			return err
+		}
+		filters = body
+	}
+
+	resp, err := client.Kestra.Dashboards().DashboardChartData(client.Ctx, dashboardID, chartID, client.Tenant, filters)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderChartData(resp, renderer)
+}
+
+func newDashboardsExportChartCSVCommand() *cobra.Command {
+	var (
+		filePath   string
+		outputFile string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "export-chart-csv",
+		Short: "Export a chart definition's data as CSV.",
+		Long:  "Send a chart definition to the server and export the resulting data as CSV. The file is the same chart definition accepted by 'validate-chart'. The output is written to stdout or --output-file.",
+		Example: `  kestractl dashboards export-chart-csv --file my-chart.yml
+  kestractl dashboards export-chart-csv --file my-chart.yml --output-file chart.csv`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if filePath == "" {
+				return fmt.Errorf("--file is required")
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runDashboardsExportChartCSV(client, filePath, outputFile, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the YAML chart definition file (required)")
+	cmd.Flags().StringVar(&outputFile, "output-file", "", "Write CSV to this file instead of stdout")
+	return cmd
+}
+
+func runDashboardsExportChartCSV(client *Client, filePath, outputFile string, out io.Writer) error {
+	request, err := readChartPreviewRequest(filePath)
+	if err != nil {
+		return err
+	}
+
+	data, err := client.Kestra.Dashboards().ExportChartToCsv(client.Ctx, client.Tenant, request)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return writeCSVOutput(data, outputFile, out)
+}
+
+func newDashboardsExportChartDataCSVCommand() *cobra.Command {
+	var (
+		filePath   string
+		outputFile string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "export-chart-data-csv <dashboard-id> <chart-id>",
+		Short: "Export an existing dashboard chart's data as CSV.",
+		Long:  "Export the data of a chart belonging to an existing dashboard as CSV. The output is written to stdout or --output-file.",
+		Args:  cobra.ExactArgs(2),
+		Example: `  kestractl dashboards export-chart-data-csv my-dashboard my-chart
+  kestractl dashboards export-chart-data-csv my-dashboard my-chart --output-file chart.csv`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runDashboardsExportChartDataCSV(client, args[0], args[1], filePath, outputFile, cmd.OutOrStdout())
+		},
+	}
+
+	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to a YAML file with chart filters (optional)")
+	cmd.Flags().StringVar(&outputFile, "output-file", "", "Write CSV to this file instead of stdout")
+	return cmd
+}
+
+func runDashboardsExportChartDataCSV(client *Client, dashboardID, chartID, filePath, outputFile string, out io.Writer) error {
+	// The endpoint requires a (possibly empty) global filter body; default to an
+	// empty object so --file stays optional.
+	filters := map[string]interface{}{}
+	if filePath != "" {
+		body, err := readYAMLBody(filePath)
+		if err != nil {
+			return err
+		}
+		filters = body
+	}
+
+	data, err := client.Kestra.Dashboards().ExportDashboardChartDataToCSV(client.Ctx, dashboardID, chartID, client.Tenant, filters)
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	return writeCSVOutput(data, outputFile, out)
+}
+
+// readYAMLBody reads a YAML file and unmarshals it into a generic map for use
+// as a JSON request body.
+func readYAMLBody(filePath string) (map[string]interface{}, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+	var body map[string]interface{}
+	if unmarshalErr := yaml.Unmarshal(data, &body); unmarshalErr != nil {
+		return nil, fmt.Errorf("invalid YAML: %w", unmarshalErr)
+	}
+	return body, nil
+}
+
+// renderChartData renders a paged chart-data result: a count summary in table
+// mode (the raw rows are only meaningful as JSON).
+func renderChartData(resp *kestra.PagedResultsMapStringObject, renderer *Renderer) error {
+	results := resp.GetResults()
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "KEY\tVALUE")
+		fmt.Fprintf(w, "Rows\t%d\n", len(results))
+		fmt.Fprintf(w, "Total\t%d\n", resp.GetTotal())
+		fmt.Fprintln(w, "\nUse --output json to see the full data.")
+		return nil
+	})
+}
+
+func writeCSVOutput(data []byte, outputFile string, out io.Writer) error {
+	if outputFile != "" {
+		if err := os.WriteFile(outputFile, data, 0o644); err != nil {
+			return fmt.Errorf("failed to write %q: %w", outputFile, err)
+		}
+		fmt.Fprintf(out, "Chart data exported to %s (%d bytes)\n", outputFile, len(data))
+		return nil
+	}
+	_, err := out.Write(data)
+	return err
 }

--- a/src/cli/dashboards_test.go
+++ b/src/cli/dashboards_test.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -16,7 +19,11 @@ func TestDashboardsCommand_Structure(t *testing.T) {
 	for _, sub := range cmd.Commands() {
 		subNames[sub.Name()] = true
 	}
-	for _, want := range []string{"list", "get", "create", "update", "delete"} {
+	for _, want := range []string{
+		"list", "get", "create", "update", "delete",
+		"defaults", "validate", "validate-chart", "preview-chart",
+		"chart-data", "export-chart-csv", "export-chart-data-csv",
+	} {
 		if !subNames[want] {
 			t.Errorf("expected subcommand %q to exist", want)
 		}
@@ -239,6 +246,208 @@ func TestRunDashboardsDelete_SkipConfirm(t *testing.T) {
 	if !hit {
 		t.Error("expected API request when --yes is set")
 	}
+}
+
+func TestRunDashboardsDefaults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/dashboards/settings/default-dashboards") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"defaultHomeDashboard":"home-1","defaultFlowOverviewDashboard":"flow-1"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runDashboardsDefaults(newTestClient(t, server.URL), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runDashboardsDefaults error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"home-1", "flow-1", "(none)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunDashboardsValidate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/dashboards/validate") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"index":0,"constraints":"","warnings":["watch out"]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	f := writeTempFile(t, "title: My Dashboard\ncharts: []")
+	var buf bytes.Buffer
+	err := runDashboardsValidate(newTestClient(t, server.URL), f, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runDashboardsValidate error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"passed", "watch out"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunDashboardsValidateChart(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/dashboards/validate/chart") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"index":0,"constraints":"bad chart"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	f := writeTempFile(t, "type: bar")
+	var buf bytes.Buffer
+	err := runDashboardsValidateChart(newTestClient(t, server.URL), f, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runDashboardsValidateChart error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "bad chart") {
+		t.Errorf("expected validation failure, got:\n%s", buf.String())
+	}
+}
+
+func TestRunDashboardsPreviewChart(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/dashboards/charts/preview") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"x":"a"},{"x":"b"}],"total":2}`))
+	}))
+	t.Cleanup(server.Close)
+
+	f := writeTempFile(t, "id: c1\ntype: bar")
+	var buf bytes.Buffer
+	err := runDashboardsPreviewChart(newTestClient(t, server.URL), f, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runDashboardsPreviewChart error: %v", err)
+	}
+	// The chart field must be sent as a raw string, not a nested object.
+	if got, ok := gotBody["chart"].(string); !ok || !strings.Contains(got, "type: bar") {
+		t.Errorf("expected chart sent as a YAML string, got body: %v", gotBody)
+	}
+	out := buf.String()
+	for _, want := range []string{"Rows", "Total", "2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunDashboardsChartData(t *testing.T) {
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/dashboards/my-dashboard/charts/my-chart") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[{"x":"a"}],"total":1}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runDashboardsChartData(newTestClient(t, server.URL), "my-dashboard", "my-chart", "", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runDashboardsChartData error: %v", err)
+	}
+	// The endpoint requires a body; with no --file we must still send "{}".
+	if strings.TrimSpace(gotBody) != "{}" {
+		t.Errorf("expected empty-object filters body, got: %q", gotBody)
+	}
+	if !strings.Contains(buf.String(), "Rows") {
+		t.Errorf("expected chart data summary, got:\n%s", buf.String())
+	}
+}
+
+func TestRunDashboardsExportChartCSV_Stdout(t *testing.T) {
+	var gotBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/dashboards/charts/export/to-csv") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write([]byte("col1,col2\n1,2\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	f := writeTempFile(t, "id: c1\ntype: bar")
+	var buf bytes.Buffer
+	err := runDashboardsExportChartCSV(newTestClient(t, server.URL), f, "", &buf)
+	if err != nil {
+		t.Fatalf("runDashboardsExportChartCSV error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "col1,col2") {
+		t.Errorf("expected CSV output, got:\n%s", buf.String())
+	}
+	// The chart field must be sent as a raw string, not a nested object.
+	if got, ok := gotBody["chart"].(string); !ok || !strings.Contains(got, "type: bar") {
+		t.Errorf("expected chart sent as a YAML string, got body: %v", gotBody)
+	}
+}
+
+func TestRunDashboardsExportChartDataCSV_File(t *testing.T) {
+	var gotBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/dashboards/my-dashboard/charts/my-chart/export/to-csv") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "text/csv")
+		_, _ = w.Write([]byte("a,b\n3,4\n"))
+	}))
+	t.Cleanup(server.Close)
+
+	outPath := filepath.Join(t.TempDir(), "chart.csv")
+	var buf bytes.Buffer
+	err := runDashboardsExportChartDataCSV(newTestClient(t, server.URL), "my-dashboard", "my-chart", "", outPath, &buf)
+	if err != nil {
+		t.Fatalf("runDashboardsExportChartDataCSV error: %v", err)
+	}
+	// The endpoint requires a body; with no --file we must still send "{}".
+	if strings.TrimSpace(gotBody) != "{}" {
+		t.Errorf("expected empty-object global filter body, got: %q", gotBody)
+	}
+	if !strings.Contains(buf.String(), "exported to") {
+		t.Errorf("expected export confirmation, got:\n%s", buf.String())
+	}
+	data, readErr := os.ReadFile(outPath)
+	if readErr != nil {
+		t.Fatalf("read output file: %v", readErr)
+	}
+	if !strings.Contains(string(data), "a,b") {
+		t.Errorf("expected CSV in file, got: %s", string(data))
+	}
+}
+
+func writeTempFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "input.yml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+	return path
 }
 
 func TestDashboardsListCommand_ClientError(t *testing.T) {

--- a/src/cli/executions.go
+++ b/src/cli/executions.go
@@ -2221,13 +2221,17 @@ func runExecutionsChangeStatusByIds(client *Client, ids []string, newStatus stri
 }
 
 func newExecutionsTriggerWebhookCommand() *cobra.Command {
-	var method string
+	var (
+		method string
+		path   string
+	)
 
 	cmd := &cobra.Command{
 		Use:   "trigger-webhook <namespace> <flow_id> <key>",
 		Short: "Trigger an execution via a webhook.",
 		Example: `  kestractl executions trigger-webhook my.namespace my-flow my-key
   kestractl executions trigger-webhook my.namespace my-flow my-key --method POST
+  kestractl executions trigger-webhook my.namespace my-flow my-key --method PUT --path extra/segment
   kestractl executions trigger-webhook my.namespace my-flow my-key --output json`,
 		Args: cobra.ExactArgs(3),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -2239,41 +2243,59 @@ func newExecutionsTriggerWebhookCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runExecutionsTriggerWebhook(client, args[0], args[1], args[2], method, renderer)
+			return runExecutionsTriggerWebhook(client, args[0], args[1], args[2], method, path, renderer)
 		},
 	}
 
-	cmd.Flags().StringVar(&method, "method", "GET", "HTTP method to use (GET or POST)")
+	cmd.Flags().StringVar(&method, "method", "GET", "HTTP method to use (GET, POST or PUT)")
+	cmd.Flags().StringVar(&path, "path", "", "Optional path suffix appended to the webhook URL")
 	return cmd
 }
 
-func runExecutionsTriggerWebhook(client *Client, namespace, flowID, key, method string, renderer *Renderer) error {
+func runExecutionsTriggerWebhook(client *Client, namespace, flowID, key, method, path string, renderer *Renderer) error {
+	m := strings.ToUpper(method)
+	if m != "GET" && m != "POST" && m != "PUT" {
+		return fmt.Errorf("unsupported method %q: use GET, POST or PUT", method)
+	}
+
 	var row map[string]any
 
-	switch strings.ToUpper(method) {
-	case "POST":
-		result, err := triggerWebhookPost(client, namespace, flowID, key)
-		if err != nil {
-			return err
+	switch {
+	case path != "":
+		// A path suffix maps to the SDK's *WebhookWithPath variants.
+		var result *kestra.WebhookResponse
+		var err error
+		switch m {
+		case "GET":
+			result, err = client.Kestra.Executions().TriggerExecutionByGetWebhookWithPath(
+				client.Ctx, client.Tenant, namespace, flowID, key, path)
+		case "POST":
+			result, err = client.Kestra.Executions().TriggerExecutionByPostWebhookWithPath(
+				client.Ctx, client.Tenant, namespace, flowID, key, path)
+		default: // PUT
+			result, err = client.Kestra.Executions().TriggerExecutionByPutWebhookWithPath(
+				client.Ctx, client.Tenant, namespace, flowID, key, path)
 		}
-		row = result
-	case "GET":
-		// The SDK's only POST webhook helper appends a path segment, so we issue
-		// POST directly (see triggerWebhookPost); GET has a path-less helper.
+		if err != nil {
+			return formatSDKError(err)
+		}
+		row = webhookResponseRow(result)
+	case m == "GET":
 		result, err := client.Kestra.Executions().TriggerExecutionByGetWebhook(
 			client.Ctx, client.Tenant, namespace, flowID, key)
 		if err != nil {
 			return formatSDKError(err)
 		}
-		if result != nil {
-			row = map[string]any{
-				"id":        result.GetId(),
-				"namespace": result.GetNamespace(),
-				"flowId":    result.GetFlowId(),
-			}
+		row = webhookResponseRow(result)
+	default: // path-less POST or PUT
+		// The SDK only exposes *WebhookWithPath helpers for POST/PUT, which append
+		// a trailing path segment the server rejects with 404 when none is wanted.
+		// So we issue the request directly (see triggerWebhookDirect).
+		result, err := triggerWebhookDirect(client, m, namespace, flowID, key)
+		if err != nil {
+			return err
 		}
-	default:
-		return fmt.Errorf("unsupported method %q: use GET or POST", method)
+		row = result
 	}
 
 	if len(row) == 0 {
@@ -2298,11 +2320,24 @@ func runExecutionsTriggerWebhook(client *Client, namespace, flowID, key, method 
 	})
 }
 
-// triggerWebhookPost issues a POST to the canonical webhook endpoint. The SDK
-// only exposes a POST helper that appends a trailing path segment, which the
-// server rejects with 404, so we build the request directly while reusing the
-// SDK's configured host, default headers, and context-based authentication.
-func triggerWebhookPost(client *Client, namespace, flowID, key string) (map[string]any, error) {
+// webhookResponseRow flattens a WebhookResponse into the fields we render.
+func webhookResponseRow(result *kestra.WebhookResponse) map[string]any {
+	if result == nil {
+		return nil
+	}
+	return map[string]any{
+		"id":        result.GetId(),
+		"namespace": result.GetNamespace(),
+		"flowId":    result.GetFlowId(),
+	}
+}
+
+// triggerWebhookDirect issues a path-less webhook request with the given method.
+// The SDK only exposes *WebhookWithPath helpers for POST/PUT, which append a
+// trailing path segment the server rejects with 404, so we build the request
+// directly while reusing the SDK's configured host, default headers, and
+// context-based authentication.
+func triggerWebhookDirect(client *Client, method, namespace, flowID, key string) (map[string]any, error) {
 	cfg := client.API.GetConfig()
 
 	base := ""
@@ -2322,7 +2357,7 @@ func triggerWebhookPost(client *Client, namespace, flowID, key string) (map[stri
 		url.PathEscape(key),
 	)
 
-	req, err := http.NewRequestWithContext(client.Ctx, http.MethodPost, endpoint, nil)
+	req, err := http.NewRequestWithContext(client.Ctx, method, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/src/cli/executions_test.go
+++ b/src/cli/executions_test.go
@@ -1375,6 +1375,85 @@ func TestExecutionsTriggerWebhookCommand_ClientError(t *testing.T) {
 	}
 }
 
+func TestRunExecutionsTriggerWebhook_GetWithPath(t *testing.T) {
+	var gotMethod, gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"exec-1","namespace":"my.ns","flowId":"my-flow"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runExecutionsTriggerWebhook(newTestClient(t, server.URL), "my.ns", "my-flow", "my-key", "GET", "extra/seg", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runExecutionsTriggerWebhook error: %v", err)
+	}
+	if gotMethod != http.MethodGet {
+		t.Errorf("expected GET, got %s", gotMethod)
+	}
+	if !strings.HasSuffix(gotPath, "/executions/webhook/my.ns/my-flow/my-key/extra/seg") {
+		t.Errorf("unexpected path: %s", gotPath)
+	}
+	if !strings.Contains(buf.String(), "exec-1") {
+		t.Errorf("expected execution id in output, got:\n%s", buf.String())
+	}
+}
+
+func TestRunExecutionsTriggerWebhook_PutWithPath(t *testing.T) {
+	var gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"exec-2","namespace":"my.ns","flowId":"my-flow"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runExecutionsTriggerWebhook(newTestClient(t, server.URL), "my.ns", "my-flow", "my-key", "PUT", "seg", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runExecutionsTriggerWebhook error: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("expected PUT, got %s", gotMethod)
+	}
+}
+
+func TestRunExecutionsTriggerWebhook_PutPathless(t *testing.T) {
+	var gotMethod, gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"exec-3"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runExecutionsTriggerWebhook(newTestClient(t, server.URL), "my.ns", "my-flow", "my-key", "PUT", "", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runExecutionsTriggerWebhook error: %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Errorf("expected PUT, got %s", gotMethod)
+	}
+	if !strings.HasSuffix(gotPath, "/executions/webhook/my.ns/my-flow/my-key") {
+		t.Errorf("unexpected path: %s", gotPath)
+	}
+}
+
+func TestRunExecutionsTriggerWebhook_BadMethod(t *testing.T) {
+	var buf bytes.Buffer
+	err := runExecutionsTriggerWebhook(newTestClient(t, "http://example.invalid"), "my.ns", "my-flow", "my-key", "DELETE", "", newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected error for unsupported method")
+	}
+	if !strings.Contains(err.Error(), "unsupported method") {
+		t.Fatalf("expected unsupported method error, got: %v", err)
+	}
+}
+
 func TestExecutionsWatchCommand_NoArgs(t *testing.T) {
 	cmd := newExecutionsWatchCommand()
 	_, err := executeCommand(cmd)

--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -71,6 +71,7 @@ func newFlowsCommand() *cobra.Command {
 	cmd.AddCommand(newFlowsExportByIdsCommand())
 	cmd.AddCommand(newFlowsExportByQueryCommand())
 	cmd.AddCommand(newFlowsGenerateGraphFromSourceCommand())
+	cmd.AddCommand(newFlowsGenerateGraphCommand())
 	cmd.AddCommand(newFlowsTaskCommand())
 	cmd.AddCommand(newFlowsBulkUpdateCommand())
 	cmd.AddCommand(newFlowsListByNamespaceCommand())
@@ -1548,6 +1549,72 @@ func runFlowsGenerateGraphFromSource(client *Client, source string, subflows []s
 	}
 
 	graph, _, err := req.Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	if graph == nil {
+		graph = kestra.NewFlowGraphWithDefaults()
+	}
+
+	nodes := graph.GetNodes()
+	edges := graph.GetEdges()
+
+	nodeList := make([]map[string]any, len(nodes))
+	for i, n := range nodes {
+		nodeList[i] = map[string]any{"uid": n.GetUid(), "type": n.GetType()}
+	}
+	edgeList := make([]map[string]any, len(edges))
+	for i, e := range edges {
+		edgeList[i] = map[string]any{"source": e.GetSource(), "target": e.GetTarget()}
+	}
+
+	result := map[string]any{"nodes": nodeList, "edges": edgeList}
+	return renderer.Render(result, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "UID\tTYPE")
+		for _, n := range nodes {
+			fmt.Fprintf(w, "%s\t%s\n", n.GetUid(), n.GetType())
+		}
+		fmt.Fprintf(w, "\nEdges: %d\n", len(edges))
+		return nil
+	})
+}
+
+func newFlowsGenerateGraphCommand() *cobra.Command {
+	var (
+		revision int
+		subflows []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "graph <namespace> <flow-id>",
+		Short: "Show the topology graph of an existing flow.",
+		Args:  cobra.ExactArgs(2),
+		Example: `  kestractl flows graph my.namespace my-flow
+  kestractl flows graph my.namespace my-flow --revision 3 --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			var revPtr *int
+			if cmd.Flags().Changed("revision") {
+				revPtr = &revision
+			}
+			return runFlowsGenerateGraph(client, args[0], args[1], revPtr, subflows, renderer)
+		},
+	}
+
+	cmd.Flags().IntVar(&revision, "revision", 0, "Flow revision to graph (defaults to the latest)")
+	cmd.Flags().StringArrayVar(&subflows, "subflow", nil, "Subflow tasks to expand (repeatable)")
+	return cmd
+}
+
+func runFlowsGenerateGraph(client *Client, namespace, id string, revision *int, subflows []string, renderer *Renderer) error {
+	graph, err := client.Kestra.Flows().GenerateFlowGraph(client.Ctx, namespace, id, client.Tenant, revision, subflows)
 	if err != nil {
 		return formatSDKError(err)
 	}

--- a/src/cli/flows_test.go
+++ b/src/cli/flows_test.go
@@ -904,6 +904,58 @@ func TestFlowsTaskCommand_NoArgs(t *testing.T) {
 	}
 }
 
+func TestFlowsGraphCommand_NoArgs(t *testing.T) {
+	cmd := newFlowsGenerateGraphCommand()
+	_, err := executeCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error when no args provided")
+	}
+	if !strings.Contains(err.Error(), "accepts 2 arg") {
+		t.Fatalf("expected args error, got: %v", err)
+	}
+}
+
+func TestRunFlowsGenerateGraph(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/flows/my.namespace/my-flow/graph") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"nodes":[{"uid":"n1","type":"io.kestra.core.tasks.flows.Sequential"}],"edges":[{"source":"n1","target":"n2"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runFlowsGenerateGraph(newTestClient(t, server.URL), "my.namespace", "my-flow", nil, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runFlowsGenerateGraph error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"n1", "Sequential", "Edges: 1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunFlowsGenerateGraph_Revision(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("revision"); got != "3" {
+			t.Errorf("expected revision=3, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"nodes":[],"edges":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	rev := 3
+	var buf bytes.Buffer
+	err := runFlowsGenerateGraph(newTestClient(t, server.URL), "my.namespace", "my-flow", &rev, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runFlowsGenerateGraph error: %v", err)
+	}
+}
+
 func TestFlowsTaskCommand_ClientError(t *testing.T) {
 	original := newClientFunc
 	newClientFunc = func() (*Client, error) {

--- a/src/cli/triggers.go
+++ b/src/cli/triggers.go
@@ -1142,11 +1142,20 @@ func runTriggersBackfillBulkByIds(client *Client, ids []kestra.TriggerController
 }
 
 func newTriggersPauseBackfillByQueryCommand() *cobra.Command {
+	var filterFlags byQueryFilterFlags
+
 	cmd := &cobra.Command{
 		Use:   "pause-backfill-by-query",
 		Short: "Pause backfills for triggers matching query filters.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
 			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			filters, err := filterFlags.resolve()
 			if err != nil {
 				return err
 			}
@@ -1154,18 +1163,28 @@ func newTriggersPauseBackfillByQueryCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runTriggersBackfillBulkByQuery(client, "pause", renderer)
+			return runTriggersBackfillBulkByQuery(client, "pause", filters, renderer)
 		},
 	}
+	addByQueryFilterFlags(cmd, &filterFlags)
 	return cmd
 }
 
 func newTriggersUnpauseBackfillByQueryCommand() *cobra.Command {
+	var filterFlags byQueryFilterFlags
+
 	cmd := &cobra.Command{
 		Use:   "unpause-backfill-by-query",
 		Short: "Unpause backfills for triggers matching query filters.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
 			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			filters, err := filterFlags.resolve()
 			if err != nil {
 				return err
 			}
@@ -1173,18 +1192,28 @@ func newTriggersUnpauseBackfillByQueryCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runTriggersBackfillBulkByQuery(client, "unpause", renderer)
+			return runTriggersBackfillBulkByQuery(client, "unpause", filters, renderer)
 		},
 	}
+	addByQueryFilterFlags(cmd, &filterFlags)
 	return cmd
 }
 
 func newTriggersDeleteBackfillByQueryCommand() *cobra.Command {
+	var filterFlags byQueryFilterFlags
+
 	cmd := &cobra.Command{
 		Use:   "delete-backfill-by-query",
 		Short: "Delete backfills for triggers matching query filters.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
 			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			filters, err := filterFlags.resolve()
 			if err != nil {
 				return err
 			}
@@ -1192,23 +1221,26 @@ func newTriggersDeleteBackfillByQueryCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return runTriggersBackfillBulkByQuery(client, "delete", renderer)
+			return runTriggersBackfillBulkByQuery(client, "delete", filters, renderer)
 		},
 	}
+	addByQueryFilterFlags(cmd, &filterFlags)
 	return cmd
 }
 
-func runTriggersBackfillBulkByQuery(client *Client, op string, renderer *Renderer) error {
+func runTriggersBackfillBulkByQuery(client *Client, op string, filters []kestra.QueryFilter, renderer *Renderer) error {
+	searchFilters := queryFiltersToSearchFilters(filters)
+
 	var result *kestra.ApiAsyncOperationResponse
 	var err error
 
 	switch op {
 	case "pause":
-		result, err = client.Kestra.Triggers().PauseBackfillByQuery(client.Ctx, client.Tenant, nil)
+		result, err = client.Kestra.Triggers().PauseBackfillByQuery(client.Ctx, client.Tenant, searchFilters)
 	case "unpause":
-		result, err = client.Kestra.Triggers().UnpauseBackfillByQuery(client.Ctx, client.Tenant, nil)
+		result, err = client.Kestra.Triggers().UnpauseBackfillByQuery(client.Ctx, client.Tenant, searchFilters)
 	default: // delete
-		result, err = client.Kestra.Triggers().DeleteBackfillByQuery(client.Ctx, client.Tenant, nil)
+		result, err = client.Kestra.Triggers().DeleteBackfillByQuery(client.Ctx, client.Tenant, searchFilters)
 	}
 	if err != nil {
 		return formatSDKError(err)

--- a/src/cli/triggers_test.go
+++ b/src/cli/triggers_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/spf13/cobra"
 )
 
 func TestTriggersListCommand_Help(t *testing.T) {
@@ -591,7 +593,7 @@ func TestTriggersPauseBackfillByQueryCommand_ClientError(t *testing.T) {
 	defer func() { newClientFunc = original }()
 
 	cmd := newTriggersPauseBackfillByQueryCommand()
-	_, err := executeCommand(cmd)
+	_, err := executeCommand(cmd, "--namespace", "my.ns")
 	if err == nil {
 		t.Fatal("expected client error")
 	}
@@ -612,7 +614,7 @@ func TestTriggersUnpauseBackfillByQueryCommand_ClientError(t *testing.T) {
 	defer func() { newClientFunc = original }()
 
 	cmd := newTriggersUnpauseBackfillByQueryCommand()
-	_, err := executeCommand(cmd)
+	_, err := executeCommand(cmd, "--namespace", "my.ns")
 	if err == nil {
 		t.Fatal("expected client error")
 	}
@@ -633,12 +635,81 @@ func TestTriggersDeleteBackfillByQueryCommand_ClientError(t *testing.T) {
 	defer func() { newClientFunc = original }()
 
 	cmd := newTriggersDeleteBackfillByQueryCommand()
-	_, err := executeCommand(cmd)
+	_, err := executeCommand(cmd, "--namespace", "my.ns")
 	if err == nil {
 		t.Fatal("expected client error")
 	}
 	if !strings.Contains(err.Error(), "client error") {
 		t.Fatalf("expected client error, got: %v", err)
+	}
+}
+
+func TestTriggersBackfillByQueryCommand_NoFilter(t *testing.T) {
+	origOutput := globalFlags.Output
+	globalFlags.Output = "table"
+	defer func() { globalFlags.Output = origOutput }()
+
+	for _, tc := range []struct {
+		name string
+		cmd  *cobra.Command
+	}{
+		{"pause", newTriggersPauseBackfillByQueryCommand()},
+		{"unpause", newTriggersUnpauseBackfillByQueryCommand()},
+		{"delete", newTriggersDeleteBackfillByQueryCommand()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := executeCommand(tc.cmd)
+			if err == nil {
+				t.Fatal("expected error when no selection filter is given")
+			}
+			if !strings.Contains(err.Error(), "selection filter is required") {
+				t.Fatalf("expected selection-filter error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestRunTriggersBackfillBulkByQuery_SendsFilters(t *testing.T) {
+	for _, tc := range []struct {
+		op   string
+		path string
+	}{
+		{"pause", "/api/v1/main/triggers/backfill/pause/by-query"},
+		{"unpause", "/api/v1/main/triggers/backfill/unpause/by-query"},
+		{"delete", "/api/v1/main/triggers/backfill/delete/by-query"},
+	} {
+		t.Run(tc.op, func(t *testing.T) {
+			var gotPath, gotQuery string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				gotQuery = r.URL.RawQuery
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"operationId":"op-123","totalItems":4}`))
+			}))
+			defer server.Close()
+
+			filters, err := parseQueryFilters("my.ns", nil)
+			if err != nil {
+				t.Fatalf("parseQueryFilters: %v", err)
+			}
+
+			var buf bytes.Buffer
+			renderer := newTableRenderer(&buf)
+			if err := runTriggersBackfillBulkByQuery(newTestClient(t, server.URL), tc.op, filters, renderer); err != nil {
+				t.Fatalf("runTriggersBackfillBulkByQuery: %v", err)
+			}
+
+			if gotPath != tc.path {
+				t.Fatalf("expected path %q, got %q", tc.path, gotPath)
+			}
+			// The namespace selection must reach the server as a filter param.
+			if !strings.Contains(gotQuery, "filters%5Bnamespace%5D%5BEQUALS%5D=my.ns") {
+				t.Fatalf("expected namespace filter in query, got %q", gotQuery)
+			}
+			if !strings.Contains(buf.String(), "4 trigger(s) scheduled") {
+				t.Fatalf("expected summary in output, got: %s", buf.String())
+			}
+		})
 	}
 }
 

--- a/src/cli/users.go
+++ b/src/cli/users.go
@@ -34,6 +34,7 @@ Users are instance-level resources. Managing users requires Kestra Enterprise Ed
 	cmd.AddCommand(newUsersImpersonateCommand())
 	cmd.AddCommand(newUsersRevokeRefreshTokenCommand())
 	cmd.AddCommand(newUsersPatchSuperAdminCommand())
+	cmd.AddCommand(newUsersSetRestrictedCommand())
 	cmd.AddCommand(newUsersDeleteAuthMethodCommand())
 	cmd.AddCommand(newUsersChangeMyPasswordCommand())
 
@@ -882,6 +883,51 @@ func runUsersPatchSuperAdmin(client *Client, id string, superAdmin bool, rendere
 		map[string]any{"id": id, "superAdmin": superAdmin, "status": status})
 }
 
+func newUsersSetRestrictedCommand() *cobra.Command {
+	var restricted bool
+
+	cmd := &cobra.Command{
+		Use:   "set-restricted <id>",
+		Short: "Mark a user as restricted, or lift the restriction. Superadmin only.",
+		Long: `Set whether a user is restricted via the dedicated restricted endpoint.
+
+This is a targeted PATCH, unlike 'users update --restricted' which performs a
+full-replace of the user. Use this when you only want to toggle the flag.`,
+		Args: cobra.ExactArgs(1),
+		Example: `  kestractl users set-restricted <id> --restricted=true
+  kestractl users set-restricted <id> --restricted=false`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runUsersSetRestricted(client, args[0], restricted, renderer)
+		},
+	}
+
+	cmd.Flags().BoolVar(&restricted, "restricted", false, "Set restricted status (true or false)")
+	return cmd
+}
+
+func runUsersSetRestricted(client *Client, id string, restricted bool, renderer *Renderer) error {
+	body := kestra.IAMUserControllerApiPatchRestrictedRequest{Restricted: restricted}
+	if err := client.Kestra.Users().PatchUserDemo(client.Ctx, id, body); err != nil {
+		return formatSDKError(err)
+	}
+
+	status := "lifted"
+	if restricted {
+		status = "applied"
+	}
+	return renderStatus(renderer,
+		fmt.Sprintf("Restriction %s for user '%s'.", status, id),
+		map[string]any{"id": id, "restricted": restricted, "status": status})
+}
+
 func newUsersDeleteAuthMethodCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete-auth-method <id> <auth-method>",
@@ -926,9 +972,9 @@ func newUsersChangeMyPasswordCommand() *cobra.Command {
 	var oldPassword, newPassword string
 
 	cmd := &cobra.Command{
-		Use:   "change-my-password",
-		Short: "Change the current user's own password.",
-		Long:  "Update the password for the currently authenticated user using the old and new passwords.",
+		Use:     "change-my-password",
+		Short:   "Change the current user's own password.",
+		Long:    "Update the password for the currently authenticated user using the old and new passwords.",
 		Example: `  kestractl users change-my-password --old-password <current> --new-password <new>`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())

--- a/src/cli/users_test.go
+++ b/src/cli/users_test.go
@@ -593,6 +593,66 @@ func TestRunUsersPatchSuperAdmin_Revoke(t *testing.T) {
 	}
 }
 
+func TestUsersSetRestrictedCommand_NoArgs(t *testing.T) {
+	origOutput := globalFlags.Output
+	globalFlags.Output = "table"
+	defer func() { globalFlags.Output = origOutput }()
+
+	cmd := newUsersSetRestrictedCommand()
+	_, err := executeCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error when no args provided")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Fatalf("expected args error, got: %v", err)
+	}
+}
+
+func TestRunUsersSetRestricted_Apply(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.Method != http.MethodPatch {
+			http.Error(w, "wrong method", http.StatusMethodNotAllowed)
+			return
+		}
+		if !strings.HasSuffix(r.URL.Path, "/restricted") {
+			http.Error(w, "wrong path: "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runUsersSetRestricted(newTestClient(t, server.URL), "user-id-123", true, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runUsersSetRestricted error: %v", err)
+	}
+	if !hit {
+		t.Error("expected PATCH request to be made")
+	}
+	if !strings.Contains(buf.String(), "applied") {
+		t.Errorf("expected 'applied' message, got:\n%s", buf.String())
+	}
+}
+
+func TestRunUsersSetRestricted_Lift(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runUsersSetRestricted(newTestClient(t, server.URL), "user-id-123", false, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runUsersSetRestricted error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "lifted") {
+		t.Errorf("expected 'lifted' message, got:\n%s", buf.String())
+	}
+}
+
 func TestUsersDeleteAuthMethodCommand_NoArgs(t *testing.T) {
 	origOutput := globalFlags.Output
 	globalFlags.Output = "table"


### PR DESCRIPTION
## Summary

Closes the remaining Kestra Go SDK coverage gaps in kestractl, working through the API groups one at a time. Each commit is scoped to a single resource area (source + tests + README), one commit per API.

## Changes

| Commit | What |
|---|---|
| `feat(apps)` | Wrap remaining AppsAPI SDK endpoints |
| `feat(blueprints)` | Wrap remaining BlueprintsAPI SDK endpoints |
| `feat(dashboards)` | Wrap remaining DashboardsAPI SDK endpoints |
| `feat(assets)` | Wrap remaining AssetsAPI SDK endpoints |
| `feat(flows)` | Wrap `GenerateFlowGraph` SDK endpoint |
| `fix(triggers)` | Forward selection filters in backfill-by-query commands (filters were being dropped) |
| `feat(users)` | Add `users set-restricted` (targeted PATCH `/users/{id}/restricted`) |
| `feat(executions)` | Support PUT and `--path` suffix for `trigger-webhook` (wires the three `*WebhookWithPath` SDK methods) |

## Audit note

The full SDK coverage-gaps list was audited end to end. The remaining groups — BindingsAPI, InvitationsAPI, LogsAPI, KvAPI, NamespacesAPI, TestSuitesAPI — were already fully wrapped, and the "unresolved" entries are SDK-naming-quirk false positives (live, compiling calls). Only the genuine gaps above required new work.

## Testing

- `go build -o kestractl .` — clean
- `gofmt -l src/cli/` — clean
- `go test ./src/...` — 735 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
