### PR TITLE
fix(install): strip v prefix from tag name for asset lookup

### DIFF
--- a/install-scripts/install.sh
+++ b/install-scripts/install.sh
@@ -83,7 +83,7 @@ if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
 else
   download "https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${VERSION}" "$release_json"
 fi
-VERSION="$(awk -F '"' '/"tag_name":/ {print $4; exit}' "$release_json")"
+VERSION="$(awk -F '"' '/"tag_name":/ {print $4; exit}' "$release_json" | sed 's/^v//')"
 
 
 asset_name="${BINARY_NAME}_${VERSION}_${os}_${arch}"


### PR DESCRIPTION
## Summary
- Release asset lookup failed for `v`-prefixed tags (e.g. `v1.16.0`) because the script built the filename `kestractl_v1.16.0_linux_amd64` while the actual asset is `kestractl_1.16.0_linux_amd64`
- Strip leading `v` from the tag after extraction via `sed 's/^v//'` — no-op for bare tags, fixes `v`-prefixed ones

Fixes #81

## Test plan
- [ ] `curl … | bash` installs successfully for `v1.16.0`
- [ ] Install still works for a bare-tagged release (e.g. `1.15.0`)
- [ ] `VERSION=v1.16.0 bash install.sh` works