### PR TITLE
fix(flows): tolerate array-format labels in get/list/deploy (#83)

### DIFF
--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -498,7 +498,7 @@ Returns a table showing flow ID, namespace, description, and revision number.`,
 }
 
 func runFlowsList(client *Client, namespace string, renderer *Renderer) error {
-	var flows []kestra.Flow
+	var flows []parsedFlow
 	if namespace == "" {
 		var err error
 		flows, err = listAllFlows(client)
@@ -506,63 +506,215 @@ func runFlowsList(client *Client, namespace string, renderer *Renderer) error {
 			return err
 		}
 	} else {
-		var err error
-		flows, _, err = client.API.FlowsAPI.ListFlowsByNamespace(client.Ctx, namespace, client.Tenant).Execute()
+		sdkFlows, _, err := client.API.FlowsAPI.ListFlowsByNamespace(client.Ctx, namespace, client.Tenant).Execute()
 		if err != nil {
-			return formatSDKError(err)
+			// The generated client cannot decode array-format labels (#83);
+			// recover the flows from the raw response body.
+			parsed, ok := tryParseFlowListFromError(err)
+			if !ok {
+				return formatSDKError(err)
+			}
+			flows = parsed
+		} else {
+			flows = make([]parsedFlow, len(sdkFlows))
+			for i, f := range sdkFlows {
+				flows[i] = parsedFlowFromFlow(f)
+			}
 		}
 	}
 
 	result := make([]map[string]any, len(flows))
 	for i, flow := range flows {
 		result[i] = map[string]any{
-			"id":          flow.GetId(),
-			"namespace":   flow.GetNamespace(),
-			"description": flow.GetDescription(),
-			"revision":    flow.GetRevision(),
+			"id":          flow.ID,
+			"namespace":   flow.Namespace,
+			"description": flow.Description,
+			"revision":    flow.Revision,
 		}
 	}
 
 	return renderer.Render(result, func(w *tabwriter.Writer) error {
 		fmt.Fprintln(w, "ID\tNamespace\tDescription\tRevision")
 		for _, flow := range flows {
-			desc := flow.GetDescription()
+			desc := flow.Description
 			if desc == "" {
 				desc = "-"
 			}
 			fmt.Fprintf(w, "%s\t%s\t%s\t%d\n",
-				flow.GetId(),
-				flow.GetNamespace(),
+				flow.ID,
+				flow.Namespace,
 				desc,
-				flow.GetRevision())
+				flow.Revision)
 		}
 		return nil
 	})
 }
 
-func listAllFlows(client *Client) ([]kestra.Flow, error) {
+func listAllFlows(client *Client) ([]parsedFlow, error) {
 	const pageSize int32 = 1000
 	page := int32(1)
-	results := make([]kestra.Flow, 0)
+	results := make([]parsedFlow, 0)
 
 	for {
 		resp, _, err := client.API.FlowsAPI.SearchFlows(client.Ctx, client.Tenant).
 			Page(page).
 			Size(pageSize).
 			Execute()
+
+		var batch []parsedFlow
+		var total int64
 		if err != nil {
-			return nil, formatSDKError(err)
+			// The generated client cannot decode array-format labels (#83);
+			// recover the flows from the raw response body.
+			parsed, parsedTotal, ok := tryParseFlowSearchFromError(err)
+			if !ok {
+				return nil, formatSDKError(err)
+			}
+			batch, total = parsed, parsedTotal
+		} else {
+			for _, f := range resp.GetResults() {
+				batch = append(batch, parsedFlowFromFlow(f))
+			}
+			total = resp.GetTotal()
 		}
-		batch := resp.GetResults()
+
 		results = append(results, batch...)
 
-		if len(batch) == 0 || int64(len(results)) >= resp.GetTotal() {
+		if len(batch) == 0 || int64(len(results)) >= total {
 			break
 		}
 		page++
 	}
 
 	return results, nil
+}
+
+// parsedFlow holds the flow fields kestractl renders, recovered from a raw JSON
+// response body. See the tryParseFlow* helpers below.
+type parsedFlow struct {
+	ID          string
+	Namespace   string
+	Description string
+	Revision    int32
+	Source      string
+}
+
+// parsedFlowFromFlow normalizes a decoded SDK Flow into a parsedFlow.
+func parsedFlowFromFlow(f kestra.Flow) parsedFlow {
+	return parsedFlow{
+		ID:          f.GetId(),
+		Namespace:   f.GetNamespace(),
+		Description: f.GetDescription(),
+		Revision:    f.GetRevision(),
+	}
+}
+
+// parsedFlowFromMap extracts flow fields from a raw JSON object. Labels are
+// intentionally ignored (kestractl does not render them) — that field is
+// exactly what the generated client cannot decode (see tryParseFlowFromError).
+func parsedFlowFromMap(m map[string]any) parsedFlow {
+	f := parsedFlow{}
+	if v, ok := m["id"].(string); ok {
+		f.ID = v
+	}
+	if v, ok := m["namespace"].(string); ok {
+		f.Namespace = v
+	}
+	if v, ok := m["description"].(string); ok {
+		f.Description = v
+	}
+	if v, ok := m["source"].(string); ok {
+		f.Source = v
+	}
+	if v, ok := m["revision"].(float64); ok {
+		f.Revision = int32(v)
+	}
+	return f
+}
+
+// tryParseFlowFromError recovers a single flow from the raw body of a known SDK
+// deserialization failure. Kestra returns flow labels as an array
+// ([{"key":..,"value":..}]) but the generated client types the field as an
+// object, so decoding an otherwise-successful (200) response fails. The SDK
+// preserves the raw body on the returned GenericOpenAPIError, so we parse the
+// fields we need ourselves. See kestra-io/kestractl#83.
+//
+// Returns false when the error is a genuine failure (no JSON body, or a body
+// without an "id"), so the caller propagates it.
+func tryParseFlowFromError(err error) (*parsedFlow, bool) {
+	sdkErr, ok := err.(*kestra.GenericOpenAPIError)
+	if !ok {
+		return nil, false
+	}
+	body := sdkErr.Body()
+	if len(body) == 0 {
+		return nil, false
+	}
+	var m map[string]any
+	if json.Unmarshal(body, &m) != nil {
+		return nil, false
+	}
+	if _, hasID := m["id"]; !hasID {
+		return nil, false
+	}
+	f := parsedFlowFromMap(m)
+	return &f, true
+}
+
+// tryParseFlowListFromError recovers a list of flows from the raw body of the
+// same SDK label-decoding failure, for endpoints that return a top-level JSON
+// array (ListFlowsByNamespace). See tryParseFlowFromError and #83.
+func tryParseFlowListFromError(err error) ([]parsedFlow, bool) {
+	sdkErr, ok := err.(*kestra.GenericOpenAPIError)
+	if !ok {
+		return nil, false
+	}
+	body := sdkErr.Body()
+	if len(body) == 0 {
+		return nil, false
+	}
+	var raw []any
+	if json.Unmarshal(body, &raw) != nil {
+		return nil, false
+	}
+	flows := make([]parsedFlow, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		flows = append(flows, parsedFlowFromMap(m))
+	}
+	return flows, true
+}
+
+// tryParseFlowSearchFromError recovers flows from the raw body of the same SDK
+// label-decoding failure, for the paged SearchFlows endpoint whose body is
+// {"results":[...],"total":N}. See tryParseFlowFromError and #83.
+func tryParseFlowSearchFromError(err error) ([]parsedFlow, int64, bool) {
+	sdkErr, ok := err.(*kestra.GenericOpenAPIError)
+	if !ok {
+		return nil, 0, false
+	}
+	body := sdkErr.Body()
+	if len(body) == 0 {
+		return nil, 0, false
+	}
+	var raw struct {
+		Results []map[string]any `json:"results"`
+		Total   int64            `json:"total"`
+	}
+	if json.Unmarshal(body, &raw) != nil {
+		return nil, 0, false
+	}
+	if raw.Results == nil {
+		return nil, 0, false
+	}
+	flows := make([]parsedFlow, 0, len(raw.Results))
+	for _, m := range raw.Results {
+		flows = append(flows, parsedFlowFromMap(m))
+	}
+	return flows, raw.Total, true
 }
 
 func newFlowsGetCommand() *cobra.Command {
@@ -595,24 +747,35 @@ Use --output json to include metadata alongside the source.`,
 }
 
 func runFlowsGet(client *Client, namespace, flowID string, renderer *Renderer) error {
+	var (
+		id, ns, source string
+		revision       int32
+	)
+
 	flow, _, err := client.API.FlowsAPI.Flow(client.Ctx, namespace, flowID, client.Tenant).
 		Source(true).
 		AllowDeleted(false).
 		Execute()
 	if err != nil {
-		return formatSDKError(err)
+		// The generated client cannot decode array-format labels (#83);
+		// recover the flow from the raw response body.
+		parsed, ok := tryParseFlowFromError(err)
+		if !ok {
+			return formatSDKError(err)
+		}
+		id, ns, revision, source = parsed.ID, parsed.Namespace, parsed.Revision, parsed.Source
+	} else {
+		if flow == nil {
+			return fmt.Errorf("flow not found")
+		}
+		id, ns, revision, source = flow.GetId(), flow.GetNamespace(), flow.GetRevision(), flow.GetSource()
 	}
-	if flow == nil {
-		return fmt.Errorf("flow not found")
-	}
-
-	source := flow.GetSource()
 
 	if renderer.IsJSON() {
 		result := map[string]any{
-			"id":        flow.GetId(),
-			"namespace": flow.GetNamespace(),
-			"revision":  flow.GetRevision(),
+			"id":        id,
+			"namespace": ns,
+			"revision":  revision,
 			"source":    source,
 		}
 		return renderer.RenderJSON(result)
@@ -1149,6 +1312,10 @@ func deployFlow(client *Client, filePath string, namespaceOverride string, overr
 		Execute()
 	if checkErr == nil {
 		exists = true
+	} else if _, ok := tryParseFlowFromError(checkErr); ok {
+		// The generated client cannot decode array-format labels (#83), but a
+		// body that parses to a flow means it exists — proceed to the update.
+		exists = true
 	} else if resp != nil && resp.StatusCode != 404 {
 		result.Error = formatSDKError(checkErr).Error()
 		return result
@@ -1165,20 +1332,33 @@ func deployFlow(client *Client, filePath string, namespaceOverride string, overr
 			Body(yamlContent).
 			Execute()
 		if err != nil {
-			result.Error = formatSDKError(err).Error()
-			return result
+			// The generated client cannot decode array-format labels (#83), but
+			// the update still succeeded; recover the revision from the raw body.
+			parsed, ok := tryParseFlowFromError(err)
+			if !ok {
+				result.Error = formatSDKError(err).Error()
+				return result
+			}
+			result.Revision = parsed.Revision
+		} else {
+			result.Revision = updateResp.GetRevision()
 		}
-		result.Revision = updateResp.GetRevision()
 	} else {
 		// Create new flow
 		flowResp, _, err := client.API.FlowsAPI.CreateFlow(client.Ctx, client.Tenant).
 			Body(yamlContent).
 			Execute()
 		if err != nil {
-			result.Error = formatSDKError(err).Error()
-			return result
+			// Same array-format labels decode failure as above (#83).
+			parsed, ok := tryParseFlowFromError(err)
+			if !ok {
+				result.Error = formatSDKError(err).Error()
+				return result
+			}
+			result.Revision = parsed.Revision
+		} else {
+			result.Revision = flowResp.GetRevision()
 		}
-		result.Revision = flowResp.GetRevision()
 	}
 
 	result.Success = true

--- a/src/cli/flows_test.go
+++ b/src/cli/flows_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -1494,5 +1495,266 @@ func TestRunFlowsNamespaceSync(t *testing.T) {
 	}
 	if !strings.Contains(buf.String(), "prod") {
 		t.Errorf("expected namespace in output, got:\n%s", buf.String())
+	}
+}
+
+// --- Array-format labels regression tests (kestra-io/kestractl#83) -----------
+//
+// Kestra returns flow labels as a JSON array ([{"key":..,"value":..}]) which the
+// generated client cannot decode into its object-typed field, failing every
+// flows get/list/deploy against a namespace that has labelled flows. These tests
+// drive the real SDK against a stub server returning array-format labels and
+// assert the commands recover from the raw response body.
+
+// A complete, otherwise-valid flow that fails to decode ONLY because of its
+// array-format labels — faithfully reproducing #83 (see the assertion in
+// TestConfirmArrayLabelsDecodeError).
+const flowWithArrayLabelsJSON = `{"id":"my-flow","namespace":"my.namespace","revision":2,"description":"labelled flow","disabled":false,"deleted":false,"tasks":[],"source":"id: my-flow\nnamespace: my.namespace\nlabels:\n  - key: type\n    value: data_extraction\n","labels":[{"key":"type","value":"data_extraction"},{"key":"version","value":"v2"}]}`
+
+func TestRunFlowsGet_ArrayLabels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/flows/my.namespace/my-flow") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(flowWithArrayLabelsJSON))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runFlowsGet(newTestClient(t, server.URL), "my.namespace", "my-flow", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runFlowsGet error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "data_extraction") {
+		t.Errorf("expected flow source in output, got:\n%s", buf.String())
+	}
+}
+
+func TestRunFlowsGet_ArrayLabels_JSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(flowWithArrayLabelsJSON))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runFlowsGet(newTestClient(t, server.URL), "my.namespace", "my-flow", newJSONRenderer(&buf)); err != nil {
+		t.Fatalf("runFlowsGet error: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if got["id"] != "my-flow" {
+		t.Errorf("expected id my-flow, got %v", got["id"])
+	}
+	if got["revision"] != float64(2) {
+		t.Errorf("expected revision 2, got %v", got["revision"])
+	}
+	if !strings.Contains(got["source"].(string), "data_extraction") {
+		t.Errorf("expected recovered source, got %v", got["source"])
+	}
+}
+
+func TestRunFlowsList_Namespace_ArrayLabels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/flows/my.namespace") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[" + flowWithArrayLabelsJSON + `,{"id":"second","namespace":"my.namespace","revision":1,"disabled":false,"deleted":false,"tasks":[],"labels":[{"key":"team","value":"data"}]}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runFlowsList(newTestClient(t, server.URL), "my.namespace", newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runFlowsList error: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{"my-flow", "second", "labelled flow"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestListAllFlows_Search_ArrayLabels(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/flows/search") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[` + flowWithArrayLabelsJSON + `],"total":1}`))
+	}))
+	t.Cleanup(server.Close)
+
+	// namespace "" routes through listAllFlows -> SearchFlows.
+	var buf bytes.Buffer
+	if err := runFlowsList(newTestClient(t, server.URL), "", newTableRenderer(&buf)); err != nil {
+		t.Fatalf("runFlowsList (all) error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "my-flow") {
+		t.Errorf("expected flow in output, got:\n%s", buf.String())
+	}
+}
+
+func TestDeployFlow_OverrideWithArrayLabels(t *testing.T) {
+	var putCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			// Exists-check: 200 with array-format labels -> decode fails but flow exists.
+			_, _ = w.Write([]byte(flowWithArrayLabelsJSON))
+		case http.MethodPut:
+			putCalled = true
+			// Update response also carries the array-format labels.
+			_, _ = w.Write([]byte(`{"id":"my-flow","namespace":"my.namespace","revision":3,"disabled":false,"deleted":false,"tasks":[],"labels":[{"key":"type","value":"data_extraction"}]}`))
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "flow-*.yaml")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	_, _ = tmpFile.WriteString("id: my-flow\nnamespace: my.namespace\nlabels:\n  - key: type\n    value: data_extraction\ntasks:\n  - id: t1\n    type: io.kestra.plugin.core.log.Log\n    message: hi\n")
+	tmpFile.Close()
+
+	result := deployFlow(newTestClient(t, server.URL), tmpFile.Name(), "", true)
+	if !result.Success {
+		t.Fatalf("expected deploy success, got error: %s", result.Error)
+	}
+	if !putCalled {
+		t.Error("expected the update PUT to be issued")
+	}
+	if result.Revision != 3 {
+		t.Errorf("expected revision 3, got %d", result.Revision)
+	}
+}
+
+func TestDeployFlow_CreateWithArrayLabels(t *testing.T) {
+	var postCalled bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			// Exists-check: flow does not exist.
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodPost:
+			postCalled = true
+			_, _ = w.Write([]byte(`{"id":"my-flow","namespace":"my.namespace","revision":1,"disabled":false,"deleted":false,"tasks":[],"labels":[{"key":"type","value":"data_extraction"}]}`))
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "flow-*.yaml")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	_, _ = tmpFile.WriteString("id: my-flow\nnamespace: my.namespace\nlabels:\n  - key: type\n    value: data_extraction\ntasks:\n  - id: t1\n    type: io.kestra.plugin.core.log.Log\n    message: hi\n")
+	tmpFile.Close()
+
+	result := deployFlow(newTestClient(t, server.URL), tmpFile.Name(), "", false)
+	if !result.Success {
+		t.Fatalf("expected deploy success, got error: %s", result.Error)
+	}
+	if !postCalled {
+		t.Error("expected the create POST to be issued")
+	}
+	if result.Revision != 1 {
+		t.Errorf("expected revision 1, got %d", result.Revision)
+	}
+}
+
+func TestTryParseFlowFromError(t *testing.T) {
+	t.Run("recovers flow from labelled body", func(t *testing.T) {
+		sdkErr := &kestra.GenericOpenAPIError{}
+		setGenericOpenAPIErrorBody(sdkErr, []byte(flowWithArrayLabelsJSON))
+		f, ok := tryParseFlowFromError(sdkErr)
+		if !ok {
+			t.Fatal("expected recovery to succeed")
+		}
+		if f.ID != "my-flow" || f.Namespace != "my.namespace" || f.Revision != 2 {
+			t.Errorf("unexpected parsed flow: %+v", f)
+		}
+		if !strings.Contains(f.Source, "data_extraction") {
+			t.Errorf("expected source recovered, got %q", f.Source)
+		}
+	})
+
+	t.Run("propagates genuine error body without id", func(t *testing.T) {
+		sdkErr := &kestra.GenericOpenAPIError{}
+		setGenericOpenAPIErrorBody(sdkErr, []byte(`{"message":"boom"}`))
+		if _, ok := tryParseFlowFromError(sdkErr); ok {
+			t.Fatal("expected recovery to fail for an error body without an id")
+		}
+	})
+
+	t.Run("ignores non-SDK errors", func(t *testing.T) {
+		if _, ok := tryParseFlowFromError(errors.New("plain error")); ok {
+			t.Fatal("expected recovery to fail for a non-SDK error")
+		}
+	})
+}
+
+func TestTryParseFlowListFromError(t *testing.T) {
+	t.Run("recovers array body", func(t *testing.T) {
+		sdkErr := &kestra.GenericOpenAPIError{}
+		setGenericOpenAPIErrorBody(sdkErr, []byte("["+flowWithArrayLabelsJSON+"]"))
+		flows, ok := tryParseFlowListFromError(sdkErr)
+		if !ok || len(flows) != 1 || flows[0].ID != "my-flow" {
+			t.Fatalf("unexpected recovery: ok=%v flows=%+v", ok, flows)
+		}
+	})
+
+	t.Run("rejects non-array body", func(t *testing.T) {
+		sdkErr := &kestra.GenericOpenAPIError{}
+		setGenericOpenAPIErrorBody(sdkErr, []byte(`{"message":"boom"}`))
+		if _, ok := tryParseFlowListFromError(sdkErr); ok {
+			t.Fatal("expected recovery to fail for a non-array body")
+		}
+	})
+}
+
+func TestTryParseFlowSearchFromError(t *testing.T) {
+	t.Run("recovers paged body", func(t *testing.T) {
+		sdkErr := &kestra.GenericOpenAPIError{}
+		setGenericOpenAPIErrorBody(sdkErr, []byte(`{"results":[`+flowWithArrayLabelsJSON+`],"total":7}`))
+		flows, total, ok := tryParseFlowSearchFromError(sdkErr)
+		if !ok || total != 7 || len(flows) != 1 || flows[0].ID != "my-flow" {
+			t.Fatalf("unexpected recovery: ok=%v total=%d flows=%+v", ok, total, flows)
+		}
+	})
+
+	t.Run("rejects body without results", func(t *testing.T) {
+		sdkErr := &kestra.GenericOpenAPIError{}
+		setGenericOpenAPIErrorBody(sdkErr, []byte(`{"message":"boom"}`))
+		if _, _, ok := tryParseFlowSearchFromError(sdkErr); ok {
+			t.Fatal("expected recovery to fail for a body without results")
+		}
+	})
+}
+
+// TestConfirmArrayLabelsDecodeError guards fixture fidelity: it asserts that the
+// shared fixture is a valid flow that the generated client fails to decode
+// *specifically* because of its array-format labels — i.e. the exact condition
+// from #83 that the tryParseFlow* fallbacks exist to recover from. If the SDK is
+// ever regenerated to accept array labels, this test flips and the workaround
+// (and its tests) can be retired.
+func TestConfirmArrayLabelsDecodeError(t *testing.T) {
+	var fws kestra.FlowWithSource
+	err := json.Unmarshal([]byte(flowWithArrayLabelsJSON), &fws)
+	if err == nil {
+		t.Fatal("fixture no longer reproduces #83: decode unexpectedly succeeded")
+	}
+	if !strings.Contains(err.Error(), "labels") {
+		t.Fatalf("fixture fails to decode for the wrong reason (want a labels error): %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #83 on `main` (forward-port of #84, which targets `releases/v1.3.x`).

`flows get`, `flows list`, and `flows deploy --override` fail with `json: cannot unmarshal array into Go struct field ...labels` for any namespace containing a flow that uses array-format labels.

**Root cause:** Kestra returns labels as a JSON array (`[{"key":..,"value":..}]`), but the generated `client-sdk/go-sdk v1.1.0` (pinned on `main`) types the field as an object (`*MapObjectObject`). On an otherwise-successful **200** response, the SDK's decode step fails and wraps the failure as a `GenericOpenAPIError` — carrying the intact raw body. No SDK release fixes the typing, so we work around it client-side. `deploy --override` was hit twice: the pre-flight exists-check *and* the PUT/POST response both decode-fail, so the update never landed.

This is not 1.3-specific — the array form is the standard label representation, so `main` reproduces the same failure against any server with labelled flows.

## Fix

Recover from the SDK's preserved raw body, following the existing `tryParse*FromError` pattern in `client.go`. Added flow-specific helpers covering every affected shape:

- `tryParseFlowFromError` — single `FlowWithSource` (get, deploy exists-check, update/create responses)
- `tryParseFlowListFromError` — top-level array (`ListFlowsByNamespace`)
- `tryParseFlowSearchFromError` — paged `{results,total}` (`SearchFlows`), preserving `total` so pagination still terminates

For the deploy exists-check, a 200 body that parses to a flow now means "exists" → proceed to the PUT. Labels are intentionally ignored — kestractl doesn't render them, so there's no functional loss.

## Tests

- End-to-end tests through the real SDK via `httptest`, returning genuine array-format labels (get table+JSON, list-by-namespace, list-all/search, deploy override, deploy create)
- Unit tests for each parse helper incl. negative cases (non-SDK error, error body without `id`, non-array/non-paged bodies) so genuine errors still propagate
- `TestConfirmArrayLabelsDecodeError` — a fidelity guard asserting the fixture fails to decode *specifically* on labels; flips red if the SDK is ever regenerated to accept arrays

Full suite passes; `go build` and `go vet` clean.

## Live QA (Kestra 1.3.24 EE)

Reproduced the exact issue on the prior binary and confirmed the fix on the same instance/flow:

| Command | Before | After |
|---|---|---|
| `flows get` | ❌ `_FlowWithSource.labels` | ✅ |
| `flows list <ns>` | ❌ `_Flow.labels` | ✅ |
| `flows list` (search) | ❌ `_PagedResultsFlow.results.labels` | ✅ |
| `flows deploy --override` | ❌ FAILED, PUT never issued | ✅ revision bumped 1→2 |

## Related

- #84 — same fix targeting `releases/v1.3.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)