### PR TITLE
test(flows): add regression coverage for FORM-typed inputs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,12 @@ module github.com/kestra-io/kestractl
 go 1.25
 
 require (
-	github.com/kestra-io/client-sdk/go-sdk v1.1.0
+	// Pseudo-version of client-sdk/go-sdk@main (tracks Kestra develop). Do not
+	// `go get -u` this: v1.3.0 is a real tag from releases/v1.3.x (Kestra 1.3.x's
+	// API) and sorts higher than this pseudo-version, so an unguarded upgrade
+	// would silently swap back to the wrong API surface. Re-resolve deliberately
+	// with `go get github.com/kestra-io/client-sdk/go-sdk@main`.
+	github.com/kestra-io/client-sdk/go-sdk v1.1.1-0.20260702143038-8c3851bea2e1
 	github.com/posthog/posthog-go v1.10.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/kestra-io/client-sdk/go-sdk v1.1.0 h1:fgSd9U6bxZq1kRy+erAGky+nhws+PzJjQhCVQQbcQVI=
-github.com/kestra-io/client-sdk/go-sdk v1.1.0/go.mod h1:6oIOWghMHfNXWJcs/HA9qr6oMagBFBHoVrhPsdBEep4=
+github.com/kestra-io/client-sdk/go-sdk v1.1.1-0.20260702143038-8c3851bea2e1 h1:Hc0W4Q1DchEaqRlrMi6SVDuO213jLyeyDrsbK5GMDig=
+github.com/kestra-io/client-sdk/go-sdk v1.1.1-0.20260702143038-8c3851bea2e1/go.mod h1:6oIOWghMHfNXWJcs/HA9qr6oMagBFBHoVrhPsdBEep4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/src/cli/apps_test.go
+++ b/src/cli/apps_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -515,7 +516,9 @@ func TestRunAppsTags(t *testing.T) {
 }
 
 func TestRunAppsCatalog(t *testing.T) {
+	var gotQuery string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"results":[
 			{"uid":"cat-1","name":"Reporting","type":"DASHBOARD","tags":["analytics"],"description":"A report app"}
@@ -527,6 +530,9 @@ func TestRunAppsCatalog(t *testing.T) {
 	err := runAppsCatalog(newTestClient(t, server.URL), "report", 1, 100, newTableRenderer(&buf))
 	if err != nil {
 		t.Fatalf("runAppsCatalog error: %v", err)
+	}
+	if q, err := url.ParseQuery(gotQuery); err != nil || q.Get("filters[q][EQUALS]") != "report" {
+		t.Errorf("expected filters[q][EQUALS]=report in query %q", gotQuery)
 	}
 	out := buf.String()
 	for _, want := range []string{"cat-1", "Reporting", "DASHBOARD", "analytics", "Total catalog apps: 1"} {

--- a/src/cli/flows_form_input_test.go
+++ b/src/cli/flows_form_input_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression coverage for the originally reported bug: `flows list`/`ls` erroring
+// with "FORM is not a valid Type" whenever a returned flow has a FORM input, because
+// the bundled go-sdk's Type enum used to be closed and didn't include FORM.
+//
+// On current main this already passes without any SDK change: PR #83's generic
+// GenericOpenAPIError raw-body recovery (tryParseFlowListFromError / tryParseFlowSearchFromError)
+// kicks in on any decode failure, not just the array-format-labels bug it was written
+// for, and neither recovery path nor parsedFlow reads the "type"/"inputs" fields anyway.
+// These tests document and lock in that behavior; they do not exercise the go-sdk fix
+// itself (see go-sdk/kestra_api_client/model_type_test.go in client-sdk for that).
+const flowWithFormInputJSON = `{"id":"f1","namespace":"my.namespace","disabled":false,"deleted":false,"tasks":[{"id":"t","type":"io.kestra.plugin.core.log.Log"}],"inputs":[{"id":"myform","type":"FORM"}]}`
+
+func TestListAllFlows_ToleratesFormInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[` + flowWithFormInputJSON + `],"total":1}`))
+	}))
+	t.Cleanup(server.Close)
+
+	flows, err := listAllFlows(newTestClient(t, server.URL))
+	if err != nil {
+		t.Fatalf("listAllFlows should tolerate a FORM input, got error: %v", err)
+	}
+	if len(flows) != 1 || flows[0].ID != "f1" {
+		t.Fatalf("expected flow f1 to be listed, got: %+v", flows)
+	}
+}
+
+func TestRunFlowsList_Namespace_ToleratesFormInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[` + flowWithFormInputJSON + `]`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runFlowsList(newTestClient(t, server.URL), "my.namespace", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runFlowsList should tolerate a FORM input, got error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "f1") {
+		t.Fatalf("expected flow f1 in output, got:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
## Summary
- Regression test for the originally reported bug: `flows list`/`ls` erroring with `FORM is not a valid Type` when a flow has a FORM input, because the pinned go-sdk's `Type` enum was closed and predated `FORM`.
- `list`/`ls`/`get`/`deploy` already tolerated this decode failure via PR #83's raw-body recovery (`tryParseFlowFromError`/`tryParseFlowListFromError`/`tryParseFlowSearchFromError`), independent of the bug it was originally written for.
- `flows search`, `flows revisions`, and `flows bulk-update` were **not** covered by that recovery and needed a real dependency fix: pinned `go-sdk` to a pseudo-version off client-sdk's `main` branch (`go get github.com/kestra-io/client-sdk/go-sdk@main`), which carries the FORM decode fix and tracks Kestra develop — the same axis this branch's e2e tests run against. No client-sdk release was needed.
- Deliberately did **not** pin to `go-sdk v1.3.0`: that tag is cut from client-sdk's `releases/v1.3.x` branch, which tracks Kestra 1.3.x's narrower REST surface (missing endpoints like `triggers create-backfill`/`flows expressions`/`dashboards defaults`, differently-shaped bulk-operation responses, and a different apps-search query format) — the wrong axis for a branch tested against `develop`.
- Added a query-string assertion to `TestRunAppsCatalog` covering the `filters[field][op]=value` shape apps-search sends.
- Added a `go.mod` comment warning against `go get -u`: pseudo-versions sort below tagged releases, so an unguarded upgrade would silently swap this back to `v1.3.0`.
