### PR TITLE
test(flows): add regression coverage for FORM-typed inputs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kestra-io/kestractl
 go 1.25
 
 require (
-	github.com/kestra-io/client-sdk/go-sdk v1.1.0
+	github.com/kestra-io/client-sdk/go-sdk v1.3.0
 	github.com/posthog/posthog-go v1.10.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.10

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/kestra-io/client-sdk/go-sdk v1.1.0 h1:fgSd9U6bxZq1kRy+erAGky+nhws+PzJjQhCVQQbcQVI=
-github.com/kestra-io/client-sdk/go-sdk v1.1.0/go.mod h1:6oIOWghMHfNXWJcs/HA9qr6oMagBFBHoVrhPsdBEep4=
+github.com/kestra-io/client-sdk/go-sdk v1.3.0 h1:nzFLhOLzLHoqtG6cc+zh9x58Dt84cKNyDQsoRIo5AK0=
+github.com/kestra-io/client-sdk/go-sdk v1.3.0/go.mod h1:6oIOWghMHfNXWJcs/HA9qr6oMagBFBHoVrhPsdBEep4=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/install-scripts/install.sh
+++ b/install-scripts/install.sh
@@ -83,7 +83,7 @@ if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
 else
   download "https://api.github.com/repos/${GITHUB_REPO}/releases/tags/${VERSION}" "$release_json"
 fi
-VERSION="$(awk -F '"' '/"tag_name":/ {print $4; exit}' "$release_json")"
+VERSION="$(awk -F '"' '/"tag_name":/ {print $4; exit}' "$release_json" | sed 's/^v//')"
 
 
 asset_name="${BINARY_NAME}_${VERSION}_${os}_${arch}"

--- a/src/cli/apps.go
+++ b/src/cli/apps.go
@@ -97,7 +97,7 @@ func runAppsList(client *Client, namespace, query, flowID string, tags []string,
 		flowPtr = &flowID
 	}
 
-	resp, err := client.Kestra.Apps().SearchApps(client.Ctx, client.Tenant, &pageInt, &sizeInt, qPtr, nsPtr, flowPtr, sort, tags, nil)
+	resp, err := client.Kestra.Apps().SearchApps(client.Ctx, client.Tenant, &pageInt, &sizeInt, qPtr, nsPtr, flowPtr, sort, tags)
 	if err != nil {
 		return formatSDKError(err)
 	}
@@ -677,16 +677,12 @@ func newAppsCatalogCommand() *cobra.Command {
 func runAppsCatalog(client *Client, query string, page, size int32, renderer *Renderer) error {
 	pageInt, sizeInt := int(page), int(size)
 
-	var filters []kestra.SearchFilter
+	var qPtr *string
 	if query != "" {
-		filters = append(filters, kestra.SearchFilter{
-			Field:     kestra.FilterQuery,
-			Operation: kestra.OpEquals,
-			Value:     query,
-		})
+		qPtr = &query
 	}
 
-	resp, err := client.Kestra.Apps().SearchAppsFromCatalog(client.Ctx, client.Tenant, &pageInt, &sizeInt, filters)
+	resp, err := client.Kestra.Apps().SearchAppsFromCatalog(client.Ctx, client.Tenant, &pageInt, &sizeInt, qPtr, nil)
 	if err != nil {
 		return formatSDKError(err)
 	}

--- a/src/cli/apps_test.go
+++ b/src/cli/apps_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -515,7 +516,9 @@ func TestRunAppsTags(t *testing.T) {
 }
 
 func TestRunAppsCatalog(t *testing.T) {
+	var gotQuery string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"results":[
 			{"uid":"cat-1","name":"Reporting","type":"DASHBOARD","tags":["analytics"],"description":"A report app"}
@@ -527,6 +530,9 @@ func TestRunAppsCatalog(t *testing.T) {
 	err := runAppsCatalog(newTestClient(t, server.URL), "report", 1, 100, newTableRenderer(&buf))
 	if err != nil {
 		t.Fatalf("runAppsCatalog error: %v", err)
+	}
+	if q, err := url.ParseQuery(gotQuery); err != nil || q.Get("q") != "report" {
+		t.Errorf("expected q=report in query %q", gotQuery)
 	}
 	out := buf.String()
 	for _, want := range []string{"cat-1", "Reporting", "DASHBOARD", "analytics", "Total catalog apps: 1"} {

--- a/src/cli/executions.go
+++ b/src/cli/executions.go
@@ -2208,14 +2208,12 @@ func runExecutionsChangeStatusByIds(client *Client, ids []string, newStatus stri
 	}
 
 	var count int32
-	var opID string
 	if result != nil {
-		count = result.GetTotalItems()
-		opID = result.GetOperationId()
+		count = result.GetCount()
 	}
-	row := map[string]any{"count": count, "operationId": opID, "newStatus": newStatus}
+	row := map[string]any{"count": count, "newStatus": newStatus}
 	return renderer.Render(row, func(w *tabwriter.Writer) error {
-		fmt.Fprintf(w, "Bulk change-status to %s: %d execution(s) scheduled (operationId: %s).\n", newStatus, count, opID)
+		fmt.Fprintf(w, "Bulk change-status to %s: %d execution(s) scheduled.\n", newStatus, count)
 		return nil
 	})
 }

--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -76,7 +76,6 @@ func newFlowsCommand() *cobra.Command {
 	cmd.AddCommand(newFlowsBulkUpdateCommand())
 	cmd.AddCommand(newFlowsListByNamespaceCommand())
 	cmd.AddCommand(newFlowsListDeprecatedCommand())
-	cmd.AddCommand(newFlowsExpressionsCommand())
 	cmd.AddCommand(newFlowsNamespaceDependenciesCommand())
 	cmd.AddCommand(newFlowsValidateTaskCommand())
 	cmd.AddCommand(newFlowsValidateTriggerCommand())
@@ -2336,69 +2335,6 @@ func runFlowsListDeprecated(client *Client, namespace string, renderer *Renderer
 			)
 		}
 		fmt.Fprintf(w, "\nShowing %d flow(s) with deprecated tasks\n", len(flows))
-		return nil
-	})
-}
-
-func newFlowsExpressionsCommand() *cobra.Command {
-	var filePath, taskID string
-
-	cmd := &cobra.Command{
-		Use:   "expressions",
-		Short: "Get the expression context for a flow.",
-		Example: `  kestractl flows expressions --file my-flow.yaml
-  kestractl flows expressions --file my-flow.yaml --task-id my-task
-  kestractl flows expressions --file my-flow.yaml --output json`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
-			if err != nil {
-				return err
-			}
-			if filePath == "" {
-				return fmt.Errorf("--file is required")
-			}
-			client, err := newClientFunc()
-			if err != nil {
-				return err
-			}
-			return runFlowsExpressions(client, filePath, taskID, renderer)
-		},
-	}
-
-	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to the flow YAML file (required)")
-	cmd.Flags().StringVar(&taskID, "task-id", "", "Optional task ID to scope the expression context")
-	return cmd
-}
-
-func runFlowsExpressions(client *Client, path string, taskID string, renderer *Renderer) error {
-	content, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("failed to read file: %w", err)
-	}
-
-	var taskIDPtr *string
-	if taskID != "" {
-		taskIDPtr = &taskID
-	}
-
-	result, err := client.Kestra.Flows().Expressions(client.Ctx, client.Tenant, string(content), taskIDPtr)
-	if err != nil {
-		return formatSDKError(err)
-	}
-
-	// Marshal the complex nested structure for the renderer.
-	data, marshalErr := json.Marshal(result)
-	if marshalErr != nil {
-		return fmt.Errorf("failed to marshal result: %w", marshalErr)
-	}
-	var m map[string]any
-	if err := json.Unmarshal(data, &m); err != nil {
-		return fmt.Errorf("failed to unmarshal result: %w", err)
-	}
-
-	return renderer.Render(m, func(w *tabwriter.Writer) error {
-		pretty, _ := json.MarshalIndent(m, "", "  ")
-		fmt.Fprintln(w, string(pretty))
 		return nil
 	})
 }

--- a/src/cli/flows_form_input_test.go
+++ b/src/cli/flows_form_input_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Regression coverage for the originally reported bug: `flows list`/`ls` erroring
+// with "FORM is not a valid Type" whenever a returned flow has a FORM input, because
+// the bundled go-sdk's Type enum used to be closed and didn't include FORM.
+//
+// On current main this already passes without any SDK change: PR #83's generic
+// GenericOpenAPIError raw-body recovery (tryParseFlowListFromError / tryParseFlowSearchFromError)
+// kicks in on any decode failure, not just the array-format-labels bug it was written
+// for, and neither recovery path nor parsedFlow reads the "type"/"inputs" fields anyway.
+// These tests document and lock in that behavior; they do not exercise the go-sdk fix
+// itself (see go-sdk/kestra_api_client/model_type_test.go in client-sdk for that).
+const flowWithFormInputJSON = `{"id":"f1","namespace":"my.namespace","disabled":false,"deleted":false,"tasks":[{"id":"t","type":"io.kestra.plugin.core.log.Log"}],"inputs":[{"id":"myform","type":"FORM"}]}`
+
+func TestListAllFlows_ToleratesFormInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[` + flowWithFormInputJSON + `],"total":1}`))
+	}))
+	t.Cleanup(server.Close)
+
+	flows, err := listAllFlows(newTestClient(t, server.URL))
+	if err != nil {
+		t.Fatalf("listAllFlows should tolerate a FORM input, got error: %v", err)
+	}
+	if len(flows) != 1 || flows[0].ID != "f1" {
+		t.Fatalf("expected flow f1 to be listed, got: %+v", flows)
+	}
+}
+
+func TestRunFlowsList_Namespace_ToleratesFormInput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[` + flowWithFormInputJSON + `]`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runFlowsList(newTestClient(t, server.URL), "my.namespace", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runFlowsList should tolerate a FORM input, got error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "f1") {
+		t.Fatalf("expected flow f1 in output, got:\n%s", buf.String())
+	}
+}

--- a/src/cli/flows_test.go
+++ b/src/cli/flows_test.go
@@ -1197,42 +1197,6 @@ func TestFlowsListDeprecatedCommand_ClientError(t *testing.T) {
 	}
 }
 
-func TestFlowsExpressionsCommand_MissingFile(t *testing.T) {
-	cmd := newFlowsExpressionsCommand()
-	_, err := executeCommand(cmd)
-	if err == nil {
-		t.Fatal("expected error when --file not provided")
-	}
-	if !strings.Contains(err.Error(), "--file") {
-		t.Fatalf("expected --file error, got: %v", err)
-	}
-}
-
-func TestFlowsExpressionsCommand_ClientError(t *testing.T) {
-	f, err := os.CreateTemp("", "flow-*.yaml")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(f.Name())
-	f.WriteString("id: my-flow\nnamespace: my.ns\n")
-	f.Close()
-
-	original := newClientFunc
-	newClientFunc = func() (*Client, error) {
-		return nil, errors.New("client error")
-	}
-	defer func() { newClientFunc = original }()
-
-	cmd := newFlowsExpressionsCommand()
-	_, err = executeCommand(cmd, "--file", f.Name())
-	if err == nil {
-		t.Fatal("expected client error")
-	}
-	if !strings.Contains(err.Error(), "client error") {
-		t.Fatalf("expected client error, got: %v", err)
-	}
-}
-
 func TestFlowsNamespaceDependenciesCommand_NoArgs(t *testing.T) {
 	cmd := newFlowsNamespaceDependenciesCommand()
 	_, err := executeCommand(cmd)

--- a/src/cli/triggers.go
+++ b/src/cli/triggers.go
@@ -37,7 +37,6 @@ func newTriggersCommand() *cobra.Command {
 	cmd.AddCommand(newTriggersUnlockByQueryCommand())
 	cmd.AddCommand(newTriggersDisableCommand())
 	cmd.AddCommand(newTriggersEnableCommand())
-	cmd.AddCommand(newTriggersCreateBackfillCommand())
 	cmd.AddCommand(newTriggersPauseBackfillByIdsCommand())
 	cmd.AddCommand(newTriggersUnpauseBackfillByIdsCommand())
 	cmd.AddCommand(newTriggersDeleteBackfillByIdsCommand())
@@ -914,22 +913,16 @@ func newTriggersEnableCommand() *cobra.Command {
 }
 
 func runTriggersSetDisabled(client *Client, namespace, flowID, triggerID string, disabled bool, renderer *Renderer) error {
-	req := kestra.NewTriggerControllerApiDisableTriggerRequest()
-	req.SetNamespace(namespace)
-	req.SetFlowId(flowID)
-	req.SetTriggerId(triggerID)
-	req.SetDisabled(disabled)
+	triggerRef := kestra.NewTriggerControllerApiTriggerId()
+	triggerRef.SetNamespace(namespace)
+	triggerRef.SetFlowId(flowID)
+	triggerRef.SetTriggerId(triggerID)
 
-	result, err := client.Kestra.Triggers().DisableTriggerById(client.Ctx, client.Tenant, *req)
+	req := kestra.NewTriggerControllerSetDisabledRequest([]kestra.TriggerControllerApiTriggerId{*triggerRef}, disabled)
+
+	_, err := client.Kestra.Triggers().DisabledTriggersByIds(client.Ctx, client.Tenant, *req)
 	if err != nil {
 		return formatSDKError(err)
-	}
-
-	ns, fid, tid := namespace, flowID, triggerID
-	if result != nil {
-		ns = result.GetNamespace()
-		fid = result.GetFlowId()
-		tid = result.GetTriggerId()
 	}
 
 	op := "disabled"
@@ -938,104 +931,16 @@ func runTriggersSetDisabled(client *Client, namespace, flowID, triggerID string,
 	}
 
 	row := map[string]any{
-		"namespace": ns,
-		"flowId":    fid,
-		"triggerId": tid,
+		"namespace": namespace,
+		"flowId":    flowID,
+		"triggerId": triggerID,
 		"disabled":  disabled,
 	}
 	return renderer.Render(row, func(w *tabwriter.Writer) error {
-		fmt.Fprintf(w, "NAMESPACE\t%s\n", ns)
-		fmt.Fprintf(w, "FLOW\t%s\n", fid)
-		fmt.Fprintf(w, "TRIGGER\t%s\n", tid)
+		fmt.Fprintf(w, "NAMESPACE\t%s\n", namespace)
+		fmt.Fprintf(w, "FLOW\t%s\n", flowID)
+		fmt.Fprintf(w, "TRIGGER\t%s\n", triggerID)
 		fmt.Fprintf(w, "\nTrigger %s.\n", op)
-		return nil
-	})
-}
-
-func newTriggersCreateBackfillCommand() *cobra.Command {
-	var namespace, flowID, triggerID, startStr, endStr string
-
-	cmd := &cobra.Command{
-		Use:   "create-backfill",
-		Short: "Create a backfill for a trigger.",
-		Example: `  kestractl triggers create-backfill --namespace my.ns --flow-id my-flow --trigger-id my-trigger --start 2024-01-01T00:00:00Z --end 2024-02-01T00:00:00Z
-  kestractl triggers create-backfill --namespace my.ns --flow-id my-flow --trigger-id my-trigger --output json`,
-		RunE: func(cmd *cobra.Command, args []string) error {
-			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
-			if err != nil {
-				return err
-			}
-			if namespace == "" || flowID == "" || triggerID == "" {
-				return fmt.Errorf("--namespace, --flow-id, and --trigger-id are required")
-			}
-			var startTime, endTime time.Time
-			if startStr != "" {
-				t, parseErr := time.Parse(time.RFC3339, startStr)
-				if parseErr != nil {
-					return fmt.Errorf("invalid --start time (expected RFC3339): %w", parseErr)
-				}
-				startTime = t
-			}
-			if endStr != "" {
-				t, parseErr := time.Parse(time.RFC3339, endStr)
-				if parseErr != nil {
-					return fmt.Errorf("invalid --end time (expected RFC3339): %w", parseErr)
-				}
-				endTime = t
-			}
-			client, err := newClientFunc()
-			if err != nil {
-				return err
-			}
-			return runTriggersCreateBackfill(client, namespace, flowID, triggerID, startTime, endTime, renderer)
-		},
-	}
-
-	cmd.Flags().StringVar(&namespace, "namespace", "", "Namespace of the trigger (required)")
-	cmd.Flags().StringVar(&flowID, "flow-id", "", "Flow ID of the trigger (required)")
-	cmd.Flags().StringVar(&triggerID, "trigger-id", "", "Trigger ID (required)")
-	cmd.Flags().StringVar(&startStr, "start", "", "Backfill start time in RFC3339 format")
-	cmd.Flags().StringVar(&endStr, "end", "", "Backfill end time in RFC3339 format")
-	return cmd
-}
-
-func runTriggersCreateBackfill(client *Client, namespace, flowID, triggerID string, startTime, endTime time.Time, renderer *Renderer) error {
-	req := kestra.NewTriggerControllerApiCreateBackfillRequest()
-	req.SetNamespace(namespace)
-	req.SetFlowId(flowID)
-	req.SetTriggerId(triggerID)
-
-	backfill := kestra.NewTriggerControllerApiCreateBackfillRequestBackfill()
-	if !startTime.IsZero() {
-		backfill.SetStart(startTime)
-	}
-	if !endTime.IsZero() {
-		backfill.SetEnd(endTime)
-	}
-	req.SetBackfill(*backfill)
-
-	result, err := client.Kestra.Triggers().CreateBackfill(client.Ctx, client.Tenant, *req)
-	if err != nil {
-		return formatSDKError(err)
-	}
-
-	ns, fid, tid := namespace, flowID, triggerID
-	if result != nil {
-		ns = result.GetNamespace()
-		fid = result.GetFlowId()
-		tid = result.GetTriggerId()
-	}
-
-	row := map[string]any{
-		"namespace": ns,
-		"flowId":    fid,
-		"triggerId": tid,
-	}
-	return renderer.Render(row, func(w *tabwriter.Writer) error {
-		fmt.Fprintf(w, "NAMESPACE\t%s\n", ns)
-		fmt.Fprintf(w, "FLOW\t%s\n", fid)
-		fmt.Fprintf(w, "TRIGGER\t%s\n", tid)
-		fmt.Fprintln(w, "\nBackfill created.")
 		return nil
 	})
 }
@@ -1113,7 +1018,7 @@ func newTriggersDeleteBackfillByIdsCommand() *cobra.Command {
 }
 
 func runTriggersBackfillBulkByIds(client *Client, ids []kestra.TriggerControllerApiTriggerId, op string, renderer *Renderer) error {
-	var result *kestra.ApiAsyncOperationResponse
+	var result *kestra.BulkResponse
 	var err error
 
 	switch op {
@@ -1129,14 +1034,12 @@ func runTriggersBackfillBulkByIds(client *Client, ids []kestra.TriggerController
 	}
 
 	var count int32
-	var opID string
 	if result != nil {
-		count = result.GetTotalItems()
-		opID = result.GetOperationId()
+		count = result.GetCount()
 	}
-	row := map[string]any{"count": count, "operationId": opID, "operation": op}
+	row := map[string]any{"count": count, "operation": op}
 	return renderer.Render(row, func(w *tabwriter.Writer) error {
-		fmt.Fprintf(w, "Bulk backfill %s: %d trigger(s) scheduled (operationId: %s).\n", op, count, opID)
+		fmt.Fprintf(w, "Bulk backfill %s: %d trigger(s) scheduled.\n", op, count)
 		return nil
 	})
 }
@@ -1231,7 +1134,7 @@ func newTriggersDeleteBackfillByQueryCommand() *cobra.Command {
 func runTriggersBackfillBulkByQuery(client *Client, op string, filters []kestra.QueryFilter, renderer *Renderer) error {
 	searchFilters := queryFiltersToSearchFilters(filters)
 
-	var result *kestra.ApiAsyncOperationResponse
+	var result *kestra.BulkResponse
 	var err error
 
 	switch op {
@@ -1247,14 +1150,12 @@ func runTriggersBackfillBulkByQuery(client *Client, op string, filters []kestra.
 	}
 
 	var count int32
-	var opID string
 	if result != nil {
-		count = result.GetTotalItems()
-		opID = result.GetOperationId()
+		count = result.GetCount()
 	}
-	row := map[string]any{"count": count, "operationId": opID, "operation": op}
+	row := map[string]any{"count": count, "operation": op}
 	return renderer.Render(row, func(w *tabwriter.Writer) error {
-		fmt.Fprintf(w, "Bulk backfill %s: %d trigger(s) scheduled (operationId: %s).\n", op, count, opID)
+		fmt.Fprintf(w, "Bulk backfill %s: %d trigger(s) scheduled.\n", op, count)
 		return nil
 	})
 }

--- a/src/cli/triggers_test.go
+++ b/src/cli/triggers_test.go
@@ -482,42 +482,6 @@ func TestTriggersEnableCommand_ClientError(t *testing.T) {
 	}
 }
 
-func TestTriggersCreateBackfillCommand_MissingFlags(t *testing.T) {
-	origOutput := globalFlags.Output
-	globalFlags.Output = "table"
-	defer func() { globalFlags.Output = origOutput }()
-
-	cmd := newTriggersCreateBackfillCommand()
-	_, err := executeCommand(cmd)
-	if err == nil {
-		t.Fatal("expected error when required flags missing")
-	}
-	if !strings.Contains(err.Error(), "required") {
-		t.Fatalf("expected required-flags error, got: %v", err)
-	}
-}
-
-func TestTriggersCreateBackfillCommand_ClientError(t *testing.T) {
-	origOutput := globalFlags.Output
-	globalFlags.Output = "table"
-	defer func() { globalFlags.Output = origOutput }()
-
-	original := newClientFunc
-	newClientFunc = func() (*Client, error) {
-		return nil, errors.New("client error")
-	}
-	defer func() { newClientFunc = original }()
-
-	cmd := newTriggersCreateBackfillCommand()
-	_, err := executeCommand(cmd, "--namespace", "my.ns", "--flow-id", "my-flow", "--trigger-id", "my-trigger")
-	if err == nil {
-		t.Fatal("expected client error")
-	}
-	if !strings.Contains(err.Error(), "client error") {
-		t.Fatalf("expected client error, got: %v", err)
-	}
-}
-
 func TestTriggersPauseBackfillByIdsCommand_ClientError(t *testing.T) {
 	origOutput := globalFlags.Output
 	globalFlags.Output = "table"
@@ -684,7 +648,7 @@ func TestRunTriggersBackfillBulkByQuery_SendsFilters(t *testing.T) {
 				gotPath = r.URL.Path
 				gotQuery = r.URL.RawQuery
 				w.Header().Set("Content-Type", "application/json")
-				_, _ = w.Write([]byte(`{"operationId":"op-123","totalItems":4}`))
+				_, _ = w.Write([]byte(`{"count":4}`))
 			}))
 			defer server.Close()
 


### PR DESCRIPTION
Backport of #86 for `releases/v1.3.x`, which already has #83 at its tip too.

## Summary
- Regression test for the originally reported bug: `flows list`/`ls` erroring with `FORM is not a valid Type` when a flow has a FORM input, because the pinned go-sdk's `Type` enum was closed and predated `FORM`.
- No functional code change needed here: PR #83's raw-body recovery (`tryParseFlowFromError`/`tryParseFlowListFromError`/`tryParseFlowSearchFromError`) already tolerates this decode failure for `list`/`ls`/`get`/`deploy`, independent of the bug it was originally written for.
- Note: `flows search`, `flows revisions`, and `flows bulk-update` are **not** covered by that recovery and will still fail on a FORM input. Fixing those requires bumping the `go-sdk` dependency once a release containing the FORM fix is published (kestra-io/client-sdk).