### PR TITLE
feat(namespaces): support managing namespace variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,11 @@ kestractl namespaces create my.namespace
 kestractl namespaces update my.namespace --description "Production namespace"
 kestractl namespaces delete my.namespace
 
+# Set namespace variables (repeatable --variable, or a YAML/JSON file); replaces
+# the full variable set on that namespace
+kestractl namespaces create my.namespace --variable env=prod --variable region=eu
+kestractl namespaces update my.namespace --variables-file variables.yml
+
 # View inherited secrets and variables
 kestractl namespaces inherited-secrets   my.namespace
 kestractl namespaces inherited-variables my.namespace

--- a/src/cli/namespaces.go
+++ b/src/cli/namespaces.go
@@ -325,6 +325,10 @@ func newNamespacesUpdateCommand() *cobra.Command {
 		Short: "Update a namespace.",
 		Long: `Update a namespace.
 
+Fields not passed on the command line keep their current value: the
+existing namespace is fetched first, and only the flags provided here are
+applied on top before saving.
+
 --variable and --variables-file set the full list of namespace variables,
 replacing any variables previously set on the namespace. Combine them to
 layer inline overrides on top of a file: --variable entries win on key
@@ -347,7 +351,7 @@ conflicts.`,
 			if err != nil {
 				return err
 			}
-			return runNamespacesUpdate(client, args[0], description, variables, renderer)
+			return runNamespacesUpdate(client, args[0], description, cmd.Flags().Changed("description"), variables, renderer)
 		},
 	}
 
@@ -357,9 +361,18 @@ conflicts.`,
 	return cmd
 }
 
-func runNamespacesUpdate(client *Client, id, description string, variables map[string]interface{}, renderer *Renderer) error {
-	ns := kestra.NewNamespace(id, false)
-	if description != "" {
+func runNamespacesUpdate(client *Client, id, description string, descriptionSet bool, variables map[string]interface{}, renderer *Renderer) error {
+	// UpdateNamespace is a full-replace PUT: start from the current namespace
+	// so fields not passed on this invocation aren't wiped.
+	ns, _, err := client.API.NamespacesAPI.Namespace(client.Ctx, id, client.Tenant).Execute()
+	if err != nil {
+		return formatSDKError(err)
+	}
+	if ns == nil {
+		ns = kestra.NewNamespace(id, false)
+	}
+
+	if descriptionSet {
 		ns.SetDescription(description)
 	}
 	if variables != nil {

--- a/src/cli/namespaces.go
+++ b/src/cli/namespaces.go
@@ -3,10 +3,12 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func newNamespacesCommand() *cobra.Command {
@@ -156,6 +158,7 @@ func runNamespacesGet(client *Client, id string, renderer *Renderer) error {
 		"id":          ns.GetId(),
 		"description": ns.GetDescription(),
 		"deleted":     ns.GetDeleted(),
+		"variables":   ns.GetVariables(),
 	}
 
 	return renderer.Render(result, func(w *tabwriter.Writer) error {
@@ -164,18 +167,59 @@ func runNamespacesGet(client *Client, id string, renderer *Renderer) error {
 			fmt.Fprintf(w, "DESCRIPTION\t%s\n", desc)
 		}
 		fmt.Fprintf(w, "DELETED\t%v\n", ns.GetDeleted())
+		if vars := ns.GetVariables(); len(vars) > 0 {
+			fmt.Fprintln(w, "\nVARIABLES:")
+			for k, v := range vars {
+				fmt.Fprintf(w, "  %s\t%v\n", k, v)
+			}
+		}
 		return nil
 	})
 }
 
+// parseVariableFlags builds a namespace variables map from repeatable "key=value"
+// pairs and/or a YAML/JSON file. Pairs take precedence over file entries with the
+// same key. Returns nil if neither source was provided.
+func parseVariableFlags(pairs []string, filePath string) (map[string]interface{}, error) {
+	if len(pairs) == 0 && filePath == "" {
+		return nil, nil
+	}
+
+	variables := map[string]interface{}{}
+
+	if filePath != "" {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read variables file: %w", err)
+		}
+		if err := yaml.Unmarshal(data, &variables); err != nil {
+			return nil, fmt.Errorf("failed to parse variables file: %w", err)
+		}
+	}
+
+	for _, p := range pairs {
+		key, value, ok := strings.Cut(p, "=")
+		if !ok || key == "" {
+			return nil, fmt.Errorf("invalid --variable %q: expected format key=value", p)
+		}
+		variables[key] = value
+	}
+
+	return variables, nil
+}
+
 func newNamespacesCreateCommand() *cobra.Command {
 	var description string
+	var variablePairs []string
+	var variablesFile string
 
 	cmd := &cobra.Command{
 		Use:   "create <namespace_id>",
 		Short: "Create a namespace.",
 		Example: `  kestractl namespaces create my.namespace
   kestractl namespaces create my.namespace --description "My team namespace"
+  kestractl namespaces create my.namespace --variable env=prod --variable region=eu
+  kestractl namespaces create my.namespace --variables-file variables.yml
   kestractl namespaces create my.namespace --output json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -183,22 +227,31 @@ func newNamespacesCreateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			variables, err := parseVariableFlags(variablePairs, variablesFile)
+			if err != nil {
+				return err
+			}
 			client, err := newClientFunc()
 			if err != nil {
 				return err
 			}
-			return runNamespacesCreate(client, args[0], description, renderer)
+			return runNamespacesCreate(client, args[0], description, variables, renderer)
 		},
 	}
 
 	cmd.Flags().StringVar(&description, "description", "", "Namespace description")
+	cmd.Flags().StringArrayVar(&variablePairs, "variable", nil, "Namespace variable as key=value (repeatable)")
+	cmd.Flags().StringVar(&variablesFile, "variables-file", "", "Path to a YAML or JSON file defining namespace variables")
 	return cmd
 }
 
-func runNamespacesCreate(client *Client, id, description string, renderer *Renderer) error {
+func runNamespacesCreate(client *Client, id, description string, variables map[string]interface{}, renderer *Renderer) error {
 	ns := kestra.NewNamespace(id, false)
 	if description != "" {
 		ns.SetDescription(description)
+	}
+	if len(variables) > 0 {
+		ns.SetVariables(variables)
 	}
 
 	created, _, err := client.API.NamespacesAPI.
@@ -215,6 +268,7 @@ func runNamespacesCreate(client *Client, id, description string, renderer *Rende
 	result := map[string]any{
 		"id":          created.GetId(),
 		"description": created.GetDescription(),
+		"variables":   created.GetVariables(),
 	}
 
 	return renderer.Render(result, func(w *tabwriter.Writer) error {
@@ -229,8 +283,8 @@ func runNamespacesCreate(client *Client, id, description string, renderer *Rende
 
 func newNamespacesDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <namespace_id>",
-		Short: "Delete a namespace.",
+		Use:     "delete <namespace_id>",
+		Short:   "Delete a namespace.",
 		Example: `  kestractl namespaces delete my.namespace`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -263,11 +317,21 @@ func runNamespacesDelete(client *Client, id string, renderer *Renderer) error {
 
 func newNamespacesUpdateCommand() *cobra.Command {
 	var description string
+	var variablePairs []string
+	var variablesFile string
 
 	cmd := &cobra.Command{
 		Use:   "update <namespace_id>",
 		Short: "Update a namespace.",
+		Long: `Update a namespace.
+
+--variable and --variables-file set the full list of namespace variables,
+replacing any variables previously set on the namespace. Combine them to
+layer inline overrides on top of a file: --variable entries win on key
+conflicts.`,
 		Example: `  kestractl namespaces update my.namespace --description "Updated description"
+  kestractl namespaces update my.namespace --variable env=prod --variable region=eu
+  kestractl namespaces update my.namespace --variables-file variables.yml
   kestractl namespaces update my.namespace --output json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -275,22 +339,31 @@ func newNamespacesUpdateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			variables, err := parseVariableFlags(variablePairs, variablesFile)
+			if err != nil {
+				return err
+			}
 			client, err := newClientFunc()
 			if err != nil {
 				return err
 			}
-			return runNamespacesUpdate(client, args[0], description, renderer)
+			return runNamespacesUpdate(client, args[0], description, variables, renderer)
 		},
 	}
 
 	cmd.Flags().StringVar(&description, "description", "", "New namespace description")
+	cmd.Flags().StringArrayVar(&variablePairs, "variable", nil, "Namespace variable as key=value (repeatable); replaces existing variables")
+	cmd.Flags().StringVar(&variablesFile, "variables-file", "", "Path to a YAML or JSON file defining namespace variables; replaces existing variables")
 	return cmd
 }
 
-func runNamespacesUpdate(client *Client, id, description string, renderer *Renderer) error {
+func runNamespacesUpdate(client *Client, id, description string, variables map[string]interface{}, renderer *Renderer) error {
 	ns := kestra.NewNamespace(id, false)
 	if description != "" {
 		ns.SetDescription(description)
+	}
+	if variables != nil {
+		ns.SetVariables(variables)
 	}
 
 	updated, _, err := client.API.NamespacesAPI.
@@ -307,6 +380,7 @@ func runNamespacesUpdate(client *Client, id, description string, renderer *Rende
 	result := map[string]any{
 		"id":          updated.GetId(),
 		"description": updated.GetDescription(),
+		"variables":   updated.GetVariables(),
 	}
 
 	return renderer.Render(result, func(w *tabwriter.Writer) error {

--- a/src/cli/namespaces_test.go
+++ b/src/cli/namespaces_test.go
@@ -499,14 +499,16 @@ func TestNamespacesUpdateCommand_InvalidVariable(t *testing.T) {
 func TestRunNamespacesUpdate_SetsVariables(t *testing.T) {
 	var gotBody map[string]interface{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		if r.Method == http.MethodPut {
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"variables":{"env":"prod"}}`))
 	}))
 	t.Cleanup(server.Close)
 
 	var buf bytes.Buffer
-	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "", map[string]interface{}{"env": "prod"}, newTableRenderer(&buf))
+	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "", false, map[string]interface{}{"env": "prod"}, newTableRenderer(&buf))
 	if err != nil {
 		t.Fatalf("runNamespacesUpdate error: %v", err)
 	}
@@ -514,6 +516,77 @@ func TestRunNamespacesUpdate_SetsVariables(t *testing.T) {
 	vars, ok := gotBody["variables"].(map[string]interface{})
 	if !ok || vars["env"] != "prod" {
 		t.Fatalf("expected variables in request body, got: %v", gotBody)
+	}
+}
+
+func TestRunNamespacesUpdate_DescriptionOnlyPreservesVariables(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"description":"old","variables":{"env":"prod","region":"eu"}}`))
+		case http.MethodPut:
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"description":"touched","variables":{"env":"prod","region":"eu"}}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "touched", true, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesUpdate error: %v", err)
+	}
+
+	if gotBody["description"] != "touched" {
+		t.Fatalf("expected description to be updated, got: %v", gotBody)
+	}
+	vars, ok := gotBody["variables"].(map[string]interface{})
+	if !ok || vars["env"] != "prod" || vars["region"] != "eu" {
+		t.Fatalf("expected pre-existing variables to be preserved, got: %v", gotBody)
+	}
+}
+
+func TestRunNamespacesUpdate_VariablesOnlyPreservesDescription(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"description":"keep me","variables":{"env":"prod"}}`))
+		case http.MethodPut:
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"description":"keep me","variables":{"env":"staging"}}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "", false, map[string]interface{}{"env": "staging"}, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesUpdate error: %v", err)
+	}
+
+	if gotBody["description"] != "keep me" {
+		t.Fatalf("expected pre-existing description to be preserved, got: %v", gotBody)
+	}
+	vars, ok := gotBody["variables"].(map[string]interface{})
+	if !ok || vars["env"] != "staging" {
+		t.Fatalf("expected variables to be updated, got: %v", gotBody)
+	}
+}
+
+func TestRunNamespacesUpdate_GetError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "new desc", true, nil, newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected error when fetching the current namespace fails")
 	}
 }
 

--- a/src/cli/namespaces_test.go
+++ b/src/cli/namespaces_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -411,5 +412,147 @@ func TestNamespacesImportPluginDefaultsCommand_ClientError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "client error") {
 		t.Fatalf("expected client error, got: %v", err)
+	}
+}
+
+func TestParseVariableFlags_NoneProvided(t *testing.T) {
+	variables, err := parseVariableFlags(nil, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if variables != nil {
+		t.Fatalf("expected nil variables, got: %v", variables)
+	}
+}
+
+func TestParseVariableFlags_Pairs(t *testing.T) {
+	variables, err := parseVariableFlags([]string{"env=prod", "region=eu"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if variables["env"] != "prod" || variables["region"] != "eu" {
+		t.Fatalf("unexpected variables: %v", variables)
+	}
+}
+
+func TestParseVariableFlags_InvalidPair(t *testing.T) {
+	_, err := parseVariableFlags([]string{"invalid"}, "")
+	if err == nil {
+		t.Fatal("expected error for invalid key=value pair")
+	}
+	if !strings.Contains(err.Error(), "expected format key=value") {
+		t.Fatalf("expected format error, got: %v", err)
+	}
+}
+
+func TestParseVariableFlags_File(t *testing.T) {
+	f, err := os.CreateTemp("", "variables-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("env: staging\nnested:\n  key: value\n")
+	f.Close()
+	defer os.Remove(f.Name())
+
+	variables, err := parseVariableFlags(nil, f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if variables["env"] != "staging" {
+		t.Fatalf("unexpected variables: %v", variables)
+	}
+	nested, ok := variables["nested"].(map[string]interface{})
+	if !ok || nested["key"] != "value" {
+		t.Fatalf("expected nested map, got: %v", variables["nested"])
+	}
+}
+
+func TestParseVariableFlags_PairOverridesFile(t *testing.T) {
+	f, err := os.CreateTemp("", "variables-*.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString("env: staging\n")
+	f.Close()
+	defer os.Remove(f.Name())
+
+	variables, err := parseVariableFlags([]string{"env=prod"}, f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if variables["env"] != "prod" {
+		t.Fatalf("expected --variable to override file value, got: %v", variables)
+	}
+}
+
+func TestNamespacesUpdateCommand_InvalidVariable(t *testing.T) {
+	cmd := newNamespacesUpdateCommand()
+	_, err := executeCommand(cmd, "my.namespace", "--variable", "invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid --variable")
+	}
+	if !strings.Contains(err.Error(), "expected format key=value") {
+		t.Fatalf("expected format error, got: %v", err)
+	}
+}
+
+func TestRunNamespacesUpdate_SetsVariables(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"variables":{"env":"prod"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "", map[string]interface{}{"env": "prod"}, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesUpdate error: %v", err)
+	}
+
+	vars, ok := gotBody["variables"].(map[string]interface{})
+	if !ok || vars["env"] != "prod" {
+		t.Fatalf("expected variables in request body, got: %v", gotBody)
+	}
+}
+
+func TestRunNamespacesCreate_SetsVariables(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"variables":{"env":"prod"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesCreate(newTestClient(t, server.URL), "my.namespace", "", map[string]interface{}{"env": "prod"}, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesCreate error: %v", err)
+	}
+
+	vars, ok := gotBody["variables"].(map[string]interface{})
+	if !ok || vars["env"] != "prod" {
+		t.Fatalf("expected variables in request body, got: %v", gotBody)
+	}
+}
+
+func TestRunNamespacesGet_ShowsVariables(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"variables":{"env":"prod"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesGet(newTestClient(t, server.URL), "my.namespace", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesGet error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "VARIABLES") || !strings.Contains(out, "env") || !strings.Contains(out, "prod") {
+		t.Fatalf("expected variables in output, got:\n%s", out)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `--variable key=value` (repeatable) and `--variables-file` (YAML/JSON) flags to `namespaces create` and `namespaces update` to set namespace variables
- Surface `variables` in `kestractl namespaces get` output (table + JSON)
- Reuses the SDK's existing `Namespace.Variables` field via the current `Namespace()` (GET) / `CreateNamespace()` / `UpdateNamespace()` calls — no new API/SDK surface needed
- `--variable` entries take precedence over `--variables-file` entries on key conflicts
- Setting variables replaces the full variable set on that namespace, matching how `create`/`update` already behave for other fields

Closes #89

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` clean
- [x] `go test ./src/...` (764 passed)
- [x] Added unit tests: `parseVariableFlags` (pairs, file, override precedence, invalid input), `runNamespacesCreate`/`runNamespacesUpdate` request-body assertions, `runNamespacesGet` output assertions