### PR TITLE
docs: add Code Review & QA guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,22 @@ See `CONTRIBUTING.md` for the full checklist. Key points:
 
 `e2e_tests/` is a **separate Go module**. It builds the `kestractl` binary, then uses `os/exec` to run real CLI commands against a live Kestra EE instance. Compatible versions are listed in `COMPATIBLE_KESTRA_VERSION.properties`. Docker setup lives in `e2e_tests/docker-setup/`.
 
+## Code Review & QA
+
+In addition to `Common pitfalls` above, check for:
+- **Backward compatibility:** flags, output fields, and SDK method signatures are additive; a breaking rename needs an explicit call-out, not a silent change
+- **Command injection:** no `os/exec` call built from unsanitized user input
+- **SSRF:** outbound requests to a user-supplied host/URL (`--server`, webhook-style flags) are validated, not blindly followed
+- **Resource leaks:** HTTP clients and file handles are closed; no goroutine started without a way to stop it
+- **Idempotency:** destructive commands (`delete`, `reset`) require explicit confirmation or a `--force`/`-y` flag
+- **SDK version pinning:** see `Release` below — a floating/`-SNAPSHOT`/`develop`-tracking Go SDK version is a review blocker for anything targeting `main`
+
+**A running Kestra instance is required for QA.** Beyond unit tests, exercising a command for real needs a live Kestra instance — spin one up locally (see `e2e_tests/docker-setup/`) or point `--server`/config at one. Don't conclude a command is broken from unit tests alone.
+
+**CE vs EE:** some features only exist in Kestra **EE** (Enterprise Edition), not CE — tenants, RBAC/roles, SSO, and anything under `kestra.security.*` config. Before filing a bug or reviewing a fix for one of these, confirm which edition the test instance is running.
+
+**Known EE gotcha:** a superadmin configured with only `kestra.security.super-admin.username`/`password` never gets a tenant or `ADMIN` role bound, so every API call 403s even though login succeeds. Fix is setting `kestra.security.super-admin.tenant-admin-access: [<tenant-id>]` (e.g. `[main]`) too, which triggers tenant auto-creation and binds the built-in `ADMIN` role on startup. Check for this config before assuming a kestractl auth/permission bug.
+
 ## Release
 
 Releases are created by creating a new Git tag. See `.github/workflows/release.yml` for more details. When releasing from `main` branch, be sure that Go SDK version in `go.mod` is a fixed and short one. For example, `github.com/kestra-io/client-sdk/go-sdk v1.1.0` is valid for a release but `github.com/kestra-io/client-sdk/go-sdk v1.1.1-0.20260702143038-8c3851bea2e1` is not valid for a release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ In addition to `Common pitfalls` above, check for:
 
 **A running Kestra instance is required for QA.** Beyond unit tests, exercising a command for real needs a live Kestra instance — spin one up locally (see `e2e_tests/docker-setup/`) or point `--server`/config at one. Don't conclude a command is broken from unit tests alone.
 
-**CE vs EE:** some features only exist in Kestra **EE** (Enterprise Edition), not CE — tenants, RBAC/roles, SSO, and anything under `kestra.security.*` config. Before filing a bug or reviewing a fix for one of these, confirm which edition the test instance is running.
+**OSS vs EE:** some features only exist in Kestra **EE** (Enterprise Edition), not OSS — tenants, RBAC/roles, SSO, and anything under `kestra.security.*` config. Before filing a bug or reviewing a fix for one of these, confirm which edition the test instance is running.
 
 **Known EE gotcha:** a superadmin configured with only `kestra.security.super-admin.username`/`password` never gets a tenant or `ADMIN` role bound, so every API call 403s even though login succeeds. Fix is setting `kestra.security.super-admin.tenant-admin-access: [<tenant-id>]` (e.g. `[main]`) too, which triggers tenant auto-creation and binds the built-in `ADMIN` role on startup. Check for this config before assuming a kestractl auth/permission bug.
 


### PR DESCRIPTION
## Summary
- Adds a **Code Review & QA** section to AGENTS.md covering ecosystem-repo review checks (backward compat, command injection, SSRF, resource leaks, idempotency, SDK pinning).
- Notes that QA-ing kestractl commands requires a **running Kestra instance**, and that some features (tenants, RBAC/roles, SSO) only exist in **EE**, not CE.
- Documents a known EE gotcha: a superadmin set up with only `username`/`password` never gets a tenant or `ADMIN` role bound (403s despite successful login) unless `kestra.security.super-admin.tenant-admin-access` is also set.

Source: [kestra-io/engineering-ai-hub#75](https://github.com/kestra-io/engineering-ai-hub/pull/75), which added an equivalent ecosystem-repo checklist to the `kestra-plugin-code-reviewer` agent and documented the same QA gotcha found while QA-ing kestractl#90.

## Test plan
- [x] Docs-only change, no code/tests affected