### PR TITLE
ci: trigger pkg.go.dev indexing on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Trigger pkg.go.dev indexing
+        run: |
+          curl -sf "https://proxy.golang.org/github.com/kestra-io/kestractl/@v/${{ github.ref_name }}.info" > /dev/null
+          curl -sf "https://pkg.go.dev/github.com/kestra-io/kestractl@${{ github.ref_name }}" > /dev/null
+
       - name: Slack notification
         if: success()
         uses: kestra-io/actions/composite/slack-status@main


### PR DESCRIPTION
## Summary
- pkg.go.dev only crawls a module version once something requests its page — v1.16.1 and v1.17.0 sat unindexed for days, latest stuck showing v1.16.0
- After GoReleaser publishes the tag, hit the Go module proxy and pkg.go.dev for that version to force reindexing

## Test plan
- [ ] Cut a release tag, confirm the new step runs after GoReleaser and pkg.go.dev shows the new version as latest shortly after