### PR TITLE
fix(ci): skip e2e-tests on fork PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,9 @@ jobs:
 
   e2e-tests:
     needs: list-versions
+    # Fork PRs don't receive secrets (GCP creds for the private EE image, EE license), so e2e cannot run.
+    # Skip them. workflow_dispatch/workflow_call and internal PRs still run.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Fork PRs don't receive secrets (GCP creds for the private EE image, EE license), so the e2e-tests job fails at GCP auth. Gate it on `head.repo.fork == false` so forks skip cleanly while internal PRs, workflow_dispatch, and workflow_call still run.