### PR TITLE
build: rename the no-plugins image to slim

### DIFF
--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,7 +1,7 @@
 services:
   kestra:
     container_name: cli-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-${KESTRA_IMAGE_SUFFIX:-slim}"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}${KESTRA_IMAGE_SUFFIX}"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,7 +1,7 @@
 services:
   kestra:
     container_name: cli-test-kestra
-    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-no-plugins"
+    image: "europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-${KESTRA_IMAGE_SUFFIX:-slim}"
     pull_policy: always
     user: "root"
     command: server standalone

--- a/run-e2e-tests.sh
+++ b/run-e2e-tests.sh
@@ -29,6 +29,13 @@ for KESTRA_VERSION in $versions; do
     *) export KESTRA_IMAGE_SUFFIX="slim" ;;
   esac
 
+  # -slim can be missing for some tags (not backfilled yet); fall back to -no-plugins.
+  image="europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-${KESTRA_IMAGE_SUFFIX}"
+  if [ "$KESTRA_IMAGE_SUFFIX" = "slim" ] && ! docker pull "$image" >/dev/null 2>&1; then
+    echo "-slim image not found for $KESTRA_VERSION, falling back to -no-plugins"
+    export KESTRA_IMAGE_SUFFIX="no-plugins"
+  fi
+
   echo "start Kestra container"
   log_and_run docker compose -f docker-compose-ci.yml down
 

--- a/run-e2e-tests.sh
+++ b/run-e2e-tests.sh
@@ -7,6 +7,21 @@ log_and_run() {
   "$@"
 }
 
+# -slim replaces -no-plugins (kestra-io/kestra#16054, kestra-io/actions#204), but
+# older/unreleased versions may not have published a -slim image yet. Probe the
+# registry and fall back so CI doesn't break on those.
+resolve_kestra_image_suffix() {
+  local version="$1"
+  local repo="europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee"
+
+  if docker pull -q "${repo}:${version}-slim" >/dev/null 2>&1; then
+    echo "-slim"
+  else
+    echo "no ${repo}:${version}-slim, falling back to -no-plugins" >&2
+    echo "-no-plugins"
+  fi
+}
+
 if [ $# -ge 1 ]; then
   versions="$1"
 else
@@ -23,23 +38,11 @@ for KESTRA_VERSION in $versions; do
 
   echo "docker KESTRA_VERSION used: $KESTRA_VERSION\n"
 
-  # -slim replaces -no-plugins from 2.0; older minors were only ever published as -no-plugins.
-  case "$KESTRA_VERSION" in
-    v0.*|v1.*) export KESTRA_IMAGE_SUFFIX="no-plugins" ;;
-    *) export KESTRA_IMAGE_SUFFIX="slim" ;;
-  esac
-
-  # -slim can be missing for some tags (not backfilled yet); fall back to -no-plugins.
-  image="europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:${KESTRA_VERSION}-${KESTRA_IMAGE_SUFFIX}"
-  if [ "$KESTRA_IMAGE_SUFFIX" = "slim" ] && ! docker pull "$image" >/dev/null 2>&1; then
-    echo "-slim image not found for $KESTRA_VERSION, falling back to -no-plugins"
-    export KESTRA_IMAGE_SUFFIX="no-plugins"
-  fi
+  export KESTRA_VERSION=$KESTRA_VERSION
+  export KESTRA_IMAGE_SUFFIX=$(resolve_kestra_image_suffix "$KESTRA_VERSION")
 
   echo "start Kestra container"
   log_and_run docker compose -f docker-compose-ci.yml down
-
-  export KESTRA_VERSION=$KESTRA_VERSION
   log_and_run docker compose -f docker-compose-ci.yml up -d --wait || {
      echo "db Docker Compose failed. Dumping logs:";
      log_and_run docker compose -f docker-compose-ci.yml logs;

--- a/run-e2e-tests.sh
+++ b/run-e2e-tests.sh
@@ -23,6 +23,12 @@ for KESTRA_VERSION in $versions; do
 
   echo "docker KESTRA_VERSION used: $KESTRA_VERSION\n"
 
+  # -slim replaces -no-plugins from 2.0; older minors were only ever published as -no-plugins.
+  case "$KESTRA_VERSION" in
+    v0.*|v1.*) export KESTRA_IMAGE_SUFFIX="no-plugins" ;;
+    *) export KESTRA_IMAGE_SUFFIX="slim" ;;
+  esac
+
   echo "start Kestra container"
   log_and_run docker compose -f docker-compose-ci.yml down
 


### PR DESCRIPTION
Part-of: https://github.com/kestra-io/kestra-ee/issues/6145

-slim replaces -no-plugins (kestra-io/kestra#16054, kestra-io/actions#204). The e2e compose suffix is computed per tested version: pre-2.0 minors were only ever published as -no-plugins, 2.0+ and develop use -slim, so the whole compatibility matrix keeps working.

Ordering: merge after kestra-io/actions#204 has published a develop-slim EE image.