### PR TITLE
fix(executions): use ApiLightExecution model for list and search-by-flow

### DIFF
--- a/src/cli/executions.go
+++ b/src/cli/executions.go
@@ -876,14 +876,11 @@ func runExecutionsList(client *Client, namespace, flowID, state string, page, si
 		size = 50
 	}
 
-	req := client.API.ExecutionsAPI.SearchExecutions(client.Ctx, client.Tenant).
-		Page(page).
-		Size(size)
-	if filters := buildExecutionFilters(namespace, flowID, state); len(filters) > 0 {
-		req = req.Filters(filters)
-	}
+	pageInt, sizeInt := int(page), int(size)
+	filters := queryFiltersToSearchFilters(buildExecutionFilters(namespace, flowID, state))
 
-	resp, _, err := req.Execute()
+	resp, err := client.Kestra.Executions().
+		SearchExecutions(client.Ctx, client.Tenant, &pageInt, &sizeInt, nil, filters)
 	if err != nil {
 		return formatSDKError(err)
 	}
@@ -1251,13 +1248,10 @@ func runExecutionsSearchByFlow(client *Client, namespace, flowID string, page, s
 		size = 50
 	}
 
-	resp, _, err := client.API.ExecutionsAPI.
-		SearchExecutionsByFlowId(client.Ctx, client.Tenant).
-		Namespace(namespace).
-		FlowId(flowID).
-		Page(page).
-		Size(size).
-		Execute()
+	pageInt, sizeInt := int(page), int(size)
+
+	resp, err := client.Kestra.Executions().
+		SearchExecutionsByFlowId(client.Ctx, client.Tenant, namespace, flowID, &pageInt, &sizeInt)
 	if err != nil {
 		return formatSDKError(err)
 	}


### PR DESCRIPTION
Closes https://github.com/kestra-io/kestractl/issues/100

## Problem

`kestractl executions list` and `kestractl executions search-by-flow` fail against a Kestra 2.0 instance whenever at least one execution is returned:

```
Error: API error: no value given for required property deleted
```

An empty result set succeeds, which makes the failure look like a permissions or filter problem.

## Cause

`GET /api/v1/{tenant}/executions/search` returns `PagedResults_ApiLightExecution_`, and `ApiLightExecution` has no `deleted` property. Both commands still went through the *generated* builder API (`client.API.ExecutionsAPI.SearchExecutions` / `SearchExecutionsByFlowId`), which deserializes into `PagedResultsExecution` → `Execution`, where `deleted` and `metadata` are required. The first missing required property is what gets reported.

`executions get` and `executions latest` were unaffected — they use different models.

## Fix

go-sdk `v2.0.0-rc1` already ships the correct path in its hand-written client layer, so both call sites move over to it — the same migration `assets.go` already went through:

```go
client.Kestra.Executions().SearchExecutions(ctx, tenant, &page, &size, nil, filters)      // -> *PagedResultsApiLightExecution
client.Kestra.Executions().SearchExecutionsByFlowId(ctx, tenant, namespace, flowId, &page, &size)
```

`ApiLightExecution` carries every field the two commands render (`id`, `namespace`, `flowId`, `state`), so table and JSON output are unchanged. Existing `QueryFilter` construction is reused through `queryFiltersToSearchFilters`, which keeps `--namespace` / `--flow-id` / `--state` behaviour identical.

## QA

Verified against a local Kestra `2.0.0-SNAPSHOT` OSS instance.

Before:

```
$ kestractl executions list --namespace qa.core
Error: API error: no value given for required property deleted
```

After:

```
$ kestractl executions list --namespace qa.core
ID                      NAMESPACE  FLOW          STATE      STARTED               DURATION
1xA0msu5EOKHaJ2kUOrQGU  qa.core    qa-core-exec  "SUCCESS"  2026-08-27T12:12:58Z  0.49s
6jODpuHHVF8493DCiH6QjF  qa.core    qa-core-exec  "SUCCESS"  2026-08-27T12:15:17Z  0.40s
2EvK0fAU93n7XD5JAxiXs   qa.core    qa-preview    "SUCCESS"  2026-08-27T12:16:26Z  0.55s

Showing 3 execution(s) (page 1, total 3)

$ kestractl executions search-by-flow --namespace qa.core --flow-id qa-core-exec
ID                      NAMESPACE  FLOW          STATE      STARTED               DURATION
1xA0msu5EOKHaJ2kUOrQGU  qa.core    qa-core-exec  "SUCCESS"  2026-08-27T12:12:58Z  0.49s
6jODpuHHVF8493DCiH6QjF  qa.core    qa-core-exec  "SUCCESS"  2026-08-27T12:15:17Z  0.40s

Showing 2 execution(s) (page 1, total 2)
```

Also exercised: no-filter listing, `--state success`, `-o json`, and a namespace with no executions (still `Showing 0 execution(s)`, no error). `go test ./src/...` passes.

## Note

The `STATE` column renders as `"SUCCESS"` with quotes — `stringify` JSON-marshals the `StateType` enum. Pre-existing in this code path and orthogonal to the deserialization bug, so it is left out of this PR; happy to strip the quotes here if you would rather it ship together.
