### PR TITLE
feat(install): add install-v2.sh installing kestractl v2 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Go-based command-line interface for managing Kestra flows, executions, trigger
 Install the latest kestractl v2 release (prereleases included):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION=2 bash
+curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install-v2.sh | bash
 ```
 
 Install the latest v1 release (for legacy Kestra v1.x instances):

--- a/install-scripts/install-v2.sh
+++ b/install-scripts/install-v2.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Installs the latest kestractl v2 release (prereleases included) by default.
+# Thin wrapper around install.sh: defaults VERSION=2, everything else
+# (VERSION, INSTALL_DIR, BINARY_NAME, GITHUB_REPO) can still be overridden
+# via environment variables exactly like install.sh.
+set -euo pipefail
+
+INSTALL_SCRIPT_URL="${INSTALL_SCRIPT_URL:-https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh}"
+
+err() {
+  printf "Error: %s\n" "$1" >&2
+  exit 1
+}
+
+export VERSION="${VERSION:-2}"
+
+# When executed as a file (not piped), prefer the sibling install.sh from the
+# same checkout over fetching it from the network.
+if [ -n "${BASH_SOURCE[0]:-}" ] && [ -f "${BASH_SOURCE[0]}" ]; then
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [ -f "$script_dir/install.sh" ]; then
+    exec bash "$script_dir/install.sh"
+  fi
+fi
+
+# Piped via curl/wget: fetch install.sh and run it.
+if command -v curl >/dev/null 2>&1; then
+  script="$(curl -fsSL "$INSTALL_SCRIPT_URL")" || err "Download failed: $INSTALL_SCRIPT_URL"
+elif command -v wget >/dev/null 2>&1; then
+  script="$(wget -qO- "$INSTALL_SCRIPT_URL")" || err "Download failed: $INSTALL_SCRIPT_URL"
+else
+  err "curl or wget is required"
+fi
+[ -n "$script" ] || err "Downloaded install script is empty: $INSTALL_SCRIPT_URL"
+
+exec bash -c "$script"


### PR DESCRIPTION
## Context

The historic install command must keep installing v1 by default:

```bash
curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash
```

This PR adds a second, v2-defaulting entry point so users can be pointed at a dedicated v2 URL instead of having to know the `VERSION=2` env var:

```bash
curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install-v2.sh | bash
```

## Design

`install-v2.sh` is a **thin wrapper**, not a copy: it defaults `VERSION=2` and delegates to `install.sh` (the sibling file when run from a checkout, fetched from the raw main URL when piped). One source of truth for the actual install logic — no drift between two 150-line scripts. All env overrides (`VERSION`, `INSTALL_DIR`, `BINARY_NAME`, `GITHUB_REPO`) pass through unchanged, so `VERSION=2.1.0` etc. still works against the v2 wrapper.

`install.sh` is untouched.

## Testing

- run as a file from the checkout → installed v2.0.0-rc1 via sibling `install.sh`
- piped via stdin (curl-pipe simulation) → fetched `install.sh` from raw URL, installed v2.0.0-rc1
- `VERSION=v1.18.1` override through the wrapper → installed v1.18.1
- `bash -n` syntax check passes