### PR TITLE
feat(cli): tenant management and tenant/namespace concurrency+quota configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1
-	github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2
+	github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2.0.20260901074051-bde3ef8187d2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2 h1:Nsr5D1WmMh07Z8olfrGesBoswiEhChaDMg1L9kQi0+Y=
-github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2/go.mod h1:ckpZC/7pTYvb7B2iLxY90UGKu374oBvDsGXJ8bWtlwk=
+github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2.0.20260901074051-bde3ef8187d2 h1:Xg4T6b8rHGB0SdSwWdKtZDVYhQdfUjYORb5mpEpDwlQ=
+github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2.0.20260901074051-bde3ef8187d2/go.mod h1:ckpZC/7pTYvb7B2iLxY90UGKu374oBvDsGXJ8bWtlwk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/src/cli/flows_test.go
+++ b/src/cli/flows_test.go
@@ -1509,7 +1509,7 @@ func TestRunFlowsNamespaceSync(t *testing.T) {
 // A complete, otherwise-valid flow that fails to decode ONLY because of its
 // array-format labels — faithfully reproducing #83 (see the assertion in
 // TestConfirmArrayLabelsDecodeError).
-const flowWithArrayLabelsJSON = `{"id":"my-flow","namespace":"my.namespace","revision":2,"description":"labelled flow","disabled":false,"draft":false,"deleted":false,"tasks":[],"source":"id: my-flow\nnamespace: my.namespace\nlabels:\n  - key: type\n    value: data_extraction\n","labels":[{"key":"type","value":"data_extraction"},{"key":"version","value":"v2"}]}`
+const flowWithArrayLabelsJSON = `{"id":"my-flow","namespace":"my.namespace","revision":2,"description":"labelled flow","disabled":false,"deleted":false,"tasks":[],"source":"id: my-flow\nnamespace: my.namespace\nlabels:\n  - key: type\n    value: data_extraction\n","labels":[{"key":"type","value":"data_extraction"},{"key":"version","value":"v2"}]}`
 
 func TestRunFlowsGet_ArrayLabels(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1742,17 +1742,21 @@ func TestTryParseFlowSearchFromError(t *testing.T) {
 	})
 }
 
-// TestConfirmArrayLabelsDecodeError used to guard fixture fidelity for #83: the
-// generated client failed to decode array-format labels, which is what the
-// tryParseFlow* fallbacks exist to recover from. go-sdk v2 fixed this (Labels
-// is now a MapObjectObject that accepts both array and map form), so the
-// fixture now decodes cleanly. The tryParseFlow* fallbacks are kept as a
-// defensive fallback for other SDK type-mismatch-on-error cases (see
-// formatSDKError / AGENTS.md), but are no longer exercised by this fixture.
-func TestConfirmArrayLabelsDecodeError(t *testing.T) {
+// TestConfirmFixtureDecodeError guards fixture fidelity: it asserts that the
+// shared fixture is a valid flow that the generated client fails to decode —
+// the condition the tryParseFlow* fallbacks exist to recover from. The v2 SDK
+// accepts array-format labels (the original #83 condition), but its strict
+// decode still rejects the fixture because the required `draft` property is
+// absent, as it is in responses from servers older than 2.0. If the SDK ever
+// decodes the fixture as-is, this test flips and the workaround (and its
+// tests) can be retired.
+func TestConfirmFixtureDecodeError(t *testing.T) {
 	var fws kestra.FlowWithSource
 	err := json.Unmarshal([]byte(flowWithArrayLabelsJSON), &fws)
-	if err != nil {
-		t.Fatalf("expected array-format labels to decode cleanly on go-sdk v2, got: %v", err)
+	if err == nil {
+		t.Fatal("decode unexpectedly succeeded: the tryParseFlow* fallbacks have no condition left to recover from")
+	}
+	if !strings.Contains(err.Error(), "draft") {
+		t.Fatalf("fixture fails to decode for the wrong reason (want a missing-draft error): %v", err)
 	}
 }

--- a/src/cli/namespaces.go
+++ b/src/cli/namespaces.go
@@ -157,6 +157,12 @@ func runNamespacesGet(client *Client, id string, renderer *Renderer) error {
 		"deleted":     ns.GetDeleted(),
 		"variables":   ns.GetVariables(),
 	}
+	if c, ok := ns.GetConcurrencyOk(); ok {
+		result["concurrency"] = c
+	}
+	if quotas := ns.GetQuotas(); len(quotas) > 0 {
+		result["quotas"] = quotas
+	}
 
 	return renderer.Render(result, func(w *tabwriter.Writer) error {
 		fmt.Fprintf(w, "ID\t%s\n", ns.GetId())
@@ -164,6 +170,7 @@ func runNamespacesGet(client *Client, id string, renderer *Renderer) error {
 			fmt.Fprintf(w, "DESCRIPTION\t%s\n", desc)
 		}
 		fmt.Fprintf(w, "DELETED\t%v\n", ns.GetDeleted())
+		writeConcurrencyAndQuotas(w, ns.Concurrency, ns.GetQuotas())
 		if vars := ns.GetVariables(); len(vars) > 0 {
 			fmt.Fprintln(w, "\nVARIABLES:")
 			for k, v := range vars {
@@ -209,6 +216,9 @@ func newNamespacesCreateCommand() *cobra.Command {
 	var description string
 	var variablePairs []string
 	var variablesFile string
+	var concurrencyLimit int32
+	var concurrencyBehavior string
+	var quotaSpecs []string
 
 	cmd := &cobra.Command{
 		Use:   "create <namespace_id>",
@@ -217,6 +227,8 @@ func newNamespacesCreateCommand() *cobra.Command {
   kestractl namespaces create my.namespace --description "My team namespace"
   kestractl namespaces create my.namespace --variable env=prod --variable region=eu
   kestractl namespaces create my.namespace --variables-file variables.yml
+  kestractl namespaces create my.namespace --concurrency-limit 10 --concurrency-behavior QUEUE
+  kestractl namespaces create my.namespace --quota duration=PT1H,limit=100,behavior=FAIL
   kestractl namespaces create my.namespace --output json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -228,27 +240,45 @@ func newNamespacesCreateCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			concurrency, err := parseConcurrencyFlags(
+				concurrencyLimit, cmd.Flags().Changed("concurrency-limit"),
+				concurrencyBehavior, cmd.Flags().Changed("concurrency-behavior"))
+			if err != nil {
+				return err
+			}
+			quotas, err := parseQuotaFlags(quotaSpecs)
+			if err != nil {
+				return err
+			}
 			client, err := newClientFunc()
 			if err != nil {
 				return err
 			}
-			return runNamespacesCreate(client, args[0], description, variables, renderer)
+			return runNamespacesCreate(client, args[0], description, variables, concurrency, quotas, renderer)
 		},
 	}
 
 	cmd.Flags().StringVar(&description, "description", "", "Namespace description")
 	cmd.Flags().StringArrayVar(&variablePairs, "variable", nil, "Namespace variable as key=value (repeatable)")
 	cmd.Flags().StringVar(&variablesFile, "variables-file", "", "Path to a YAML or JSON file defining namespace variables")
+	addConcurrencyFlags(cmd, &concurrencyLimit, &concurrencyBehavior)
+	addQuotaFlag(cmd, &quotaSpecs, "Execution quota as duration=<ISO-8601>,limit=<n>,behavior=<FAIL|CANCEL> (repeatable)")
 	return cmd
 }
 
-func runNamespacesCreate(client *Client, id, description string, variables map[string]interface{}, renderer *Renderer) error {
+func runNamespacesCreate(client *Client, id, description string, variables map[string]interface{}, concurrency *kestra.Concurrency, quotas []kestra.Quota, renderer *Renderer) error {
 	ns := kestra.NewNamespace(id, false)
 	if description != "" {
 		ns.SetDescription(description)
 	}
 	if len(variables) > 0 {
 		ns.SetVariables(variables)
+	}
+	if concurrency != nil {
+		ns.SetConcurrency(*concurrency)
+	}
+	if quotas != nil {
+		ns.SetQuotas(quotas)
 	}
 
 	created, _, err := client.API.NamespacesAPI.
@@ -316,6 +346,9 @@ func newNamespacesUpdateCommand() *cobra.Command {
 	var description string
 	var variablePairs []string
 	var variablesFile string
+	var concurrencyLimit int32
+	var concurrencyBehavior string
+	var quotaSpecs []string
 
 	cmd := &cobra.Command{
 		Use:   "update <namespace_id>",
@@ -329,10 +362,15 @@ applied on top before saving.
 --variable and --variables-file set the full list of namespace variables,
 replacing any variables previously set on the namespace. Combine them to
 layer inline overrides on top of a file: --variable entries win on key
-conflicts.`,
+conflicts.
+
+--quota sets the full list of execution quotas, replacing any quotas
+previously set on the namespace.`,
 		Example: `  kestractl namespaces update my.namespace --description "Updated description"
   kestractl namespaces update my.namespace --variable env=prod --variable region=eu
   kestractl namespaces update my.namespace --variables-file variables.yml
+  kestractl namespaces update my.namespace --concurrency-limit 20 --concurrency-behavior FAIL
+  kestractl namespaces update my.namespace --quota duration=PT1H,limit=100,behavior=FAIL
   kestractl namespaces update my.namespace --output json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -344,21 +382,33 @@ conflicts.`,
 			if err != nil {
 				return err
 			}
+			concurrency, err := parseConcurrencyFlags(
+				concurrencyLimit, cmd.Flags().Changed("concurrency-limit"),
+				concurrencyBehavior, cmd.Flags().Changed("concurrency-behavior"))
+			if err != nil {
+				return err
+			}
+			quotas, err := parseQuotaFlags(quotaSpecs)
+			if err != nil {
+				return err
+			}
 			client, err := newClientFunc()
 			if err != nil {
 				return err
 			}
-			return runNamespacesUpdate(client, args[0], description, cmd.Flags().Changed("description"), variables, renderer)
+			return runNamespacesUpdate(client, args[0], description, cmd.Flags().Changed("description"), variables, concurrency, quotas, renderer)
 		},
 	}
 
 	cmd.Flags().StringVar(&description, "description", "", "New namespace description")
 	cmd.Flags().StringArrayVar(&variablePairs, "variable", nil, "Namespace variable as key=value (repeatable); replaces existing variables")
 	cmd.Flags().StringVar(&variablesFile, "variables-file", "", "Path to a YAML or JSON file defining namespace variables; replaces existing variables")
+	addConcurrencyFlags(cmd, &concurrencyLimit, &concurrencyBehavior)
+	addQuotaFlag(cmd, &quotaSpecs, "Execution quota as duration=<ISO-8601>,limit=<n>,behavior=<FAIL|CANCEL> (repeatable); replaces existing quotas")
 	return cmd
 }
 
-func runNamespacesUpdate(client *Client, id, description string, descriptionSet bool, variables map[string]interface{}, renderer *Renderer) error {
+func runNamespacesUpdate(client *Client, id, description string, descriptionSet bool, variables map[string]interface{}, concurrency *kestra.Concurrency, quotas []kestra.Quota, renderer *Renderer) error {
 	// UpdateNamespace is a full-replace PUT: start from the current namespace
 	// so fields not passed on this invocation aren't wiped.
 	ns, _, err := client.API.NamespacesAPI.Namespace(client.Ctx, id, client.Tenant).Execute()
@@ -374,6 +424,12 @@ func runNamespacesUpdate(client *Client, id, description string, descriptionSet 
 	}
 	if variables != nil {
 		ns.SetVariables(variables)
+	}
+	if concurrency != nil {
+		ns.SetConcurrency(*concurrency)
+	}
+	if quotas != nil {
+		ns.SetQuotas(quotas)
 	}
 
 	updated, _, err := client.API.NamespacesAPI.

--- a/src/cli/namespaces.go
+++ b/src/cli/namespaces.go
@@ -297,12 +297,19 @@ func runNamespacesCreate(client *Client, id, description string, variables map[s
 		"description": created.GetDescription(),
 		"variables":   created.GetVariables(),
 	}
+	if c, ok := created.GetConcurrencyOk(); ok {
+		result["concurrency"] = c
+	}
+	if quotas := created.GetQuotas(); len(quotas) > 0 {
+		result["quotas"] = quotas
+	}
 
 	return renderer.Render(result, func(w *tabwriter.Writer) error {
 		fmt.Fprintf(w, "ID\t%s\n", created.GetId())
 		if desc := created.GetDescription(); desc != "" {
 			fmt.Fprintf(w, "DESCRIPTION\t%s\n", desc)
 		}
+		writeConcurrencyAndQuotas(w, created.Concurrency, created.GetQuotas())
 		fmt.Fprintln(w, "\nNamespace created.")
 		return nil
 	})
@@ -448,12 +455,19 @@ func runNamespacesUpdate(client *Client, id, description string, descriptionSet 
 		"description": updated.GetDescription(),
 		"variables":   updated.GetVariables(),
 	}
+	if c, ok := updated.GetConcurrencyOk(); ok {
+		result["concurrency"] = c
+	}
+	if quotas := updated.GetQuotas(); len(quotas) > 0 {
+		result["quotas"] = quotas
+	}
 
 	return renderer.Render(result, func(w *tabwriter.Writer) error {
 		fmt.Fprintf(w, "ID\t%s\n", updated.GetId())
 		if desc := updated.GetDescription(); desc != "" {
 			fmt.Fprintf(w, "DESCRIPTION\t%s\n", desc)
 		}
+		writeConcurrencyAndQuotas(w, updated.Concurrency, updated.GetQuotas())
 		fmt.Fprintln(w, "\nNamespace updated.")
 		return nil
 	})

--- a/src/cli/namespaces_test.go
+++ b/src/cli/namespaces_test.go
@@ -359,7 +359,7 @@ func TestRunNamespacesUpdate_SetsVariables(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	var buf bytes.Buffer
-	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "", false, map[string]interface{}{"env": "prod"}, newTableRenderer(&buf))
+	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "", false, map[string]interface{}{"env": "prod"}, nil, nil, newTableRenderer(&buf))
 	if err != nil {
 		t.Fatalf("runNamespacesUpdate error: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestRunNamespacesUpdate_DescriptionOnlyPreservesVariables(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	var buf bytes.Buffer
-	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "touched", true, nil, newTableRenderer(&buf))
+	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "touched", true, nil, nil, nil, newTableRenderer(&buf))
 	if err != nil {
 		t.Fatalf("runNamespacesUpdate error: %v", err)
 	}
@@ -414,7 +414,7 @@ func TestRunNamespacesUpdate_VariablesOnlyPreservesDescription(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	var buf bytes.Buffer
-	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "", false, map[string]interface{}{"env": "staging"}, newTableRenderer(&buf))
+	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "", false, map[string]interface{}{"env": "staging"}, nil, nil, newTableRenderer(&buf))
 	if err != nil {
 		t.Fatalf("runNamespacesUpdate error: %v", err)
 	}
@@ -435,7 +435,7 @@ func TestRunNamespacesUpdate_GetError(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	var buf bytes.Buffer
-	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "new desc", true, nil, newTableRenderer(&buf))
+	err := runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "new desc", true, nil, nil, nil, newTableRenderer(&buf))
 	if err == nil {
 		t.Fatal("expected error when fetching the current namespace fails")
 	}
@@ -451,7 +451,7 @@ func TestRunNamespacesCreate_SetsVariables(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	var buf bytes.Buffer
-	err := runNamespacesCreate(newTestClient(t, server.URL), "my.namespace", "", map[string]interface{}{"env": "prod"}, newTableRenderer(&buf))
+	err := runNamespacesCreate(newTestClient(t, server.URL), "my.namespace", "", map[string]interface{}{"env": "prod"}, nil, nil, newTableRenderer(&buf))
 	if err != nil {
 		t.Fatalf("runNamespacesCreate error: %v", err)
 	}
@@ -478,5 +478,89 @@ func TestRunNamespacesGet_ShowsVariables(t *testing.T) {
 	out := buf.String()
 	if !strings.Contains(out, "VARIABLES") || !strings.Contains(out, "env") || !strings.Contains(out, "prod") {
 		t.Fatalf("expected variables in output, got:\n%s", out)
+	}
+}
+
+func TestRunNamespacesCreate_SendsConcurrencyAndQuotas(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"concurrency":{"limit":10,"behavior":"QUEUE"},"quotas":[{"duration":"PT1H","limit":100,"behavior":"FAIL"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	concurrency, err := parseConcurrencyFlags(10, true, "QUEUE", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	quotas, err := parseQuotaFlags([]string{"duration=PT1H,limit=100,behavior=FAIL"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err = runNamespacesCreate(newTestClient(t, server.URL), "my.namespace", "", nil, concurrency, quotas, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesCreate error: %v", err)
+	}
+
+	sentConcurrency, ok := gotBody["concurrency"].(map[string]interface{})
+	if !ok || sentConcurrency["limit"] != float64(10) || sentConcurrency["behavior"] != "QUEUE" {
+		t.Fatalf("expected concurrency in request body, got: %v", gotBody)
+	}
+	sentQuotas, ok := gotBody["quotas"].([]interface{})
+	if !ok || len(sentQuotas) != 1 {
+		t.Fatalf("expected quotas in request body, got: %v", gotBody)
+	}
+}
+
+func TestRunNamespacesUpdate_ConcurrencyOnlyPreservesVariables(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"variables":{"env":"prod"},"quotas":[{"duration":"PT1H","limit":100,"behavior":"FAIL"}]}`))
+		case http.MethodPut:
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_, _ = w.Write([]byte(`{"id":"my.namespace","deleted":false,"variables":{"env":"prod"}}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	concurrency, err := parseConcurrencyFlags(20, true, "FAIL", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err = runNamespacesUpdate(newTestClient(t, server.URL), "my.namespace", "", false, nil, concurrency, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesUpdate error: %v", err)
+	}
+
+	sentConcurrency, ok := gotBody["concurrency"].(map[string]interface{})
+	if !ok || sentConcurrency["limit"] != float64(20) || sentConcurrency["behavior"] != "FAIL" {
+		t.Fatalf("expected concurrency in request body, got: %v", gotBody)
+	}
+	vars, ok := gotBody["variables"].(map[string]interface{})
+	if !ok || vars["env"] != "prod" {
+		t.Fatalf("expected pre-existing variables to be preserved, got: %v", gotBody)
+	}
+	sentQuotas, ok := gotBody["quotas"].([]interface{})
+	if !ok || len(sentQuotas) != 1 {
+		t.Fatalf("expected pre-existing quotas to be preserved, got: %v", gotBody)
+	}
+}
+
+func TestNamespacesCreateCommand_InvalidQuota(t *testing.T) {
+	cmd := newNamespacesCreateCommand()
+	_, err := executeCommand(cmd, "my.namespace", "--quota", "duration=PT1H")
+	if err == nil {
+		t.Fatal("expected error for incomplete --quota")
+	}
+	if !strings.Contains(err.Error(), "duration, limit and behavior are all required") {
+		t.Fatalf("expected missing-key error, got: %v", err)
 	}
 }

--- a/src/cli/namespaces_test.go
+++ b/src/cli/namespaces_test.go
@@ -513,6 +513,10 @@ func TestRunNamespacesCreate_SendsConcurrencyAndQuotas(t *testing.T) {
 	if !ok || len(sentQuotas) != 1 {
 		t.Fatalf("expected quotas in request body, got: %v", gotBody)
 	}
+	out := buf.String()
+	if !strings.Contains(out, "CONCURRENCY") || !strings.Contains(out, "QUOTAS") {
+		t.Fatalf("expected concurrency and quotas echoed in create output, got:\n%s", out)
+	}
 }
 
 func TestRunNamespacesUpdate_ConcurrencyOnlyPreservesVariables(t *testing.T) {

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -111,6 +111,7 @@ with support for multiple authentication contexts and output formats.`,
 	root.AddCommand(newConfigCommand())
 	root.AddCommand(newFlowsCommand())
 	root.AddCommand(newNamespacesCommand())
+	root.AddCommand(newTenantsCommand())
 	root.AddCommand(newNamespaceFilesCommand())
 	root.AddCommand(newKVCommand())
 	root.AddCommand(newExecutionsCommand())

--- a/src/cli/tenants.go
+++ b/src/cli/tenants.go
@@ -1,0 +1,451 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+	"github.com/spf13/cobra"
+)
+
+func newTenantsCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tenants",
+		Short: "Manage tenants (list, get, create, update, delete)",
+		Long: `Manage tenants in your Kestra instance.
+
+Tenants are instance-level resources: managing them requires Kestra
+Enterprise Edition and instance-owner permissions.`,
+	}
+
+	cmd.AddCommand(newTenantsListCommand())
+	cmd.AddCommand(newTenantsGetCommand())
+	cmd.AddCommand(newTenantsCreateCommand())
+	cmd.AddCommand(newTenantsUpdateCommand())
+	cmd.AddCommand(newTenantsDeleteCommand())
+
+	return cmd
+}
+
+func newTenantsListCommand() *cobra.Command {
+	var (
+		page int32
+		size int32
+		sort []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List tenants.",
+		Long:  "List all tenants in your Kestra instance.",
+		Example: `  # List all tenants
+  kestractl tenants list
+
+  # List tenants as JSON
+  kestractl tenants list --output json`,
+		Aliases: []string{"ls"},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runTenantsList(client, page, size, sort, renderer)
+		},
+	}
+
+	cmd.Flags().Int32Var(&page, "page", 1, "Page number")
+	cmd.Flags().Int32Var(&size, "size", 100, "Page size")
+	cmd.Flags().StringArrayVar(&sort, "sort", nil, "Sort expression (e.g. 'id:asc', repeatable)")
+
+	return cmd
+}
+
+func runTenantsList(client *Client, page, size int32, sort []string, renderer *Renderer) error {
+	pageParam, sizeParam := int(page), int(size)
+	resp, err := client.Kestra.Tenants().SearchTenants(client.Ctx, &pageParam, &sizeParam, sort, nil)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	if resp == nil {
+		resp = &kestra.PagedResultsTenant{}
+	}
+
+	results := resp.Results
+	if results == nil {
+		results = []kestra.Tenant{}
+	}
+
+	return renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintln(w, "ID\tNAME\tCONCURRENCY LIMIT\tQUOTAS")
+		for _, tenant := range results {
+			concurrencyLimit := ""
+			if c, ok := tenant.GetConcurrencyOk(); ok {
+				concurrencyLimit = fmt.Sprintf("%d (%s)", c.GetLimit(), c.GetBehavior())
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%d\n",
+				tenant.GetId(), tenant.GetName(), concurrencyLimit, len(tenant.GetQuotas()))
+		}
+		fmt.Fprintf(w, "\nTotal tenants: %d\n", resp.Total)
+		return nil
+	})
+}
+
+func newTenantsGetCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <tenant_id>",
+		Short: "Get a tenant by ID.",
+		Example: `  kestractl tenants get my-tenant
+  kestractl tenants get my-tenant --output json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runTenantsGet(client, args[0], renderer)
+		},
+	}
+	return cmd
+}
+
+func runTenantsGet(client *Client, id string, renderer *Renderer) error {
+	tenant, err := client.Kestra.Tenants().Tenant(client.Ctx, id)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	if tenant == nil {
+		tenant = kestra.NewTenantWithDefaults()
+	}
+
+	return renderTenant(renderer, tenant, "")
+}
+
+func newTenantsCreateCommand() *cobra.Command {
+	var (
+		name                string
+		concurrencyLimit    int32
+		concurrencyBehavior string
+		quotaSpecs          []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "create <tenant_id>",
+		Short: "Create a tenant.",
+		Example: `  kestractl tenants create my-tenant
+  kestractl tenants create my-tenant --name "My Tenant"
+  kestractl tenants create my-tenant --concurrency-limit 10 --concurrency-behavior QUEUE
+  kestractl tenants create my-tenant --quota duration=PT1H,limit=100,behavior=FAIL
+  kestractl tenants create my-tenant --output json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			concurrency, err := parseConcurrencyFlags(
+				concurrencyLimit, cmd.Flags().Changed("concurrency-limit"),
+				concurrencyBehavior, cmd.Flags().Changed("concurrency-behavior"))
+			if err != nil {
+				return err
+			}
+			quotas, err := parseQuotaFlags(quotaSpecs)
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runTenantsCreate(client, args[0], name, concurrency, quotas, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "Tenant display name (defaults to the tenant ID)")
+	addConcurrencyFlags(cmd, &concurrencyLimit, &concurrencyBehavior)
+	addQuotaFlag(cmd, &quotaSpecs, "Execution quota as duration=<ISO-8601>,limit=<n>,behavior=<FAIL|CANCEL> (repeatable)")
+
+	return cmd
+}
+
+func runTenantsCreate(client *Client, id, name string, concurrency *kestra.Concurrency, quotas []kestra.Quota, renderer *Renderer) error {
+	if name == "" {
+		name = id
+	}
+
+	tenant := kestra.NewTenant(id, name, false)
+	if concurrency != nil {
+		tenant.SetConcurrency(*concurrency)
+	}
+	if quotas != nil {
+		tenant.SetQuotas(quotas)
+	}
+
+	created, err := client.Kestra.Tenants().CreateTenant(client.Ctx, *tenant)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	if created == nil {
+		created = tenant
+	}
+
+	return renderTenant(renderer, created, "Tenant created.")
+}
+
+func newTenantsUpdateCommand() *cobra.Command {
+	var (
+		name                string
+		concurrencyLimit    int32
+		concurrencyBehavior string
+		quotaSpecs          []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "update <tenant_id>",
+		Short: "Update a tenant.",
+		Long: `Update a tenant.
+
+Fields not passed on the command line keep their current value: the
+existing tenant is fetched first, and only the flags provided here are
+applied on top before saving.
+
+--quota sets the full list of execution quotas, replacing any quotas
+previously set on the tenant.`,
+		Example: `  kestractl tenants update my-tenant --name "Renamed Tenant"
+  kestractl tenants update my-tenant --concurrency-limit 20 --concurrency-behavior FAIL
+  kestractl tenants update my-tenant --quota duration=PT1H,limit=100,behavior=FAIL --quota duration=P1D,limit=1000,behavior=CANCEL
+  kestractl tenants update my-tenant --output json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			concurrency, err := parseConcurrencyFlags(
+				concurrencyLimit, cmd.Flags().Changed("concurrency-limit"),
+				concurrencyBehavior, cmd.Flags().Changed("concurrency-behavior"))
+			if err != nil {
+				return err
+			}
+			quotas, err := parseQuotaFlags(quotaSpecs)
+			if err != nil {
+				return err
+			}
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+			return runTenantsUpdate(client, args[0], name, cmd.Flags().Changed("name"), concurrency, quotas, renderer)
+		},
+	}
+
+	cmd.Flags().StringVar(&name, "name", "", "New tenant display name")
+	addConcurrencyFlags(cmd, &concurrencyLimit, &concurrencyBehavior)
+	addQuotaFlag(cmd, &quotaSpecs, "Execution quota as duration=<ISO-8601>,limit=<n>,behavior=<FAIL|CANCEL> (repeatable); replaces existing quotas")
+
+	return cmd
+}
+
+func runTenantsUpdate(client *Client, id, name string, nameSet bool, concurrency *kestra.Concurrency, quotas []kestra.Quota, renderer *Renderer) error {
+	// UpdateTenant is a full-replace PUT: start from the current tenant so
+	// fields not passed on this invocation aren't wiped.
+	tenant, err := client.Kestra.Tenants().Tenant(client.Ctx, id)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	if tenant == nil {
+		tenant = kestra.NewTenant(id, id, false)
+	}
+
+	if nameSet {
+		tenant.Name = name
+	}
+	if concurrency != nil {
+		tenant.SetConcurrency(*concurrency)
+	}
+	if quotas != nil {
+		tenant.SetQuotas(quotas)
+	}
+
+	updated, err := client.Kestra.Tenants().UpdateTenant(client.Ctx, id, *tenant)
+	if err != nil {
+		return formatSDKError(err)
+	}
+	if updated == nil {
+		updated = tenant
+	}
+
+	return renderTenant(renderer, updated, "Tenant updated.")
+}
+
+func newTenantsDeleteCommand() *cobra.Command {
+	var skipConfirm bool
+
+	cmd := &cobra.Command{
+		Use:     "delete <tenant_id>",
+		Short:   "Delete a tenant.",
+		Long:    "Delete a tenant and all resources linked to it (flows, namespaces, apps, ...). Prompts for confirmation unless --yes is provided.",
+		Aliases: []string{"rm"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+			return runTenantsDelete(client, args[0], skipConfirm, cmd.InOrStdin(), renderer)
+		},
+	}
+
+	cmd.Flags().BoolVarP(&skipConfirm, "yes", "y", false, "Skip the confirmation prompt")
+
+	return cmd
+}
+
+func runTenantsDelete(client *Client, id string, skipConfirm bool, in io.Reader, renderer *Renderer) error {
+	if !skipConfirm {
+		// Prompt on stderr so it never pollutes stdout (e.g. --output json).
+		confirmed, err := confirm(in, os.Stderr,
+			fmt.Sprintf("Are you sure you want to delete tenant '%s' and all resources linked to it? [y/N]: ", id))
+		if err != nil {
+			return err
+		}
+		if !confirmed {
+			return renderStatus(renderer, "Cancelled.", map[string]any{"id": id, "status": "cancelled"})
+		}
+	}
+
+	if err := client.Kestra.Tenants().DeleteTenant(client.Ctx, id); err != nil {
+		return formatSDKError(err)
+	}
+
+	return renderStatus(renderer, fmt.Sprintf("Tenant '%s' deleted.", id),
+		map[string]any{"id": id, "status": "deleted"})
+}
+
+func renderTenant(renderer *Renderer, tenant *kestra.Tenant, footer string) error {
+	result := map[string]any{
+		"id":      tenant.GetId(),
+		"name":    tenant.GetName(),
+		"deleted": tenant.GetDeleted(),
+	}
+	if c, ok := tenant.GetConcurrencyOk(); ok {
+		result["concurrency"] = c
+	}
+	if quotas := tenant.GetQuotas(); len(quotas) > 0 {
+		result["quotas"] = quotas
+	}
+
+	return renderer.Render(result, func(w *tabwriter.Writer) error {
+		fmt.Fprintf(w, "ID\t%s\n", tenant.GetId())
+		fmt.Fprintf(w, "NAME\t%s\n", tenant.GetName())
+		fmt.Fprintf(w, "DELETED\t%v\n", tenant.GetDeleted())
+		writeConcurrencyAndQuotas(w, tenant.Concurrency, tenant.GetQuotas())
+		if footer != "" {
+			fmt.Fprintf(w, "\n%s\n", footer)
+		}
+		return nil
+	})
+}
+
+func writeConcurrencyAndQuotas(w *tabwriter.Writer, concurrency *kestra.Concurrency, quotas []kestra.Quota) {
+	if concurrency != nil {
+		fmt.Fprintf(w, "CONCURRENCY\tlimit=%d behavior=%s\n", concurrency.GetLimit(), concurrency.GetBehavior())
+	}
+	if len(quotas) > 0 {
+		fmt.Fprintln(w, "\nQUOTAS:")
+		fmt.Fprintln(w, "  DURATION\tLIMIT\tBEHAVIOR")
+		for _, q := range quotas {
+			fmt.Fprintf(w, "  %s\t%d\t%s\n", q.GetDuration(), q.GetLimit(), q.GetBehavior())
+		}
+	}
+}
+
+func addConcurrencyFlags(cmd *cobra.Command, limit *int32, behavior *string) {
+	cmd.Flags().Int32Var(limit, "concurrency-limit", 0, "Maximum number of concurrent executions")
+	cmd.Flags().StringVar(behavior, "concurrency-behavior", "QUEUE", "Behavior when the concurrency limit is reached (QUEUE, CANCEL or FAIL)")
+}
+
+func addQuotaFlag(cmd *cobra.Command, specs *[]string, usage string) {
+	cmd.Flags().StringArrayVar(specs, "quota", nil, usage)
+}
+
+// parseConcurrencyFlags builds a concurrency setting from the
+// --concurrency-limit and --concurrency-behavior flags. Returns nil if
+// neither flag was provided.
+func parseConcurrencyFlags(limit int32, limitSet bool, behavior string, behaviorSet bool) (*kestra.Concurrency, error) {
+	if !limitSet && !behaviorSet {
+		return nil, nil
+	}
+	if !limitSet {
+		return nil, fmt.Errorf("--concurrency-behavior requires --concurrency-limit")
+	}
+
+	parsed, err := kestra.NewConcurrencyBehaviorFromValue(strings.ToUpper(behavior))
+	if err != nil {
+		return nil, fmt.Errorf("invalid --concurrency-behavior %q: expected QUEUE, CANCEL or FAIL", behavior)
+	}
+
+	return kestra.NewConcurrency(limit, *parsed), nil
+}
+
+// parseQuotaFlags builds a quota list from repeatable --quota specs of the
+// form "duration=PT1H,limit=100,behavior=FAIL". Returns nil if no spec was
+// provided.
+func parseQuotaFlags(specs []string) ([]kestra.Quota, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+
+	quotas := make([]kestra.Quota, 0, len(specs))
+	for _, spec := range specs {
+		var duration, limitValue, behaviorValue string
+		for _, part := range strings.Split(spec, ",") {
+			key, value, ok := strings.Cut(part, "=")
+			if !ok || key == "" || value == "" {
+				return nil, fmt.Errorf("invalid --quota %q: expected format duration=<ISO-8601>,limit=<n>,behavior=<FAIL|CANCEL>", spec)
+			}
+			switch key {
+			case "duration":
+				duration = value
+			case "limit":
+				limitValue = value
+			case "behavior":
+				behaviorValue = value
+			default:
+				return nil, fmt.Errorf("invalid --quota %q: unknown key %q (expected duration, limit or behavior)", spec, key)
+			}
+		}
+		if duration == "" || limitValue == "" || behaviorValue == "" {
+			return nil, fmt.Errorf("invalid --quota %q: duration, limit and behavior are all required", spec)
+		}
+
+		limit, err := strconv.ParseInt(limitValue, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --quota %q: limit must be an integer", spec)
+		}
+
+		behavior, err := kestra.NewQuotaBehaviorFromValue(strings.ToUpper(behaviorValue))
+		if err != nil {
+			return nil, fmt.Errorf("invalid --quota %q: behavior must be FAIL or CANCEL", spec)
+		}
+
+		quotas = append(quotas, *kestra.NewQuota(duration, limit, *behavior))
+	}
+
+	return quotas, nil
+}

--- a/src/cli/tenants_test.go
+++ b/src/cli/tenants_test.go
@@ -1,0 +1,458 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTenantsCommand_Structure(t *testing.T) {
+	cmd := newTenantsCommand()
+
+	if cmd.Use != "tenants" {
+		t.Fatalf("expected use 'tenants', got '%s'", cmd.Use)
+	}
+
+	expected := map[string]bool{"list": false, "get <tenant_id>": false, "create <tenant_id>": false, "update <tenant_id>": false, "delete <tenant_id>": false}
+	for _, sub := range cmd.Commands() {
+		if _, ok := expected[sub.Use]; ok {
+			expected[sub.Use] = true
+		}
+	}
+	for use, found := range expected {
+		if !found {
+			t.Fatalf("expected '%s' subcommand", use)
+		}
+	}
+}
+
+func TestTenantsListCommand_Help(t *testing.T) {
+	cmd := newTenantsListCommand()
+	output, err := executeCommand(cmd, "--help")
+	if err != nil {
+		t.Fatalf("Execute() returned error: %v", err)
+	}
+	if !strings.Contains(output, "List all tenants") {
+		t.Fatalf("expected help text, got: %s", output)
+	}
+}
+
+func TestTenantsGetCommand_NoArgs(t *testing.T) {
+	cmd := newTenantsGetCommand()
+	_, err := executeCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error when no args provided")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Fatalf("expected args error, got: %v", err)
+	}
+}
+
+func TestTenantsCreateCommand_NoArgs(t *testing.T) {
+	cmd := newTenantsCreateCommand()
+	_, err := executeCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error when no args provided")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Fatalf("expected args error, got: %v", err)
+	}
+}
+
+func TestTenantsUpdateCommand_NoArgs(t *testing.T) {
+	cmd := newTenantsUpdateCommand()
+	_, err := executeCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error when no args provided")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Fatalf("expected args error, got: %v", err)
+	}
+}
+
+func TestTenantsDeleteCommand_NoArgs(t *testing.T) {
+	cmd := newTenantsDeleteCommand()
+	_, err := executeCommand(cmd)
+	if err == nil {
+		t.Fatal("expected error when no args provided")
+	}
+	if !strings.Contains(err.Error(), "accepts 1 arg") {
+		t.Fatalf("expected args error, got: %v", err)
+	}
+}
+
+func TestTenantsGetCommand_ClientError(t *testing.T) {
+	origOutput := globalFlags.Output
+	globalFlags.Output = "table"
+	defer func() { globalFlags.Output = origOutput }()
+
+	original := newClientFunc
+	newClientFunc = func() (*Client, error) {
+		return nil, errors.New("client error")
+	}
+	defer func() { newClientFunc = original }()
+
+	cmd := newTenantsGetCommand()
+	_, err := executeCommand(cmd, "my-tenant")
+	if err == nil {
+		t.Fatal("expected client error")
+	}
+	if !strings.Contains(err.Error(), "client error") {
+		t.Fatalf("expected client error, got: %v", err)
+	}
+}
+
+func TestTenantsCreateCommand_ClientError(t *testing.T) {
+	origOutput := globalFlags.Output
+	globalFlags.Output = "table"
+	defer func() { globalFlags.Output = origOutput }()
+
+	original := newClientFunc
+	newClientFunc = func() (*Client, error) {
+		return nil, errors.New("client error")
+	}
+	defer func() { newClientFunc = original }()
+
+	cmd := newTenantsCreateCommand()
+	_, err := executeCommand(cmd, "my-tenant")
+	if err == nil {
+		t.Fatal("expected client error")
+	}
+	if !strings.Contains(err.Error(), "client error") {
+		t.Fatalf("expected client error, got: %v", err)
+	}
+}
+
+func TestTenantsCreateCommand_InvalidQuota(t *testing.T) {
+	origOutput := globalFlags.Output
+	globalFlags.Output = "table"
+	defer func() { globalFlags.Output = origOutput }()
+
+	cmd := newTenantsCreateCommand()
+	_, err := executeCommand(cmd, "my-tenant", "--quota", "invalid")
+	if err == nil {
+		t.Fatal("expected error for invalid --quota")
+	}
+	if !strings.Contains(err.Error(), "expected format duration=") {
+		t.Fatalf("expected format error, got: %v", err)
+	}
+}
+
+func TestTenantsUpdateCommand_BehaviorWithoutLimit(t *testing.T) {
+	origOutput := globalFlags.Output
+	globalFlags.Output = "table"
+	defer func() { globalFlags.Output = origOutput }()
+
+	cmd := newTenantsUpdateCommand()
+	_, err := executeCommand(cmd, "my-tenant", "--concurrency-behavior", "FAIL")
+	if err == nil {
+		t.Fatal("expected error for --concurrency-behavior without --concurrency-limit")
+	}
+	if !strings.Contains(err.Error(), "--concurrency-behavior requires --concurrency-limit") {
+		t.Fatalf("expected flag dependency error, got: %v", err)
+	}
+}
+
+func TestParseConcurrencyFlags_NoneProvided(t *testing.T) {
+	concurrency, err := parseConcurrencyFlags(0, false, "QUEUE", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if concurrency != nil {
+		t.Fatalf("expected nil concurrency, got: %+v", concurrency)
+	}
+}
+
+func TestParseConcurrencyFlags_LimitOnlyDefaultsToQueue(t *testing.T) {
+	concurrency, err := parseConcurrencyFlags(10, true, "QUEUE", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if concurrency.GetLimit() != 10 || string(concurrency.GetBehavior()) != "QUEUE" {
+		t.Fatalf("unexpected concurrency: %+v", concurrency)
+	}
+}
+
+func TestParseConcurrencyFlags_LowercaseBehavior(t *testing.T) {
+	concurrency, err := parseConcurrencyFlags(5, true, "fail", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(concurrency.GetBehavior()) != "FAIL" {
+		t.Fatalf("unexpected behavior: %s", concurrency.GetBehavior())
+	}
+}
+
+func TestParseConcurrencyFlags_InvalidBehavior(t *testing.T) {
+	_, err := parseConcurrencyFlags(5, true, "EXPLODE", true)
+	if err == nil {
+		t.Fatal("expected error for invalid behavior")
+	}
+	if !strings.Contains(err.Error(), "expected QUEUE, CANCEL or FAIL") {
+		t.Fatalf("expected behavior error, got: %v", err)
+	}
+}
+
+func TestParseQuotaFlags_NoneProvided(t *testing.T) {
+	quotas, err := parseQuotaFlags(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if quotas != nil {
+		t.Fatalf("expected nil quotas, got: %+v", quotas)
+	}
+}
+
+func TestParseQuotaFlags_Multiple(t *testing.T) {
+	quotas, err := parseQuotaFlags([]string{
+		"duration=PT1H,limit=100,behavior=FAIL",
+		"behavior=cancel,duration=P1D,limit=1000",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(quotas) != 2 {
+		t.Fatalf("expected 2 quotas, got: %d", len(quotas))
+	}
+	if quotas[0].Duration != "PT1H" || quotas[0].Limit != 100 || string(quotas[0].Behavior) != "FAIL" {
+		t.Fatalf("unexpected first quota: %+v", quotas[0])
+	}
+	if quotas[1].Duration != "P1D" || quotas[1].Limit != 1000 || string(quotas[1].Behavior) != "CANCEL" {
+		t.Fatalf("unexpected second quota: %+v", quotas[1])
+	}
+}
+
+func TestParseQuotaFlags_MissingKey(t *testing.T) {
+	_, err := parseQuotaFlags([]string{"duration=PT1H,limit=100"})
+	if err == nil {
+		t.Fatal("expected error for missing behavior")
+	}
+	if !strings.Contains(err.Error(), "duration, limit and behavior are all required") {
+		t.Fatalf("expected missing-key error, got: %v", err)
+	}
+}
+
+func TestParseQuotaFlags_UnknownKey(t *testing.T) {
+	_, err := parseQuotaFlags([]string{"duration=PT1H,limit=100,behavior=FAIL,bogus=1"})
+	if err == nil {
+		t.Fatal("expected error for unknown key")
+	}
+	if !strings.Contains(err.Error(), `unknown key "bogus"`) {
+		t.Fatalf("expected unknown-key error, got: %v", err)
+	}
+}
+
+func TestParseQuotaFlags_InvalidLimit(t *testing.T) {
+	_, err := parseQuotaFlags([]string{"duration=PT1H,limit=ten,behavior=FAIL"})
+	if err == nil {
+		t.Fatal("expected error for non-integer limit")
+	}
+	if !strings.Contains(err.Error(), "limit must be an integer") {
+		t.Fatalf("expected limit error, got: %v", err)
+	}
+}
+
+func TestParseQuotaFlags_InvalidBehavior(t *testing.T) {
+	_, err := parseQuotaFlags([]string{"duration=PT1H,limit=100,behavior=QUEUE"})
+	if err == nil {
+		t.Fatal("expected error for invalid quota behavior")
+	}
+	if !strings.Contains(err.Error(), "behavior must be FAIL or CANCEL") {
+		t.Fatalf("expected behavior error, got: %v", err)
+	}
+}
+
+const tenantWithLimitsJSON = `{"id":"my-tenant","name":"My Tenant","deleted":false,"concurrency":{"limit":10,"behavior":"QUEUE"},"quotas":[{"duration":"PT1H","limit":100,"behavior":"FAIL"}]}`
+
+func TestRunTenantsList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/tenants/search") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[` + tenantWithLimitsJSON + `],"total":1}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runTenantsList(newTestClient(t, server.URL), 1, 100, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runTenantsList error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "my-tenant") || !strings.Contains(buf.String(), "Total tenants: 1") {
+		t.Fatalf("unexpected output:\n%s", buf.String())
+	}
+}
+
+func TestRunTenantsGet_RendersConcurrencyAndQuotas(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/tenants/my-tenant") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(tenantWithLimitsJSON))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runTenantsGet(newTestClient(t, server.URL), "my-tenant", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runTenantsGet error: %v", err)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "limit=10 behavior=QUEUE") {
+		t.Fatalf("expected concurrency in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "PT1H") || !strings.Contains(output, "FAIL") {
+		t.Fatalf("expected quota in output, got:\n%s", output)
+	}
+}
+
+func TestRunTenantsCreate_SendsConcurrencyAndQuotas(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/tenants") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(tenantWithLimitsJSON))
+	}))
+	t.Cleanup(server.Close)
+
+	concurrency, err := parseConcurrencyFlags(10, true, "QUEUE", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	quotas, err := parseQuotaFlags([]string{"duration=PT1H,limit=100,behavior=FAIL"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err = runTenantsCreate(newTestClient(t, server.URL), "my-tenant", "", concurrency, quotas, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runTenantsCreate error: %v", err)
+	}
+
+	if gotBody["name"] != "my-tenant" {
+		t.Fatalf("expected name to default to the tenant ID, got: %v", gotBody)
+	}
+	sentConcurrency, ok := gotBody["concurrency"].(map[string]interface{})
+	if !ok || sentConcurrency["limit"] != float64(10) || sentConcurrency["behavior"] != "QUEUE" {
+		t.Fatalf("expected concurrency in request body, got: %v", gotBody)
+	}
+	sentQuotas, ok := gotBody["quotas"].([]interface{})
+	if !ok || len(sentQuotas) != 1 {
+		t.Fatalf("expected quotas in request body, got: %v", gotBody)
+	}
+}
+
+func TestRunTenantsUpdate_PreservesUnsetFields(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(tenantWithLimitsJSON))
+		case http.MethodPut:
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_, _ = w.Write([]byte(tenantWithLimitsJSON))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runTenantsUpdate(newTestClient(t, server.URL), "my-tenant", "Renamed", true, nil, nil, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runTenantsUpdate error: %v", err)
+	}
+
+	if gotBody["name"] != "Renamed" {
+		t.Fatalf("expected name to be updated, got: %v", gotBody)
+	}
+	sentConcurrency, ok := gotBody["concurrency"].(map[string]interface{})
+	if !ok || sentConcurrency["limit"] != float64(10) {
+		t.Fatalf("expected pre-existing concurrency to be preserved, got: %v", gotBody)
+	}
+	sentQuotas, ok := gotBody["quotas"].([]interface{})
+	if !ok || len(sentQuotas) != 1 {
+		t.Fatalf("expected pre-existing quotas to be preserved, got: %v", gotBody)
+	}
+}
+
+func TestRunTenantsUpdate_ReplacesQuotas(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write([]byte(tenantWithLimitsJSON))
+		case http.MethodPut:
+			_ = json.NewDecoder(r.Body).Decode(&gotBody)
+			_, _ = w.Write([]byte(tenantWithLimitsJSON))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	quotas, err := parseQuotaFlags([]string{"duration=P1D,limit=1000,behavior=CANCEL"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err = runTenantsUpdate(newTestClient(t, server.URL), "my-tenant", "", false, nil, quotas, newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runTenantsUpdate error: %v", err)
+	}
+
+	sentQuotas, ok := gotBody["quotas"].([]interface{})
+	if !ok || len(sentQuotas) != 1 {
+		t.Fatalf("expected quotas in request body, got: %v", gotBody)
+	}
+	sentQuota, _ := sentQuotas[0].(map[string]interface{})
+	if sentQuota["duration"] != "P1D" || sentQuota["behavior"] != "CANCEL" {
+		t.Fatalf("expected quotas to be replaced, got: %v", gotBody)
+	}
+}
+
+func TestRunTenantsDelete_SkipConfirm(t *testing.T) {
+	var gotMethod, gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runTenantsDelete(newTestClient(t, server.URL), "my-tenant", true, strings.NewReader(""), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runTenantsDelete error: %v", err)
+	}
+	if gotMethod != http.MethodDelete || !strings.HasSuffix(gotPath, "/tenants/my-tenant") {
+		t.Fatalf("unexpected request: %s %s", gotMethod, gotPath)
+	}
+	if !strings.Contains(buf.String(), "deleted") {
+		t.Fatalf("unexpected output:\n%s", buf.String())
+	}
+}
+
+func TestRunTenantsDelete_Cancelled(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("no request expected when the deletion is cancelled")
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runTenantsDelete(newTestClient(t, server.URL), "my-tenant", false, strings.NewReader("n\n"), newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runTenantsDelete error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Cancelled") {
+		t.Fatalf("expected cancellation output, got:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
Adds tenant management to kestractl, plus concurrency-limit and execution-quota configuration on both tenants and namespaces.

## What's new

| Command | Route | Notes |
|---|---|---|
| `tenants list` | `GET /api/v1/tenants/search` | paged, `--sort` |
| `tenants get <id>` | `GET /api/v1/tenants/{id}` | renders concurrency + quotas |
| `tenants create <id>` | `POST /api/v1/tenants` | `--name`, `--concurrency-limit`, `--concurrency-behavior`, `--quota` |
| `tenants update <id>` | `GET` + `PUT /api/v1/tenants/{id}` | read-modify-write: unspecified fields keep their value; `--quota` replaces the quota list |
| `tenants delete <id>` | `DELETE /api/v1/tenants/{id}` | confirmation prompt, `--yes` |
| `namespaces create/update` | existing routes | same `--concurrency-limit`/`--concurrency-behavior`/`--quota` flags; `get`, `create` and `update` all render them |

Flag encoding: `--concurrency-limit 10 --concurrency-behavior QUEUE|CANCEL|FAIL` (behavior defaults to `QUEUE`), and repeatable `--quota duration=PT1H,limit=100,behavior=FAIL|CANCEL`.

The `tenants` group uses the SDK's hand-written `KestraClient` (`Tenants()` accessor), which the CLI's `Client` already builds alongside the generated client from the same host/auth config.

## Dependency pin (first commit)

`go.mod` bumps `go-sdk/v2` from the `v2.0.0-rc2` tag to a pseudo-version of client-sdk `main` (`bde3ef818`), which carries `TenantsAPI`, `QuotasAPI` and the namespace concurrency/quotas fields — none of which are in the rc2 tag. Re-pin to the next tagged v2 release once one is cut.

One test adjusted with the bump: on this SDK the #83 array-labels fixture fails strict decode because the required `draft` property is absent (as it is on pre-2.0 servers), which keeps the `tryParseFlow*` fallbacks exercised.

## Verification

**Unit tests**: `go build ./... && go vet ./... && go test ./...` — all green, no pre-existing failures. The namespace create/update output assertions were verified to fail when the rendering is neutered.

**Live run** against Kestra EE `v2.0.0-rc12` (basic auth, instance owner):

```console
$ kestractl tenants create ctl-verify --name CtlVerify --concurrency-limit 5 --concurrency-behavior QUEUE --quota duration=PT1H,limit=100,behavior=FAIL -o json
{ "id": "ctl-verify", "name": "CtlVerify", "concurrency": { "limit": 5, "behavior": "QUEUE" },
  "quotas": [ { "duration": "PT1H", "limit": 100, "behavior": "FAIL" } ], "deleted": false }

$ kestractl tenants update ctl-verify --concurrency-limit 20 --concurrency-behavior FAIL \
    --quota duration=PT2H,limit=50,behavior=CANCEL --quota duration=P1D,limit=1000,behavior=FAIL -o json
# name preserved; quota list replaced (P1D normalized to PT24H server-side); raw API GET agrees byte-for-byte

$ kestractl tenants list
ID          NAME       CONCURRENCY LIMIT  QUOTAS
main        main                          0
ctl-verify  CtlVerify  20 (FAIL)          2

$ kestractl namespaces create io.ctl.verify --concurrency-limit 3 --concurrency-behavior CANCEL --quota duration=PT1H,limit=10,behavior=FAIL
$ kestractl namespaces update io.ctl.verify --description "updated desc"
# description-only update preserves concurrency and quotas (GET-then-PUT merge), and echoes them:
ID           io.ctl.verify
DESCRIPTION  updated desc
CONCURRENCY  limit=3 behavior=CANCEL

QUOTAS:
  DURATION  LIMIT  BEHAVIOR
  PT1H      10     FAIL
```

Validation is client-side and fails before any API call: unknown behaviors, malformed `--quota` specs, and `--concurrency-behavior` without `--concurrency-limit` are all rejected with actionable errors.

## Out of scope

~11 execution commands (pause/resume/restart/replay/kill, ...) still call legacy v1 routes that 404 against Kestra 2.0. They compile fine against the v2 SDK's legacy surface and are untouched here; fixing them is a separate follow-up.
