### PR TITLE
chore(deps): pin go-sdk to the v2.0.0-rc3 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1
-	github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2.0.20260901074051-bde3ef8187d2
+	github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2.0.20260901074051-bde3ef8187d2 h1:Xg4T6b8rHGB0SdSwWdKtZDVYhQdfUjYORb5mpEpDwlQ=
-github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2.0.20260901074051-bde3ef8187d2/go.mod h1:ckpZC/7pTYvb7B2iLxY90UGKu374oBvDsGXJ8bWtlwk=
+github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3 h1:wWymwgqpnDlwpWurxmSUFbpMOh8wVhK9qQx+fU7xqSM=
+github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3/go.mod h1:ckpZC/7pTYvb7B2iLxY90UGKu374oBvDsGXJ8bWtlwk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=


### PR DESCRIPTION
Swaps the temporary pseudo-version pin for the published `go-sdk/v2.0.0-rc3` tag.

#109 had to pin a pseudo-version of client-sdk `main` (`bde3ef818`) because `TenantsAPI` and `QuotasAPI` had no tagged release yet. rc3 now carries them, and `bde3ef818` is an ancestor of the tag with an identical tree, so this is a reference change only — no code moves.

## Is anything needed for rc2 → rc3?

No. The diff is **purely additive**: 456 insertions, zero deletions, no signature changes. New surface is `TenantsAPI`, `QuotasAPI`, `TenantAccessAPI`, `CasesAPI`, the `Cases()`/`TenantAccess()`/`Quotas()`/`Tenants()` accessors, plus `StreamAppEvents` and `ReplayExecutionWithInputs`. Nothing kestractl already calls changed shape.

## Verification

`go build ./... && go vet ./... && go test ./...` — all green. Diff is `go.mod` + `go.sum` only.
