### PR TITLE
feat(cli): flows usage-report command for v2 migration planning

### DIFF
--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -56,6 +56,7 @@ func newFlowsCommand() *cobra.Command {
 	cmd.AddCommand(newFlowsEnableCommand())
 	cmd.AddCommand(newFlowsDisableCommand())
 	cmd.AddCommand(newFlowsExportCommand())
+	cmd.AddCommand(newFlowsUsageReportCommand())
 	cmd.AddCommand(newFlowsImportCommand())
 	cmd.AddCommand(newFlowsDeleteCommand())
 	cmd.AddCommand(newFlowsSearchCommand())
@@ -550,12 +551,18 @@ func runFlowsList(client *Client, namespace string, renderer *Renderer) error {
 }
 
 func listAllFlows(client *Client) ([]parsedFlow, error) {
+	return listAllFlowsForTenant(client, client.Tenant)
+}
+
+// listAllFlowsForTenant pages through every flow of the given tenant. Commands
+// that scan more than the configured tenant call it directly.
+func listAllFlowsForTenant(client *Client, tenant string) ([]parsedFlow, error) {
 	const pageSize int32 = 1000
 	page := int32(1)
 	results := make([]parsedFlow, 0)
 
 	for {
-		resp, _, err := client.API.FlowsAPI.SearchFlows(client.Ctx, client.Tenant).
+		resp, _, err := client.API.FlowsAPI.SearchFlows(client.Ctx, tenant).
 			Page(page).
 			Size(pageSize).
 			Execute()

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -62,6 +62,9 @@ type usageTotals struct {
 	PebbleFunctionCount        map[string]int64 `json:"pebble_function_count"`
 	PebbleFunctionFlowCount    map[string]int64 `json:"pebble_function_flow_count"`
 	PebbleUnknownFunctionCount int64            `json:"pebble_unknown_function_count"`
+	PebbleFilterCount          map[string]int64 `json:"pebble_filter_count"`
+	PebbleFilterFlowCount      map[string]int64 `json:"pebble_filter_flow_count"`
+	PebbleUnknownFilterCount   int64            `json:"pebble_unknown_filter_count"`
 	SubflowTaskCount           int64            `json:"subflow_task_count"`
 	FlowsUsingSubflow          int              `json:"flows_using_subflow"`
 }
@@ -189,6 +192,8 @@ type flowAnalysis struct {
 	// else a flow calls is counted anonymously in PebbleUnknownFunctions.
 	PebbleFunctions        map[string]int64
 	PebbleUnknownFunctions int64
+	PebbleFilters          map[string]int64
+	PebbleUnknownFilters   int64
 }
 
 // taskContainerKeys are the flow-level keys walked in task context. inputs,
@@ -229,6 +234,25 @@ var pebbleFunctionNames = []string{
 	"dayOfWeek", "dayOfMonth", "monthOfYear", "hourOfDay",
 }
 
+// pebbleFilterNames is the filter reference of the Kestra docs. Filters are
+// allowlisted separately from functions: they are invoked in a different
+// position and a name can legitimately exist in both sets (yaml, toJson).
+var pebbleFilterNames = []string{
+	"toJson", "toIon", "jq", "abs", "number", "className", "numberFormat",
+	"first", "last", "length", "join", "split", "sort", "rsort", "reverse", "chunk", "distinct",
+	"slice", "merge", "flatten", "keys", "values",
+	"lower", "upper", "title", "capitalize", "trim", "abbreviate", "replace",
+	"substringBefore", "substringAfter", "substringBeforeLast", "substringAfterLast", "slugify",
+	"default", "startsWith", "endsWith",
+	"base64encode", "base64decode", "urlencode", "urldecode", "sha1", "sha512", "md5",
+	"string", "escapeChar",
+	"date", "dateAdd", "timestamp", "timestampMilli", "timestampMicro", "timestampNano",
+	"yaml", "indent", "nindent",
+}
+
+// pebbleFilters indexes the filter allowlist by lowercase name.
+var pebbleFilters = newPebbleFunctionIndex(pebbleFilterNames)
+
 // pebbleFunctions indexes the allowlist by lowercase name — Pebble resolves
 // function names case-insensitively.
 var pebbleFunctions = newPebbleFunctionIndex(pebbleFunctionNames)
@@ -252,6 +276,10 @@ var pebbleExpressionPatterns = []*regexp.Regexp{
 // and consuming the boundary would hide the inner call of render(kv('K')).
 var pebbleCallPattern = regexp.MustCompile(`([A-Za-z_]\w*)\s*\(`)
 
+// pebbleBareFilterPattern catches the filters used without arguments, such as
+// `| upper` or `| trim`, which the call pattern cannot see.
+var pebbleBareFilterPattern = regexp.MustCompile(`\|\s*([A-Za-z_]\w*)`)
+
 // collectPebbleFunctions counts the function calls of every expression block in
 // the raw source. Like the `json(` heuristic it works on text, so it still
 // reports something for a flow whose YAML does not parse.
@@ -264,6 +292,10 @@ func (a *flowAnalysis) collectPebbleFunctions(raw string) {
 }
 
 func (a *flowAnalysis) countPebbleCalls(block string) {
+	// Identifier offsets already counted, so a filter written with arguments
+	// is not counted twice by the bare-filter scan below.
+	counted := map[int]bool{}
+
 	for _, match := range pebbleCallPattern.FindAllStringSubmatchIndex(block, -1) {
 		start, end := match[2], match[3]
 		if start > 0 {
@@ -274,14 +306,51 @@ func (a *flowAnalysis) countPebbleCalls(block string) {
 			}
 		}
 
-		if canonical, ok := pebbleFunctions[strings.ToLower(block[start:end])]; ok {
-			a.PebbleFunctions[canonical]++
+		counted[start] = true
+		if isFilterPosition(block, start) {
+			a.recordPebbleName(block[start:end], pebbleFilters, &a.PebbleFilters, &a.PebbleUnknownFilters)
+		} else {
+			a.recordPebbleName(block[start:end], pebbleFunctions, &a.PebbleFunctions, &a.PebbleUnknownFunctions)
+		}
+	}
+
+	for _, match := range pebbleBareFilterPattern.FindAllStringSubmatchIndex(block, -1) {
+		pipe, start, end := match[0], match[2], match[3]
+		if counted[start] {
 			continue
 		}
-		// An unrecognized identifier is never recorded by name: it may be a
-		// customer macro, and the report must stay shareable.
-		a.PebbleUnknownFunctions++
+		// `a || b` is a boolean or, not a filter.
+		if pipe > 0 && block[pipe-1] == '|' {
+			continue
+		}
+		a.recordPebbleName(block[start:end], pebbleFilters, &a.PebbleFilters, &a.PebbleUnknownFilters)
 	}
+}
+
+// isFilterPosition reports whether the identifier at start is applied as a
+// filter, i.e. the first non-space character before it is a single `|`.
+func isFilterPosition(block string, start int) bool {
+	index := start - 1
+	for index >= 0 && (block[index] == ' ' || block[index] == '\t' || block[index] == '\n' || block[index] == '\r') {
+		index--
+	}
+	if index < 0 || block[index] != '|' {
+		return false
+	}
+	// `a || b(x)` is a boolean or followed by a plain call.
+	return index == 0 || block[index-1] != '|'
+}
+
+// recordPebbleName counts one name against its allowlist, falling back to the
+// anonymous bucket. An unrecognized name is never stored: it may be a customer
+// macro, a custom filter, or another templating engine entirely (dbt's
+// `{{ ref('...') }}` inside a SQL string, for one).
+func (a *flowAnalysis) recordPebbleName(name string, allowlist map[string]string, known *map[string]int64, unknown *int64) {
+	if canonical, ok := allowlist[strings.ToLower(name)]; ok {
+		(*known)[canonical]++
+		return
+	}
+	*unknown++
 }
 
 func isWordByte(char byte) bool {
@@ -301,6 +370,7 @@ func analyzeFlowSource(raw string) (flowAnalysis, error) {
 		PluginDefaultsTypes: map[string]int64{},
 		RemovedTasks:        map[string]int64{},
 		PebbleFunctions:     map[string]int64{},
+		PebbleFilters:       map[string]int64{},
 	}
 
 	// Raw-text signals first: they must survive a YAML parse failure.
@@ -723,6 +793,13 @@ func aggregateReport(scans []tenantScan, anon *anonymizer, generatedAt time.Time
 				}
 			}
 			tenant.Totals.PebbleUnknownFunctionCount += flow.PebbleUnknownFunctions
+			for name, occurrences := range flow.PebbleFilters {
+				tenant.Totals.PebbleFilterCount[name] += occurrences
+				if ref != "" {
+					tenant.Totals.PebbleFilterFlowCount[name]++
+				}
+			}
+			tenant.Totals.PebbleUnknownFilterCount += flow.PebbleUnknownFilters
 
 			triggerConditions.add(flow.TriggerConditions, ref)
 			conditionProperty.add(flow.ConditionProperty, ref)
@@ -818,6 +895,8 @@ func newUsageTotals() usageTotals {
 		PluginFamilyCount:       map[string]int64{},
 		PebbleFunctionCount:     map[string]int64{},
 		PebbleFunctionFlowCount: map[string]int64{},
+		PebbleFilterCount:       map[string]int64{},
+		PebbleFilterFlowCount:   map[string]int64{},
 	}
 }
 
@@ -839,6 +918,9 @@ func mergeTotals(into *usageTotals, from usageTotals) {
 	mergeCounts(into.PebbleFunctionCount, from.PebbleFunctionCount)
 	mergeCounts(into.PebbleFunctionFlowCount, from.PebbleFunctionFlowCount)
 	into.PebbleUnknownFunctionCount += from.PebbleUnknownFunctionCount
+	mergeCounts(into.PebbleFilterCount, from.PebbleFilterCount)
+	mergeCounts(into.PebbleFilterFlowCount, from.PebbleFilterFlowCount)
+	into.PebbleUnknownFilterCount += from.PebbleUnknownFilterCount
 }
 
 func mergeCounts(into, from map[string]int64) {
@@ -1129,24 +1211,34 @@ func renderCountTable(out *markdownWriter, level, title, column string, counts, 
 	table.render(out)
 }
 
-// renderPebbleFunctionsSection lists the Pebble functions the flows call.
-// Calls that are not part of the documented function set are reported as a
-// single count, never by name.
+// renderPebbleFunctionsSection lists the Pebble functions and filters the
+// flows use. Names outside the documented sets are reported as a single count,
+// never by name.
 func renderPebbleFunctionsSection(out *markdownWriter, report *usageReport) {
 	totals := report.Totals
 
-	out.printf("## Pebble functions\n\n")
-	if len(totals.PebbleFunctionCount) == 0 && totals.PebbleUnknownFunctionCount == 0 {
+	out.printf("## Pebble functions and filters\n\n")
+	renderPebbleUsageTable(out, "Functions", "Function", totals.PebbleFunctionCount,
+		totals.PebbleFunctionFlowCount, totals.PebbleUnknownFunctionCount, "(unrecognized function-like calls)")
+	renderPebbleUsageTable(out, "Filters", "Filter", totals.PebbleFilterCount,
+		totals.PebbleFilterFlowCount, totals.PebbleUnknownFilterCount, "(unrecognized filters)")
+}
+
+// renderPebbleUsageTable renders one "name → uses / flows" table plus the
+// anonymous bucket, when it is not empty.
+func renderPebbleUsageTable(out *markdownWriter, title, column string, counts, flowCounts map[string]int64, unknown int64, unknownLabel string) {
+	out.printf("### %s\n\n", title)
+	if len(counts) == 0 && unknown == 0 {
 		out.printf("None found.\n\n")
 		return
 	}
 
-	table := newMarkdownTable([]string{"Function", "Uses", "Flows"}, []bool{false, true, true})
-	for _, entry := range sortedCounts(totals.PebbleFunctionCount) {
-		table.row(code(entry.Name), count(entry.Count), count(totals.PebbleFunctionFlowCount[entry.Name]))
+	table := newMarkdownTable([]string{column, "Uses", "Flows"}, []bool{false, true, true})
+	for _, entry := range sortedCounts(counts) {
+		table.row(code(entry.Name), count(entry.Count), count(flowCounts[entry.Name]))
 	}
-	if totals.PebbleUnknownFunctionCount > 0 {
-		table.row("(unrecognized function-like calls)", count(totals.PebbleUnknownFunctionCount), "-")
+	if unknown > 0 {
+		table.row(unknownLabel, count(unknown), "-")
 	}
 	table.render(out)
 }
@@ -1161,7 +1253,7 @@ func renderNotesSection(out *markdownWriter, report *usageReport) {
 	}
 	out.printf("- Namespace-level plugin defaults are stored outside flow sources and are not covered by this report.\n")
 	out.printf("- The Pebble `json()` count is a text heuristic over the flow source.\n")
-	out.printf("- Pebble functions are extracted from the `{{ }}` and `{%% %%}` expression blocks of the sources, also a text heuristic; calls that are not documented Kestra functions are counted without their names.\n")
+	out.printf("- Pebble functions and filters are extracted from the `{{ }}` and `{%% %%}` expression blocks of the sources, also a text heuristic: a name after a `|` is read as a filter, anything else as a function. Names outside the documented Kestra sets — a custom macro, or another templating engine embedded in a property — are counted without their names.\n")
 	// The next section follows straight after: markdown needs the blank line.
 	out.printf("\n")
 }

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -282,10 +282,22 @@ var pebbleExpressionPatterns = []*regexp.Regexp{
 	regexp.MustCompile(`(?s)\{%(.*?)%\}`),
 }
 
-// pebbleCallPattern matches an identifier used as a function call. The
-// preceding character is checked separately: Go's regexp has no lookbehind,
-// and consuming the boundary would hide the inner call of render(kv('K')).
-var pebbleCallPattern = regexp.MustCompile(`([A-Za-z_]\w*)\s*\(`)
+// pebbleCallPattern matches an identifier used as a function call. The `(`
+// must follow the name immediately: expressions are written `now()` and
+// `secret('X')`, while prose inside a block ("the managed fields (see docs)")
+// would otherwise match. The preceding character is checked separately, since
+// Go's regexp has no lookbehind and consuming the boundary would hide the
+// inner call of render(kv('K')).
+var pebbleCallPattern = regexp.MustCompile(`([A-Za-z_]\w*)\(`)
+
+// pebbleKeywords are the Pebble language keywords. They are never a function
+// or a filter, whatever punctuation follows them.
+var pebbleKeywords = map[string]bool{
+	"if": true, "elseif": true, "else": true, "endif": true,
+	"for": true, "endfor": true,
+	"and": true, "or": true, "not": true, "is": true, "in": true,
+	"true": true, "false": true, "null": true,
+}
 
 // pebbleBareFilterPattern catches the filters used without arguments, such as
 // `| upper` or `| trim`, which the call pattern cannot see.
@@ -297,9 +309,44 @@ var pebbleBareFilterPattern = regexp.MustCompile(`\|\s*([A-Za-z_]\w*)`)
 func (a *flowAnalysis) collectPebbleFunctions(raw string) {
 	for _, pattern := range pebbleExpressionPatterns {
 		for _, block := range pattern.FindAllStringSubmatch(raw, -1) {
-			a.countPebbleCalls(block[1])
+			a.countPebbleCalls(stripQuotedLiterals(block[1]))
 		}
 	}
+}
+
+// stripQuotedLiterals blanks out the quoted string arguments of an expression
+// before it is scanned. A jq program such as `jq('.[] | select(.a)')` is not
+// Pebble, and reading it as Pebble invented filters and functions that do not
+// exist. It also keeps the scanner away from the one place customer data
+// actually lives inside an expression. Each literal becomes a single space so
+// the surrounding boundaries stay intact; an unterminated quote swallows the
+// rest of the block.
+func stripQuotedLiterals(block string) string {
+	var stripped strings.Builder
+	stripped.Grow(len(block))
+
+	for index := 0; index < len(block); {
+		quote := block[index]
+		if quote != '\'' && quote != '"' {
+			stripped.WriteByte(quote)
+			index++
+			continue
+		}
+
+		stripped.WriteByte(' ')
+		for index++; index < len(block); index++ {
+			if block[index] == '\\' {
+				index++
+				continue
+			}
+			if block[index] == quote {
+				index++
+				break
+			}
+		}
+	}
+
+	return stripped.String()
 }
 
 func (a *flowAnalysis) countPebbleCalls(block string) {
@@ -318,6 +365,9 @@ func (a *flowAnalysis) countPebbleCalls(block string) {
 		}
 
 		counted[start] = true
+		if pebbleKeywords[strings.ToLower(block[start:end])] {
+			continue
+		}
 		if isFilterPosition(block, start) {
 			a.recordPebbleName(block[start:end], pebbleFilters, &a.PebbleFilters, &a.PebbleUnknownFilters)
 		} else {
@@ -332,6 +382,9 @@ func (a *flowAnalysis) countPebbleCalls(block string) {
 		}
 		// `a || b` is a boolean or, not a filter.
 		if pipe > 0 && block[pipe-1] == '|' {
+			continue
+		}
+		if pebbleKeywords[strings.ToLower(block[start:end])] {
 			continue
 		}
 		a.recordPebbleName(block[start:end], pebbleFilters, &a.PebbleFilters, &a.PebbleUnknownFilters)

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -9,8 +9,10 @@ import (
 	"io"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"gopkg.in/yaml.v3"
 )
@@ -824,33 +826,35 @@ func renderSignalsSection(out *markdownWriter, report *usageReport) {
 	signals := report.Signals
 
 	out.printf("## Migration signals\n\n")
-	out.printf("| Signal | Occurrences | Flows | Kestra 2.0 impact |\n")
-	out.printf("| --- | ---: | ---: | --- |\n")
-	out.printf("| pluginDefaults | %d | %d | Removed in 2.0 — move defaults into each task |\n",
-		signals.PluginDefaults.Entries, signals.PluginDefaults.Flows)
+	table := newMarkdownTable(
+		[]string{"Signal", "Occurrences", "Flows", "Kestra 2.0 impact"},
+		[]bool{false, true, true, false},
+	)
+	table.row("pluginDefaults", count(signals.PluginDefaults.Entries), count(signals.PluginDefaults.Flows),
+		"Removed in 2.0 — move defaults into each task")
 	for _, class := range removedTaskClasses {
 		signal := signals.RemovedTasks[class]
-		out.printf("| Task %s | %d | %d | Removed or reworked in 2.0 |\n", class, signal.Occurrences, signal.Flows)
+		table.row("Task "+class, count(signal.Occurrences), count(signal.Flows), "Removed or reworked in 2.0")
 	}
-	out.printf("| Trigger conditions/preconditions | %d | %d | Replaced by `when` |\n",
-		signals.TriggerConditions.Occurrences, signals.TriggerConditions.Flows)
-	out.printf("| `condition` property | %d | %d | Replaced by `when` |\n",
-		signals.ConditionProperty.Occurrences, signals.ConditionProperty.Flows)
-	out.printf("| Pebble `json()` | %d | %d | Removed — use `fromJson()`/`toJson()` (text heuristic) |\n",
-		signals.PebbleJsonFunction.Occurrences, signals.PebbleJsonFunction.Flows)
-	out.printf("| `fs.local.Delete` | %d | %d | `recursive` default changed in 2.0 |\n",
-		signals.FsLocalDelete.Occurrences, signals.FsLocalDelete.Flows)
+	table.row("Trigger conditions/preconditions", count(signals.TriggerConditions.Occurrences),
+		count(signals.TriggerConditions.Flows), "Replaced by `when`")
+	table.row("`condition` property", count(signals.ConditionProperty.Occurrences),
+		count(signals.ConditionProperty.Flows), "Replaced by `when`")
+	table.row("Pebble `json()`", count(signals.PebbleJsonFunction.Occurrences),
+		count(signals.PebbleJsonFunction.Flows), "Removed — use `fromJson()`/`toJson()` (text heuristic)")
+	table.row("`fs.local.Delete`", count(signals.FsLocalDelete.Occurrences),
+		count(signals.FsLocalDelete.Flows), "`recursive` default changed in 2.0")
 	if signals.ServerDeprecationsAvailable {
 		deprecatedTasks := int64(0)
 		for _, dep := range signals.ServerDeprecations {
 			deprecatedTasks += int64(dep.DeprecatedTasks)
 		}
-		out.printf("| Server-reported deprecations | %d | %d | Reported by the Kestra instance itself |\n",
-			deprecatedTasks, len(signals.ServerDeprecations))
+		table.row("Server-reported deprecations", count(deprecatedTasks), count(len(signals.ServerDeprecations)),
+			"Reported by the Kestra instance itself")
 	} else {
-		out.printf("| Server-reported deprecations | n/a | n/a | The deprecation endpoint could not be read |\n")
+		table.row("Server-reported deprecations", "n/a", "n/a", "The deprecation endpoint could not be read")
 	}
-	out.printf("\n")
+	table.render(out)
 }
 
 func renderPluginDefaultsSection(out *markdownWriter, report *usageReport) {
@@ -864,11 +868,11 @@ func renderPluginDefaultsSection(out *markdownWriter, report *usageReport) {
 		return
 	}
 
-	out.printf("| Default type | Entries |\n| --- | ---: |\n")
+	table := newMarkdownTable([]string{"Default type", "Entries"}, []bool{false, true})
 	for _, entry := range sortedCounts(defaults.TypeCount) {
-		out.printf("| `%s` | %d |\n", entry.Name, entry.Count)
+		table.row(code(entry.Name), count(entry.Count))
 	}
-	out.printf("\n")
+	table.render(out)
 }
 
 // renderDeprecatedTaskTypesSection lists the deprecations the instance itself
@@ -885,15 +889,15 @@ func renderDeprecatedTaskTypesSection(out *markdownWriter, report *usageReport) 
 		return
 	}
 
-	out.printf("| Task type | Replacement | Count |\n| --- | --- | ---: |\n")
+	table := newMarkdownTable([]string{"Task type", "Replacement", "Count"}, []bool{false, false, true})
 	for _, entry := range report.Signals.DeprecatedTaskTypes {
 		replacement := "-"
 		if entry.Replacement != "" {
-			replacement = "`" + entry.Replacement + "`"
+			replacement = code(entry.Replacement)
 		}
-		out.printf("| `%s` | %s | %d |\n", entry.TaskType, replacement, entry.Count)
+		table.row(code(entry.TaskType), replacement, count(entry.Count))
 	}
-	out.printf("\n")
+	table.render(out)
 }
 
 func renderAffectedFlowsSection(out *markdownWriter, report *usageReport, detailed bool) {
@@ -947,27 +951,30 @@ func renderInventorySection(out *markdownWriter, report *usageReport, detailed b
 	totals := report.Totals
 
 	out.printf("## Inventory\n\n")
-	out.printf("| Metric | Value |\n| --- | ---: |\n")
-	out.printf("| Tenants scanned | %d |\n", totals.TenantsScanned)
-	out.printf("| Flows | %d |\n", totals.Count)
-	out.printf("| Namespaces | %d |\n", totals.NamespacesCount)
-	out.printf("| Disabled flows | %d |\n", totals.DisabledFlows)
-	out.printf("| Flows with inputs | %d |\n", totals.FlowsWithInputs)
-	out.printf("| Flows with triggers | %d |\n", totals.FlowsWithTriggers)
-	out.printf("| Subflow tasks | %d |\n", totals.SubflowTaskCount)
-	out.printf("| Flows calling a subflow | %d |\n", totals.FlowsUsingSubflow)
-	out.printf("\n")
+	overview := newMarkdownTable([]string{"Metric", "Value"}, []bool{false, true})
+	overview.row("Tenants scanned", count(totals.TenantsScanned))
+	overview.row("Flows", count(totals.Count))
+	overview.row("Namespaces", count(totals.NamespacesCount))
+	overview.row("Disabled flows", count(totals.DisabledFlows))
+	overview.row("Flows with inputs", count(totals.FlowsWithInputs))
+	overview.row("Flows with triggers", count(totals.FlowsWithTriggers))
+	overview.row("Subflow tasks", count(totals.SubflowTaskCount))
+	overview.row("Flows calling a subflow", count(totals.FlowsUsingSubflow))
+	overview.render(out)
 
 	if detailed {
 		out.printf("### Flows per namespace\n\n")
-		out.printf("| Tenant | Namespace | Flows | Disabled | With triggers |\n| --- | --- | ---: | ---: | ---: |\n")
+		table := newMarkdownTable(
+			[]string{"Tenant", "Namespace", "Flows", "Disabled", "With triggers"},
+			[]bool{false, false, true, true, true},
+		)
 		for _, tenant := range report.Tenants {
 			for _, ns := range tenant.Namespaces {
-				out.printf("| `%s` | `%s` | %d | %d | %d |\n",
-					tenant.Tenant, ns.Namespace, ns.FlowCount, ns.DisabledFlows, ns.FlowsWithTriggers)
+				table.row(code(tenant.Tenant), code(ns.Namespace), count(ns.FlowCount),
+					count(ns.DisabledFlows), count(ns.FlowsWithTriggers))
 			}
 		}
-		out.printf("\n")
+		table.render(out)
 	}
 }
 
@@ -987,11 +994,11 @@ func renderPluginFamiliesSection(out *markdownWriter, report *usageReport) {
 		return
 	}
 
-	out.printf("| Plugin family | Uses |\n| --- | ---: |\n")
+	table := newMarkdownTable([]string{"Plugin family", "Uses"}, []bool{false, true})
 	for _, entry := range sortedCounts(families) {
-		out.printf("| `%s` | %d |\n", entry.Name, entry.Count)
+		table.row(code(entry.Name), count(entry.Count))
 	}
-	out.printf("\n")
+	table.render(out)
 }
 
 // renderTaskTypesSection closes the report with the task-type inventory. It
@@ -1010,11 +1017,11 @@ func renderCountTable(out *markdownWriter, level, title, column string, counts, 
 		return
 	}
 
-	out.printf("| %s | Uses | Flows |\n| --- | ---: | ---: |\n", column)
+	table := newMarkdownTable([]string{column, "Uses", "Flows"}, []bool{false, true, true})
 	for _, entry := range sortedCounts(counts) {
-		out.printf("| `%s` | %d | %d |\n", entry.Name, entry.Count, flowCounts[entry.Name])
+		table.row(code(entry.Name), count(entry.Count), count(flowCounts[entry.Name]))
 	}
-	out.printf("\n")
+	table.render(out)
 }
 
 func renderNotesSection(out *markdownWriter, report *usageReport) {
@@ -1027,6 +1034,101 @@ func renderNotesSection(out *markdownWriter, report *usageReport) {
 	}
 	out.printf("- Namespace-level plugin defaults are stored outside flow sources and are not covered by this report.\n")
 	out.printf("- The Pebble `json()` count is a text heuristic over the flow source.\n")
+}
+
+// markdownTable builds a column-aligned pipe table. The padding is
+// insignificant whitespace in GitHub-flavoured markdown, so the rendered table
+// is unchanged while the raw report stays readable in a terminal.
+type markdownTable struct {
+	header []string
+	right  []bool
+	rows   [][]string
+}
+
+// newMarkdownTable starts a table; right marks the columns to right-align,
+// which is where the counts go.
+func newMarkdownTable(header []string, right []bool) *markdownTable {
+	return &markdownTable{header: header, right: right}
+}
+
+func (t *markdownTable) row(cells ...string) {
+	t.rows = append(t.rows, cells)
+}
+
+// render writes the table with every column padded to its widest cell.
+func (t *markdownTable) render(out *markdownWriter) {
+	widths := make([]int, len(t.header))
+	for i, cell := range t.header {
+		widths[i] = cellWidth(cell)
+	}
+	for _, row := range t.rows {
+		for i, cell := range row {
+			if i < len(widths) && cellWidth(cell) > widths[i] {
+				widths[i] = cellWidth(cell)
+			}
+		}
+	}
+	// A separator needs three dashes at least, plus room for the colon that
+	// carries the alignment.
+	for i := range widths {
+		minimum := 3
+		if t.right[i] {
+			minimum = 4
+		}
+		if widths[i] < minimum {
+			widths[i] = minimum
+		}
+	}
+
+	separators := make([]string, len(widths))
+	for i, width := range widths {
+		if t.right[i] {
+			separators[i] = strings.Repeat("-", width-1) + ":"
+		} else {
+			separators[i] = strings.Repeat("-", width)
+		}
+	}
+
+	out.printf("%s\n", t.line(t.header, widths))
+	out.printf("| %s |\n", strings.Join(separators, " | "))
+	for _, row := range t.rows {
+		out.printf("%s\n", t.line(row, widths))
+	}
+	out.printf("\n")
+}
+
+// line pads one row of cells to the given column widths.
+func (t *markdownTable) line(cells []string, widths []int) string {
+	padded := make([]string, len(widths))
+	for i, width := range widths {
+		cell := ""
+		if i < len(cells) {
+			cell = cells[i]
+		}
+		padding := strings.Repeat(" ", width-cellWidth(cell))
+		if t.right[i] {
+			padded[i] = padding + cell
+		} else {
+			padded[i] = cell + padding
+		}
+	}
+	return "| " + strings.Join(padded, " | ") + " |"
+}
+
+// cellWidth counts the visible characters of a cell; the report has no ANSI
+// escapes, which would break markdown validity.
+func cellWidth(cell string) int {
+	return utf8.RuneCountInString(cell)
+}
+
+// code wraps a value in markdown backticks.
+func code(value string) string {
+	return "`" + value + "`"
+}
+
+// count renders a counter as a table cell.
+func count[T int | int64](value T) string {
+	return strconv.FormatInt(int64(value), 10)
 }
 
 // markdownWriter accumulates the first write error so the renderer does not

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -1,0 +1,1060 @@
+package cli
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// This file holds the pure analysis core of `flows usage-report`: report
+// structs, the flow-source walker, the anonymizer, aggregation and markdown
+// rendering. It deliberately depends on no SDK request type so that it can be
+// ported to the v2 branch unchanged.
+
+// maxFlowRefs caps how many flow references a single signal lists. A migration
+// planner needs a representative sample, not an exhaustive dump.
+const maxFlowRefs = 50
+
+// maxWalkDepth bounds the recursive walk of a flow source. Real flows nest a
+// handful of levels; the bound only guards against pathological input.
+const maxWalkDepth = 64
+
+// usageReport is the serialized report. Field names mirror the SDK's FlowUsage
+// shape where they overlap; JSON tags are snake_case.
+type usageReport struct {
+	GeneratedAt      string           `json:"generated_at"`
+	KestractlVersion string           `json:"kestractl_version"`
+	Anonymized       bool             `json:"anonymized"`
+	Scope            string           `json:"scope"`
+	Totals           usageTotals      `json:"totals"`
+	Signals          migrationSignals `json:"signals"`
+	Tenants          []tenantReport   `json:"tenants"`
+	Notes            []string         `json:"notes,omitempty"`
+}
+
+// usageTotals is the flow inventory, aggregated across every scanned tenant.
+type usageTotals struct {
+	TenantsScanned       int              `json:"tenants_scanned"`
+	Count                int              `json:"count"`
+	NamespacesCount      int              `json:"namespaces_count"`
+	DisabledFlows        int              `json:"disabled_flows"`
+	FlowsWithInputs      int              `json:"flows_with_inputs"`
+	FlowsWithTriggers    int              `json:"flows_with_triggers"`
+	TaskTypeCount        map[string]int64 `json:"task_type_count"`
+	TaskTypeFlowCount    map[string]int64 `json:"task_type_flow_count"`
+	TriggerTypeCount     map[string]int64 `json:"trigger_type_count"`
+	TriggerTypeFlowCount map[string]int64 `json:"trigger_type_flow_count"`
+	PluginFamilyCount    map[string]int64 `json:"plugin_family_count"`
+	SubflowTaskCount     int64            `json:"subflow_task_count"`
+	FlowsUsingSubflow    int              `json:"flows_using_subflow"`
+}
+
+// signalCount is one migration signal: how often it occurs, in how many flows,
+// and a capped sample of those flows.
+type signalCount struct {
+	Occurrences int64    `json:"occurrences"`
+	Flows       int      `json:"flows"`
+	FlowRefs    []string `json:"flow_refs,omitempty"`
+}
+
+// pluginDefaultsSignal details the pluginDefaults usage, which v2 removes.
+type pluginDefaultsSignal struct {
+	Flows         int              `json:"flows"`
+	Entries       int64            `json:"entries"`
+	ForcedEntries int64            `json:"forced_entries"`
+	TypeCount     map[string]int64 `json:"type_count,omitempty"`
+	FlowRefs      []string         `json:"flow_refs,omitempty"`
+}
+
+// serverDeprecation is one entry of the server-side deprecation cross-check
+// (`flows list-deprecated`), which complements the client-side signals.
+type serverDeprecation struct {
+	FlowRef         string `json:"flow_ref"`
+	DeprecatedTasks int    `json:"deprecated_tasks"`
+}
+
+// deprecatedTaskType aggregates the server-reported deprecations by plugin
+// type. Only type names travel here — the task ids the server returns are user
+// identifiers and are dropped on the way in.
+type deprecatedTaskType struct {
+	TaskType    string `json:"task_type"`
+	Replacement string `json:"replacement,omitempty"`
+	Count       int64  `json:"count"`
+}
+
+// migrationSignals holds every signal keyed to a known Kestra 2.0 breaking
+// change.
+type migrationSignals struct {
+	PluginDefaults              pluginDefaultsSignal   `json:"plugin_defaults"`
+	RemovedTasks                map[string]signalCount `json:"removed_tasks"`
+	TriggerConditions           signalCount            `json:"trigger_conditions"`
+	ConditionProperty           signalCount            `json:"condition_property"`
+	PebbleJsonFunction          signalCount            `json:"pebble_json_function"`
+	FsLocalDelete               signalCount            `json:"fs_local_delete"`
+	ServerDeprecationsAvailable bool                   `json:"server_deprecations_available"`
+	ServerDeprecations          []serverDeprecation    `json:"server_deprecations,omitempty"`
+	DeprecatedTaskTypes         []deprecatedTaskType   `json:"deprecated_task_types,omitempty"`
+}
+
+// tenantReport is the per-tenant breakdown.
+type tenantReport struct {
+	Tenant     string            `json:"tenant"`
+	Totals     usageTotals       `json:"totals"`
+	Namespaces []namespaceReport `json:"namespaces"`
+	ParseFails int               `json:"parse_fails"`
+	Notes      []string          `json:"notes,omitempty"`
+	Errors     []string          `json:"errors,omitempty"`
+}
+
+// namespaceReport is the per-namespace breakdown inside a tenant.
+type namespaceReport struct {
+	Namespace         string `json:"namespace"`
+	FlowCount         int    `json:"flow_count"`
+	DisabledFlows     int    `json:"disabled_flows"`
+	FlowsWithTriggers int    `json:"flows_with_triggers"`
+}
+
+// deprecatedFlow is the server-reported deprecation for one flow, reduced to
+// the fields the report needs.
+type deprecatedFlow struct {
+	Namespace string
+	FlowID    string
+	TaskCount int
+	Tasks     []deprecatedTask
+}
+
+// deprecatedTask is one deprecated task the server reported, kept as plugin
+// type names only.
+type deprecatedTask struct {
+	TaskType    string
+	Replacement string
+}
+
+// tenantScan is everything one tenant contributed to the report: analyzed
+// flows plus the notes and errors collected while fetching them.
+type tenantScan struct {
+	Tenant              string
+	Flows               []flowAnalysis
+	Deprecated          []deprecatedFlow
+	DeprecatedAvailable bool
+	Notes               []string
+	Errors              []string
+}
+
+// flowAnalysis is the intermediate per-flow result. It is never serialized,
+// and — by construction — carries only the flow's identity, booleans, counters
+// and dotted plugin `type` strings. No YAML property value can reach it, which
+// is what makes the anonymized report safe to share.
+type flowAnalysis struct {
+	Namespace   string
+	FlowID      string
+	Disabled    bool
+	HasInputs   bool
+	HasTriggers bool
+	ParseFailed bool
+
+	// TaskTypes/TriggerTypes map a dotted plugin type to its occurrence count.
+	TaskTypes    map[string]int64
+	TriggerTypes map[string]int64
+
+	PluginDefaultsEntries int64
+	PluginDefaultsForced  int64
+	PluginDefaultsTypes   map[string]int64
+
+	RemovedTasks      map[string]int64
+	SubflowTasks      int64
+	TriggerConditions int64
+	ConditionProperty int64
+	PebbleJSON        int64
+	FsLocalDelete     int64
+}
+
+// taskContainerKeys are the flow-level keys walked in task context. inputs,
+// outputs, labels, variables and description are deliberately absent: their
+// `type: STRING` entries would otherwise pollute the task-type counts.
+var taskContainerKeys = []string{"tasks", "errors", "finally", "afterExecution", "listeners"}
+
+// flowTaskPrefixes are the two package spellings of Kestra's core flow tasks —
+// the modern one and the pre-0.16 legacy one. Both must be recognized.
+var flowTaskPrefixes = []string{"io.kestra.plugin.core.flow.", "io.kestra.core.tasks.flows."}
+
+// removedTaskClasses are the core flow tasks removed or reworked in Kestra 2.0.
+var removedTaskClasses = []string{"ForEach", "ForEachItem", "EachSequential", "EachParallel", "Dag", "Template", "Worker"}
+
+// subflowTaskClasses are the two class names used to call a subflow.
+var subflowTaskClasses = []string{"Subflow", "Flow"}
+
+// fsLocalDeleteType changed its `recursive` default in Kestra 2.0.
+const fsLocalDeleteType = "io.kestra.plugin.fs.local.Delete"
+
+// pebbleJSONPattern matches Pebble's removed `json()` function while excluding
+// `fromJson(`, `toJson(` and method-style `.json(`. It is a text heuristic —
+// it also runs on sources whose YAML failed to parse — so it can over-count on
+// flows that mention `json (` in prose.
+var pebbleJSONPattern = regexp.MustCompile(`(^|[^\w.])json\s*\(`)
+
+// analyzeFlowSource walks one flow's YAML source and returns the signals it
+// carries. On a YAML parse failure it still returns a usable analysis with
+// ParseFailed set and the raw-text signals filled in, alongside the error.
+func analyzeFlowSource(raw string) (flowAnalysis, error) {
+	analysis := flowAnalysis{
+		TaskTypes:           map[string]int64{},
+		TriggerTypes:        map[string]int64{},
+		PluginDefaultsTypes: map[string]int64{},
+		RemovedTasks:        map[string]int64{},
+	}
+
+	// Raw-text signals first: they must survive a YAML parse failure.
+	analysis.PebbleJSON = int64(len(pebbleJSONPattern.FindAllStringIndex(raw, -1)))
+
+	var root map[string]any
+	if err := yaml.Unmarshal([]byte(raw), &root); err != nil {
+		analysis.ParseFailed = true
+		return analysis, err
+	}
+	if root == nil {
+		analysis.ParseFailed = true
+		return analysis, fmt.Errorf("flow source is empty")
+	}
+
+	analysis.Namespace, _ = root["namespace"].(string)
+	analysis.FlowID, _ = root["id"].(string)
+	if disabled, ok := root["disabled"].(bool); ok {
+		analysis.Disabled = disabled
+	}
+	if _, ok := root["inputs"]; ok {
+		analysis.HasInputs = true
+	}
+
+	for _, key := range taskContainerKeys {
+		analysis.walk(root[key], false, 0)
+	}
+
+	if triggers, ok := root["triggers"]; ok {
+		analysis.HasTriggers = hasAnyEntry(triggers)
+		analysis.walk(triggers, true, 0)
+	}
+
+	analysis.collectPluginDefaults(root["pluginDefaults"])
+	// The `condition` -> `when` rename covers flow-level checks, SLAs and
+	// triggers, not task properties.
+	analysis.collectConditionEntries(root["sla"])
+	analysis.collectConditionEntries(root["checks"])
+
+	return analysis, nil
+}
+
+// walk recursively records plugin types below node. It enters a map only to
+// read its `type`/`condition` keys and to keep descending; property *values*
+// are never recorded, which is what keeps flowAnalysis leak-free.
+func (a *flowAnalysis) walk(node any, trigger bool, depth int) {
+	if node == nil || depth > maxWalkDepth {
+		return
+	}
+
+	switch value := node.(type) {
+	case []any:
+		for _, item := range value {
+			a.walk(item, trigger, depth+1)
+		}
+	case map[string]any:
+		typeName, hasType := dottedType(value)
+		if hasType {
+			a.recordType(typeName, trigger)
+		}
+		if trigger && hasType {
+			// A trigger's `condition` is renamed to `when` in 2.0. Task-level
+			// `condition` properties are NOT in scope: the If task, for one,
+			// keeps its `condition` in 2.0.
+			if _, ok := value["condition"]; ok {
+				a.ConditionProperty++
+			}
+			a.TriggerConditions += entryCount(value["conditions"]) + entryCount(value["preconditions"])
+		}
+		for key, child := range value {
+			// Nested tasks live under keys such as tasks/errors/then/else/
+			// cases/branches; descending generically catches every flowable
+			// without hardcoding each one. Trigger context does not nest.
+			if key == "type" || key == "conditions" || key == "preconditions" {
+				continue
+			}
+			a.walk(child, false, depth+1)
+		}
+	}
+}
+
+// recordType counts one plugin type and its migration signals.
+func (a *flowAnalysis) recordType(typeName string, trigger bool) {
+	if trigger {
+		a.TriggerTypes[typeName]++
+		return
+	}
+
+	a.TaskTypes[typeName]++
+	if class, ok := coreFlowClass(typeName, removedTaskClasses); ok {
+		a.RemovedTasks[class]++
+	}
+	if _, ok := coreFlowClass(typeName, subflowTaskClasses); ok {
+		a.SubflowTasks++
+	}
+	if typeName == fsLocalDeleteType {
+		a.FsLocalDelete++
+	}
+}
+
+// collectPluginDefaults counts the flow-level pluginDefaults entries. Kestra
+// 1.3 spells the key `pluginDefaults`; the pre-0.18 `taskDefaults` alias is out
+// of scope.
+func (a *flowAnalysis) collectPluginDefaults(node any) {
+	entries, ok := node.([]any)
+	if !ok {
+		return
+	}
+
+	for _, item := range entries {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		a.PluginDefaultsEntries++
+		if typeName, ok := dottedType(entry); ok {
+			a.PluginDefaultsTypes[typeName]++
+		}
+		if forced, ok := entry["forced"].(bool); ok && forced {
+			a.PluginDefaultsForced++
+		}
+	}
+}
+
+// collectConditionEntries counts the `condition` property on a list of
+// flow-level entries — SLAs and checks — which v2 replaces with `when`.
+func (a *flowAnalysis) collectConditionEntries(node any) {
+	entries, ok := node.([]any)
+	if !ok {
+		return
+	}
+
+	for _, item := range entries {
+		entry, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if _, ok := entry["condition"]; ok {
+			a.ConditionProperty++
+		}
+	}
+}
+
+// dottedType returns the map's `type` value only when it looks like a plugin
+// class name, i.e. contains a dot. This is the guard that keeps input
+// declarations (`type: STRING`) out of the task counts.
+func dottedType(m map[string]any) (string, bool) {
+	typeName, ok := m["type"].(string)
+	if !ok {
+		return "", false
+	}
+	typeName = strings.TrimSpace(typeName)
+	if !strings.Contains(typeName, ".") {
+		return "", false
+	}
+	return typeName, true
+}
+
+// coreFlowClass reports whether typeName is one of the given core flow classes,
+// under either the modern or the legacy package spelling.
+func coreFlowClass(typeName string, classes []string) (string, bool) {
+	for _, prefix := range flowTaskPrefixes {
+		if !strings.HasPrefix(typeName, prefix) {
+			continue
+		}
+		class := strings.TrimPrefix(typeName, prefix)
+		for _, candidate := range classes {
+			if class == candidate {
+				return class, true
+			}
+		}
+	}
+	return "", false
+}
+
+// entryCount returns the number of entries in a list or map node, and 0 for
+// anything else.
+func entryCount(node any) int64 {
+	switch value := node.(type) {
+	case []any:
+		return int64(len(value))
+	case map[string]any:
+		return int64(len(value))
+	default:
+		return 0
+	}
+}
+
+// hasAnyEntry reports whether node is a non-empty list or map.
+func hasAnyEntry(node any) bool {
+	switch value := node.(type) {
+	case []any:
+		return len(value) > 0
+	case map[string]any:
+		return len(value) > 0
+	default:
+		return false
+	}
+}
+
+// pluginFamily reduces a plugin type to the family it belongs to: the class
+// segment is dropped, official plugins collapse to their first four segments
+// (io.kestra.plugin.jdbc), legacy core tasks map onto io.kestra.plugin.core and
+// custom plugins keep their full package.
+func pluginFamily(typeName string) string {
+	segments := strings.Split(typeName, ".")
+	if len(segments) < 2 {
+		return typeName
+	}
+	pkg := segments[:len(segments)-1]
+
+	if strings.HasPrefix(typeName, "io.kestra.core.tasks.") {
+		return "io.kestra.plugin.core"
+	}
+	// EE plugins all live under io.kestra.plugin.ee, so they need one segment
+	// more than the open-source ones to stay distinguishable
+	// (io.kestra.plugin.ee.jdbc rather than a single io.kestra.plugin.ee).
+	switch {
+	case strings.HasPrefix(typeName, "io.kestra.plugin.ee."):
+		if len(pkg) > 5 {
+			pkg = pkg[:5]
+		}
+	case strings.HasPrefix(typeName, "io.kestra.plugin."):
+		if len(pkg) > 4 {
+			pkg = pkg[:4]
+		}
+	}
+	return strings.Join(pkg, ".")
+}
+
+// anonymizer maps tenant, namespace and flow identifiers to stable short
+// hashes. The hash is unsalted so the same identifier yields the same label on
+// every run and every machine: reports stay diffable and a follow-up
+// conversation can refer to "ns-3f9a12" without ever revealing the name.
+type anonymizer struct {
+	enabled bool
+	cache   map[string]string
+	used    map[string]string
+}
+
+func newAnonymizer(enabled bool) *anonymizer {
+	return &anonymizer{
+		enabled: enabled,
+		cache:   map[string]string{},
+		used:    map[string]string{},
+	}
+}
+
+func (a *anonymizer) tenant(id string) string    { return a.label("tenant", "t-", id) }
+func (a *anonymizer) namespace(id string) string { return a.label("namespace", "ns-", id) }
+func (a *anonymizer) flow(id string) string      { return a.label("flow", "f-", id) }
+
+// label returns the stable pseudonym for id within kind. Namespaces are hashed
+// whole — segments are not preserved, since a namespace path is as identifying
+// as the leaf.
+func (a *anonymizer) label(kind, prefix, id string) string {
+	if !a.enabled {
+		return id
+	}
+
+	key := kind + ":" + id
+	if label, ok := a.cache[key]; ok {
+		return label
+	}
+
+	sum := sha256.Sum256([]byte(key))
+	digest := hex.EncodeToString(sum[:])
+	label := prefix + digest[:6]
+	// Lengthen on collision so two different identifiers never share a label.
+	for length := 8; length <= len(digest); length += 2 {
+		if owner, taken := a.used[label]; !taken || owner == key {
+			break
+		}
+		label = prefix + digest[:length]
+	}
+
+	a.cache[key] = label
+	a.used[label] = key
+	return label
+}
+
+// flowRef builds the "t-xx/ns-yy/f-zz" reference used throughout the report.
+func (a *anonymizer) flowRef(tenant, namespace, flowID string) string {
+	return a.tenant(tenant) + "/" + a.namespace(namespace) + "/" + a.flow(flowID)
+}
+
+// signalAccumulator collects one signal's occurrences and affected flows while
+// aggregating, capping the reference sample at maxFlowRefs.
+type signalAccumulator struct {
+	occurrences int64
+	flows       int
+	refs        []string
+}
+
+func (s *signalAccumulator) add(occurrences int64, ref string) {
+	if occurrences <= 0 {
+		return
+	}
+	s.occurrences += occurrences
+	if ref == "" {
+		return
+	}
+	s.flows++
+	if len(s.refs) < maxFlowRefs {
+		s.refs = append(s.refs, ref)
+	}
+}
+
+func (s *signalAccumulator) result() signalCount {
+	sort.Strings(s.refs)
+	return signalCount{Occurrences: s.occurrences, Flows: s.flows, FlowRefs: s.refs}
+}
+
+// aggregateReport merges the per-tenant scans into the final report. The
+// caller fills in Scope and any scope-level notes.
+func aggregateReport(scans []tenantScan, anon *anonymizer, generatedAt time.Time) *usageReport {
+	report := &usageReport{
+		GeneratedAt:      generatedAt.UTC().Format(time.RFC3339),
+		KestractlVersion: version,
+		Anonymized:       anon.enabled,
+		Totals:           newUsageTotals(),
+		Signals: migrationSignals{
+			RemovedTasks: map[string]signalCount{},
+			PluginDefaults: pluginDefaultsSignal{
+				TypeCount: map[string]int64{},
+			},
+		},
+		Tenants: make([]tenantReport, 0, len(scans)),
+	}
+
+	var (
+		defaults          signalAccumulator
+		triggerConditions signalAccumulator
+		conditionProperty signalAccumulator
+		pebbleJSON        signalAccumulator
+		fsLocalDelete     signalAccumulator
+		removed           = map[string]*signalAccumulator{}
+		namespaceKeys     = map[string]struct{}{}
+		deprecatedTypes   = map[deprecatedTask]int64{}
+	)
+
+	for _, scan := range scans {
+		tenant := tenantReport{
+			Tenant:     anon.tenant(scan.Tenant),
+			Totals:     newUsageTotals(),
+			Namespaces: []namespaceReport{},
+			Notes:      scan.Notes,
+			Errors:     scan.Errors,
+		}
+		namespaces := map[string]*namespaceReport{}
+
+		for _, flow := range scan.Flows {
+			// A flow whose YAML did not parse has no identity: count it as a
+			// parse failure and keep only its raw-text signals.
+			ref := ""
+			if !flow.ParseFailed {
+				ref = anon.flowRef(scan.Tenant, flow.Namespace, flow.FlowID)
+				tenant.Totals.Count++
+				namespaceKeys[scan.Tenant+"/"+flow.Namespace] = struct{}{}
+
+				ns, ok := namespaces[flow.Namespace]
+				if !ok {
+					ns = &namespaceReport{Namespace: anon.namespace(flow.Namespace)}
+					namespaces[flow.Namespace] = ns
+				}
+				ns.FlowCount++
+				if flow.Disabled {
+					ns.DisabledFlows++
+					tenant.Totals.DisabledFlows++
+				}
+				if flow.HasInputs {
+					tenant.Totals.FlowsWithInputs++
+				}
+				if flow.HasTriggers {
+					ns.FlowsWithTriggers++
+					tenant.Totals.FlowsWithTriggers++
+				}
+				if flow.SubflowTasks > 0 {
+					tenant.Totals.FlowsUsingSubflow++
+				}
+				tenant.Totals.SubflowTaskCount += flow.SubflowTasks
+
+				for typeName, count := range flow.TaskTypes {
+					tenant.Totals.TaskTypeCount[typeName] += count
+					tenant.Totals.TaskTypeFlowCount[typeName]++
+					tenant.Totals.PluginFamilyCount[pluginFamily(typeName)] += count
+				}
+				for typeName, count := range flow.TriggerTypes {
+					tenant.Totals.TriggerTypeCount[typeName] += count
+					tenant.Totals.TriggerTypeFlowCount[typeName]++
+					tenant.Totals.PluginFamilyCount[pluginFamily(typeName)] += count
+				}
+			} else {
+				tenant.ParseFails++
+			}
+
+			if flow.PluginDefaultsEntries > 0 {
+				defaults.add(flow.PluginDefaultsEntries, ref)
+				report.Signals.PluginDefaults.ForcedEntries += flow.PluginDefaultsForced
+				for typeName, count := range flow.PluginDefaultsTypes {
+					report.Signals.PluginDefaults.TypeCount[typeName] += count
+				}
+			}
+			for class, count := range flow.RemovedTasks {
+				acc, ok := removed[class]
+				if !ok {
+					acc = &signalAccumulator{}
+					removed[class] = acc
+				}
+				acc.add(count, ref)
+			}
+			triggerConditions.add(flow.TriggerConditions, ref)
+			conditionProperty.add(flow.ConditionProperty, ref)
+			pebbleJSON.add(flow.PebbleJSON, ref)
+			fsLocalDelete.add(flow.FsLocalDelete, ref)
+		}
+
+		tenant.Totals.TenantsScanned = 1
+		tenant.Totals.NamespacesCount = len(namespaces)
+		tenant.Namespaces = sortedNamespaceReports(namespaces)
+
+		if scan.DeprecatedAvailable {
+			report.Signals.ServerDeprecationsAvailable = true
+			for _, dep := range scan.Deprecated {
+				report.Signals.ServerDeprecations = append(report.Signals.ServerDeprecations, serverDeprecation{
+					FlowRef:         anon.flowRef(scan.Tenant, dep.Namespace, dep.FlowID),
+					DeprecatedTasks: dep.TaskCount,
+				})
+				for _, task := range dep.Tasks {
+					deprecatedTypes[task]++
+				}
+			}
+		}
+
+		mergeTotals(&report.Totals, tenant.Totals)
+		report.Tenants = append(report.Tenants, tenant)
+
+		for _, note := range scan.Notes {
+			report.Notes = append(report.Notes, tenant.Tenant+": "+note)
+		}
+		for _, failure := range scan.Errors {
+			report.Notes = append(report.Notes, tenant.Tenant+": "+failure)
+		}
+		if tenant.ParseFails > 0 {
+			report.Notes = append(report.Notes, fmt.Sprintf("%s: %d flow source(s) could not be parsed as YAML; only text-based signals were counted for them",
+				tenant.Tenant, tenant.ParseFails))
+		}
+	}
+
+	report.Totals.TenantsScanned = len(scans)
+	report.Totals.NamespacesCount = len(namespaceKeys)
+
+	report.Signals.PluginDefaults.Flows = defaults.flows
+	report.Signals.PluginDefaults.Entries = defaults.occurrences
+	sort.Strings(defaults.refs)
+	report.Signals.PluginDefaults.FlowRefs = defaults.refs
+	report.Signals.TriggerConditions = triggerConditions.result()
+	report.Signals.ConditionProperty = conditionProperty.result()
+	report.Signals.PebbleJsonFunction = pebbleJSON.result()
+	report.Signals.FsLocalDelete = fsLocalDelete.result()
+
+	// Every removed task gets a row, including the ones nobody uses: "0 uses
+	// of ForEach" is itself an answer for the migration plan.
+	for _, class := range removedTaskClasses {
+		if acc, ok := removed[class]; ok {
+			report.Signals.RemovedTasks[class] = acc.result()
+		} else {
+			report.Signals.RemovedTasks[class] = signalCount{}
+		}
+	}
+
+	for task, count := range deprecatedTypes {
+		report.Signals.DeprecatedTaskTypes = append(report.Signals.DeprecatedTaskTypes, deprecatedTaskType{
+			TaskType:    task.TaskType,
+			Replacement: task.Replacement,
+			Count:       count,
+		})
+	}
+	sort.Slice(report.Signals.DeprecatedTaskTypes, func(i, j int) bool {
+		left, right := report.Signals.DeprecatedTaskTypes[i], report.Signals.DeprecatedTaskTypes[j]
+		if left.Count != right.Count {
+			return left.Count > right.Count
+		}
+		if left.TaskType != right.TaskType {
+			return left.TaskType < right.TaskType
+		}
+		return left.Replacement < right.Replacement
+	})
+
+	sort.Slice(report.Signals.ServerDeprecations, func(i, j int) bool {
+		return report.Signals.ServerDeprecations[i].FlowRef < report.Signals.ServerDeprecations[j].FlowRef
+	})
+
+	return report
+}
+
+func newUsageTotals() usageTotals {
+	return usageTotals{
+		TaskTypeCount:        map[string]int64{},
+		TaskTypeFlowCount:    map[string]int64{},
+		TriggerTypeCount:     map[string]int64{},
+		TriggerTypeFlowCount: map[string]int64{},
+		PluginFamilyCount:    map[string]int64{},
+	}
+}
+
+// mergeTotals folds one tenant's totals into the report-wide totals. The
+// TenantsScanned and NamespacesCount fields are set by the caller, since they
+// are counted across tenants.
+func mergeTotals(into *usageTotals, from usageTotals) {
+	into.Count += from.Count
+	into.DisabledFlows += from.DisabledFlows
+	into.FlowsWithInputs += from.FlowsWithInputs
+	into.FlowsWithTriggers += from.FlowsWithTriggers
+	into.SubflowTaskCount += from.SubflowTaskCount
+	into.FlowsUsingSubflow += from.FlowsUsingSubflow
+	mergeCounts(into.TaskTypeCount, from.TaskTypeCount)
+	mergeCounts(into.TaskTypeFlowCount, from.TaskTypeFlowCount)
+	mergeCounts(into.TriggerTypeCount, from.TriggerTypeCount)
+	mergeCounts(into.TriggerTypeFlowCount, from.TriggerTypeFlowCount)
+	mergeCounts(into.PluginFamilyCount, from.PluginFamilyCount)
+}
+
+func mergeCounts(into, from map[string]int64) {
+	for key, count := range from {
+		into[key] += count
+	}
+}
+
+func sortedNamespaceReports(namespaces map[string]*namespaceReport) []namespaceReport {
+	result := make([]namespaceReport, 0, len(namespaces))
+	for _, ns := range namespaces {
+		result = append(result, *ns)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].FlowCount != result[j].FlowCount {
+			return result[i].FlowCount > result[j].FlowCount
+		}
+		return result[i].Namespace < result[j].Namespace
+	})
+	return result
+}
+
+// countEntry is one row of a count map, ready to render.
+type countEntry struct {
+	Name  string
+	Count int64
+}
+
+// sortedCounts orders a count map by descending count, then by name, so the
+// rendered report is deterministic.
+func sortedCounts(counts map[string]int64) []countEntry {
+	entries := make([]countEntry, 0, len(counts))
+	for name, count := range counts {
+		entries = append(entries, countEntry{Name: name, Count: count})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Count != entries[j].Count {
+			return entries[i].Count > entries[j].Count
+		}
+		return entries[i].Name < entries[j].Name
+	})
+	return entries
+}
+
+// renderUsageReportMarkdown writes the report as plain GitHub-flavoured
+// markdown, meant to be copy-pasted into an issue or a migration document.
+func renderUsageReportMarkdown(report *usageReport, w io.Writer) error {
+	out := &markdownWriter{w: w}
+
+	out.printf("# Kestra usage report\n\n")
+	out.printf("- Generated at: %s\n", report.GeneratedAt)
+	out.printf("- kestractl version: %s\n", report.KestractlVersion)
+	out.printf("- Scope: %s\n", report.Scope)
+	out.printf("- Tenants scanned: %d\n", report.Totals.TenantsScanned)
+	if report.Anonymized {
+		out.printf("- Anonymization: on — tenant, namespace and flow names are replaced by stable hashes (`t-`/`ns-`/`f-`). Plugin types and counts are unchanged. Re-run with `--anonymize=false` to see real names.\n")
+	} else {
+		out.printf("- Anonymization: off — this report contains real tenant, namespace and flow names.\n")
+	}
+	out.printf("\nThis report is built from flow sources only: no execution, log or database data is read. ")
+	out.printf("Namespace-level plugin defaults are not part of a flow source and are therefore not visible here.\n\n")
+
+	renderSignalsSection(out, report)
+	renderPluginDefaultsSection(out, report)
+	renderDeprecatedTaskTypesSection(out, report)
+	renderAffectedFlowsSection(out, report)
+	renderInventorySection(out, report)
+	renderNotesSection(out, report)
+
+	return out.err
+}
+
+func renderSignalsSection(out *markdownWriter, report *usageReport) {
+	signals := report.Signals
+
+	out.printf("## Migration signals\n\n")
+	out.printf("| Signal | Occurrences | Flows | Kestra 2.0 impact |\n")
+	out.printf("| --- | ---: | ---: | --- |\n")
+	out.printf("| pluginDefaults | %d | %d | Removed in 2.0 — move defaults into each task |\n",
+		signals.PluginDefaults.Entries, signals.PluginDefaults.Flows)
+	for _, class := range removedTaskClasses {
+		signal := signals.RemovedTasks[class]
+		out.printf("| Task %s | %d | %d | Removed or reworked in 2.0 |\n", class, signal.Occurrences, signal.Flows)
+	}
+	out.printf("| Trigger conditions/preconditions | %d | %d | Replaced by `when` |\n",
+		signals.TriggerConditions.Occurrences, signals.TriggerConditions.Flows)
+	out.printf("| `condition` property | %d | %d | Replaced by `when` |\n",
+		signals.ConditionProperty.Occurrences, signals.ConditionProperty.Flows)
+	out.printf("| Pebble `json()` | %d | %d | Removed — use `fromJson()`/`toJson()` (text heuristic) |\n",
+		signals.PebbleJsonFunction.Occurrences, signals.PebbleJsonFunction.Flows)
+	out.printf("| `fs.local.Delete` | %d | %d | `recursive` default changed in 2.0 |\n",
+		signals.FsLocalDelete.Occurrences, signals.FsLocalDelete.Flows)
+	if signals.ServerDeprecationsAvailable {
+		deprecatedTasks := int64(0)
+		for _, dep := range signals.ServerDeprecations {
+			deprecatedTasks += int64(dep.DeprecatedTasks)
+		}
+		out.printf("| Server-reported deprecations | %d | %d | Reported by the Kestra instance itself |\n",
+			deprecatedTasks, len(signals.ServerDeprecations))
+	} else {
+		out.printf("| Server-reported deprecations | n/a | n/a | The deprecation endpoint could not be read |\n")
+	}
+	out.printf("\n")
+}
+
+func renderPluginDefaultsSection(out *markdownWriter, report *usageReport) {
+	defaults := report.Signals.PluginDefaults
+
+	out.printf("## pluginDefaults detail\n\n")
+	out.printf("- Flows declaring pluginDefaults: %d\n", defaults.Flows)
+	out.printf("- Total entries: %d (of which forced: %d)\n\n", defaults.Entries, defaults.ForcedEntries)
+	if len(defaults.TypeCount) == 0 {
+		out.printf("No pluginDefaults entries found.\n\n")
+		return
+	}
+
+	out.printf("| Default type | Entries |\n| --- | ---: |\n")
+	for _, entry := range sortedCounts(defaults.TypeCount) {
+		out.printf("| `%s` | %d |\n", entry.Name, entry.Count)
+	}
+	out.printf("\n")
+}
+
+// renderDeprecatedTaskTypesSection lists the deprecations the instance itself
+// reported, aggregated by plugin type. Task ids are deliberately not part of
+// the report.
+func renderDeprecatedTaskTypesSection(out *markdownWriter, report *usageReport) {
+	if !report.Signals.ServerDeprecationsAvailable {
+		return
+	}
+
+	out.printf("## Deprecated task types (server-reported)\n\n")
+	if len(report.Signals.DeprecatedTaskTypes) == 0 {
+		out.printf("The instance reported no deprecated task.\n\n")
+		return
+	}
+
+	out.printf("| Task type | Replacement | Count |\n| --- | --- | ---: |\n")
+	for _, entry := range report.Signals.DeprecatedTaskTypes {
+		replacement := "-"
+		if entry.Replacement != "" {
+			replacement = "`" + entry.Replacement + "`"
+		}
+		out.printf("| `%s` | %s | %d |\n", entry.TaskType, replacement, entry.Count)
+	}
+	out.printf("\n")
+}
+
+func renderAffectedFlowsSection(out *markdownWriter, report *usageReport) {
+	out.printf("## Affected flows\n\n")
+
+	rendered := false
+	render := func(title string, refs []string) {
+		if len(refs) == 0 {
+			return
+		}
+		rendered = true
+		out.printf("### %s\n\n", title)
+		for _, ref := range refs {
+			out.printf("- `%s`\n", ref)
+		}
+		if len(refs) == maxFlowRefs {
+			out.printf("\n_Truncated at %d flows._\n", maxFlowRefs)
+		}
+		out.printf("\n")
+	}
+
+	render("pluginDefaults", report.Signals.PluginDefaults.FlowRefs)
+	for _, class := range removedTaskClasses {
+		render("Task "+class, report.Signals.RemovedTasks[class].FlowRefs)
+	}
+	render("Trigger conditions/preconditions", report.Signals.TriggerConditions.FlowRefs)
+	render("`condition` property", report.Signals.ConditionProperty.FlowRefs)
+	render("Pebble `json()`", report.Signals.PebbleJsonFunction.FlowRefs)
+	render("`fs.local.Delete`", report.Signals.FsLocalDelete.FlowRefs)
+
+	if len(report.Signals.ServerDeprecations) > 0 {
+		rendered = true
+		out.printf("### Server-reported deprecations\n\n")
+		for _, dep := range report.Signals.ServerDeprecations {
+			out.printf("- `%s` (%d deprecated task(s))\n", dep.FlowRef, dep.DeprecatedTasks)
+		}
+		out.printf("\n")
+	}
+
+	if !rendered {
+		out.printf("No flow matched any migration signal.\n\n")
+	}
+}
+
+func renderInventorySection(out *markdownWriter, report *usageReport) {
+	totals := report.Totals
+
+	out.printf("## Inventory\n\n")
+	out.printf("| Metric | Value |\n| --- | ---: |\n")
+	out.printf("| Tenants scanned | %d |\n", totals.TenantsScanned)
+	out.printf("| Flows | %d |\n", totals.Count)
+	out.printf("| Namespaces | %d |\n", totals.NamespacesCount)
+	out.printf("| Disabled flows | %d |\n", totals.DisabledFlows)
+	out.printf("| Flows with inputs | %d |\n", totals.FlowsWithInputs)
+	out.printf("| Flows with triggers | %d |\n", totals.FlowsWithTriggers)
+	out.printf("| Subflow tasks | %d |\n", totals.SubflowTaskCount)
+	out.printf("| Flows calling a subflow | %d |\n", totals.FlowsUsingSubflow)
+	out.printf("\n")
+
+	out.printf("### Flows per namespace\n\n")
+	out.printf("| Tenant | Namespace | Flows | Disabled | With triggers |\n| --- | --- | ---: | ---: | ---: |\n")
+	for _, tenant := range report.Tenants {
+		for _, ns := range tenant.Namespaces {
+			out.printf("| `%s` | `%s` | %d | %d | %d |\n",
+				tenant.Tenant, ns.Namespace, ns.FlowCount, ns.DisabledFlows, ns.FlowsWithTriggers)
+		}
+	}
+	out.printf("\n")
+
+	renderCountTable(out, "Task types", "Task type", totals.TaskTypeCount, totals.TaskTypeFlowCount)
+	renderCountTable(out, "Trigger types", "Trigger type", totals.TriggerTypeCount, totals.TriggerTypeFlowCount)
+
+	out.printf("### Plugin families\n\n")
+	if len(totals.PluginFamilyCount) == 0 {
+		out.printf("No plugin usage found.\n\n")
+		return
+	}
+	out.printf("| Plugin family | Uses |\n| --- | ---: |\n")
+	for _, entry := range sortedCounts(totals.PluginFamilyCount) {
+		out.printf("| `%s` | %d |\n", entry.Name, entry.Count)
+	}
+	out.printf("\n")
+}
+
+// renderCountTable renders one "type → uses / flows" inventory table.
+func renderCountTable(out *markdownWriter, title, column string, counts, flowCounts map[string]int64) {
+	out.printf("### %s\n\n", title)
+	if len(counts) == 0 {
+		out.printf("None found.\n\n")
+		return
+	}
+
+	out.printf("| %s | Uses | Flows |\n| --- | ---: | ---: |\n", column)
+	for _, entry := range sortedCounts(counts) {
+		out.printf("| `%s` | %d | %d |\n", entry.Name, entry.Count, flowCounts[entry.Name])
+	}
+	out.printf("\n")
+}
+
+func renderNotesSection(out *markdownWriter, report *usageReport) {
+	out.printf("## Scan notes\n\n")
+	if len(report.Notes) == 0 {
+		out.printf("- The scan completed without fallbacks or errors.\n")
+	}
+	for _, note := range report.Notes {
+		out.printf("- %s\n", note)
+	}
+	out.printf("- Namespace-level plugin defaults are stored outside flow sources and are not covered by this report.\n")
+	out.printf("- The Pebble `json()` count is a text heuristic over the flow source.\n")
+}
+
+// markdownWriter accumulates the first write error so the renderer does not
+// have to check every single Fprintf.
+type markdownWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (m *markdownWriter) printf(format string, args ...any) {
+	if m.err != nil {
+		return
+	}
+	_, m.err = fmt.Fprintf(m.w, format, args...)
+}
+
+// maxZipEntrySize bounds a single flow source read out of an export archive.
+// A flow YAML is a few kilobytes; anything larger is not a flow and is skipped
+// rather than buffered.
+const maxZipEntrySize = 10 << 20 // 10 MiB
+
+// flowsFromZip reads the YAML sources out of a flow export archive entirely in
+// memory — the archive never touches disk. It returns the sources plus the
+// number of entries that were skipped (oversized or unreadable).
+func flowsFromZip(data []byte) ([]string, int, error) {
+	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read the flow export archive: %w", err)
+	}
+
+	sources := make([]string, 0, len(reader.File))
+	skipped := 0
+
+	for _, entry := range reader.File {
+		if entry.FileInfo().IsDir() || !isYAMLEntry(entry.Name) {
+			continue
+		}
+		if entry.UncompressedSize64 > maxZipEntrySize {
+			skipped++
+			continue
+		}
+
+		source, err := readZipEntry(entry)
+		if err != nil {
+			skipped++
+			continue
+		}
+		sources = append(sources, source)
+	}
+
+	return sources, skipped, nil
+}
+
+func readZipEntry(entry *zip.File) (string, error) {
+	file, err := entry.Open()
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(io.LimitReader(file, maxZipEntrySize))
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func isYAMLEntry(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.HasSuffix(lower, ".yml") || strings.HasSuffix(lower, ".yaml")
+}

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -33,6 +33,7 @@ const maxWalkDepth = 64
 type usageReport struct {
 	GeneratedAt      string           `json:"generated_at"`
 	KestractlVersion string           `json:"kestractl_version"`
+	KestraVersion    string           `json:"kestra_version"`
 	Anonymized       bool             `json:"anonymized"`
 	Scope            string           `json:"scope"`
 	Totals           usageTotals      `json:"totals"`
@@ -784,6 +785,11 @@ func renderUsageReportMarkdown(report *usageReport, w io.Writer) error {
 	out.printf("# Kestra usage report\n\n")
 	out.printf("- Generated at: %s\n", report.GeneratedAt)
 	out.printf("- kestractl version: %s\n", report.KestractlVersion)
+	kestraVersion := report.KestraVersion
+	if kestraVersion == "" {
+		kestraVersion = "unknown"
+	}
+	out.printf("- Kestra version: %s\n", kestraVersion)
 	out.printf("- Scope: %s\n", report.Scope)
 	out.printf("- Tenants scanned: %d\n", report.Totals.TenantsScanned)
 	if report.Anonymized {

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -220,34 +220,45 @@ const fsLocalDeleteType = "io.kestra.plugin.fs.local.Delete"
 // flows that mention `json (` in prose.
 var pebbleJSONPattern = regexp.MustCompile(`(^|[^\w.])json\s*\(`)
 
-// pebbleFunctionNames is the function reference of the Kestra docs. Only these
-// names are ever recorded: anything else a flow calls could be a customer
-// macro, and is counted anonymously instead.
+// pebbleFunctionNames is the function set the Kestra 1.3 engine registers.
+// Source of truth, to refresh when the engine changes:
+//   - kestra, releases/v1.3.x: core/src/main/java/io/kestra/core/runners/pebble/Extension.java
+//   - kestra-ee, releases/v1.3.x: core-ee/src/main/java/io/kestra/ee/core/runners/pebble/Extensions.java
+//   - the bundled pebble 4.1.2 library: CoreExtension
+//
+// Only these names are ever recorded: anything else a flow calls could be a
+// customer macro, and is counted anonymously instead.
 var pebbleFunctionNames = []string{
-	"render", "renderOnce", "fetchContext", "printContext", "block", "parent", "macro", "i18n",
-	"secret", "credential", "read", "fileURI", "kv", "encrypt", "decrypt",
-	"fromJson", "fromIon", "yaml", "json",
-	"errorLogs", "currentEachOutput", "tasksWithState", "iterationOutput", "parentOutput", "appLink",
-	"now", "max", "min", "range", "uuid", "id", "ksuid", "nanoId", "randomInt", "randomPort",
-	"http", "fileSize", "fileExists", "isFileEmpty",
-	"isWeekend", "isPublicHoliday", "isDayWeekInMonth",
-	"dayOfWeek", "dayOfMonth", "monthOfYear", "hourOfDay",
+	// kestra core
+	"now", "json", "fromJson", "currentEachOutput", "secret", "kv", "read", "fileURI",
+	"render", "renderOnce", "encrypt", "decrypt", "yaml", "printContext", "fetchContext",
+	"uuid", "id", "ksuid", "fromIon", "fileSize", "errorLogs", "randomInt", "randomPort",
+	"fileExists", "isFileEmpty", "nanoId", "tasksWithState", "http", "subflow",
+	// kestra ee
+	"credential", "appLink", "assets",
+	// pebble library
+	"max", "min", "range", "i18n",
 }
 
-// pebbleFilterNames is the filter reference of the Kestra docs. Filters are
-// allowlisted separately from functions: they are invoked in a different
-// position and a name can legitimately exist in both sets (yaml, toJson).
+// pebbleFilterNames is the filter set the Kestra 1.3 engine registers, from
+// the same sources as pebbleFunctionNames (kestra Extension.java, kestra-ee
+// Extensions.java, pebble 4.1.2 CoreExtension and its escaper extension).
+// Filters are allowlisted separately from functions: they are invoked in a
+// different position and a name can legitimately exist in both sets (json,
+// yaml, toJson). Matching is case-insensitive, so pebble's all-lowercase
+// registrations still resolve to the casing the Kestra docs use.
 var pebbleFilterNames = []string{
-	"toJson", "toIon", "jq", "abs", "number", "className", "numberFormat",
-	"first", "last", "length", "join", "split", "sort", "rsort", "reverse", "chunk", "distinct",
-	"slice", "merge", "flatten", "keys", "values",
-	"lower", "upper", "title", "capitalize", "trim", "abbreviate", "replace",
-	"substringBefore", "substringAfter", "substringBeforeLast", "substringAfterLast", "slugify",
-	"default", "startsWith", "endsWith",
-	"base64encode", "base64decode", "urlencode", "urldecode", "sha1", "sha512", "md5",
-	"string", "escapeChar",
-	"date", "dateAdd", "timestamp", "timestampMilli", "timestampMicro", "timestampNano",
-	"yaml", "indent", "nindent",
+	// kestra core
+	"chunk", "className", "date", "dateAdd", "timestamp", "timestampMicro", "timestampMilli",
+	"timestampNano", "jq", "escapeChar", "json", "toJson", "distinct", "keys", "number",
+	"urldecode", "slugify", "substringBefore", "substringBeforeLast", "substringAfter",
+	"substringAfterLast", "flatten", "indent", "nindent", "yaml", "startsWith", "endsWith",
+	"values", "toIon", "sha1", "sha512", "md5", "string",
+	// pebble library
+	"abbreviate", "abs", "capitalize", "default", "first", "format", "join", "last", "lower",
+	"numberFormat", "slice", "sort", "rsort", "reverse", "title", "trim", "upper", "urlencode",
+	"length", "replace", "merge", "split", "base64encode", "base64decode", "sha256", "nl2br",
+	"escape", "raw",
 }
 
 // pebbleFilters indexes the filter allowlist by lowercase name.

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -779,7 +779,11 @@ func sortedCounts(counts map[string]int64) []countEntry {
 
 // renderUsageReportMarkdown writes the report as plain GitHub-flavoured
 // markdown, meant to be copy-pasted into an issue or a migration document.
-func renderUsageReportMarkdown(report *usageReport, w io.Writer) error {
+//
+// detailed adds the two long-form blocks — the per-namespace table and the
+// per-signal affected-flow lists. It is a rendering choice only: the report
+// itself always carries the full data, which `--output json` dumps verbatim.
+func renderUsageReportMarkdown(report *usageReport, w io.Writer, detailed bool) error {
 	out := &markdownWriter{w: w}
 
 	out.printf("# Kestra usage report\n\n")
@@ -803,8 +807,8 @@ func renderUsageReportMarkdown(report *usageReport, w io.Writer) error {
 	renderSignalsSection(out, report)
 	renderPluginDefaultsSection(out, report)
 	renderDeprecatedTaskTypesSection(out, report)
-	renderAffectedFlowsSection(out, report)
-	renderInventorySection(out, report)
+	renderAffectedFlowsSection(out, report, detailed)
+	renderInventorySection(out, report, detailed)
 	renderNotesSection(out, report)
 
 	return out.err
@@ -886,7 +890,12 @@ func renderDeprecatedTaskTypesSection(out *markdownWriter, report *usageReport) 
 	out.printf("\n")
 }
 
-func renderAffectedFlowsSection(out *markdownWriter, report *usageReport) {
+func renderAffectedFlowsSection(out *markdownWriter, report *usageReport, detailed bool) {
+	if !detailed {
+		out.printf("_Run with --detailed to list the affected flows._\n\n")
+		return
+	}
+
 	out.printf("## Affected flows\n\n")
 
 	rendered := false
@@ -928,7 +937,7 @@ func renderAffectedFlowsSection(out *markdownWriter, report *usageReport) {
 	}
 }
 
-func renderInventorySection(out *markdownWriter, report *usageReport) {
+func renderInventorySection(out *markdownWriter, report *usageReport, detailed bool) {
 	totals := report.Totals
 
 	out.printf("## Inventory\n\n")
@@ -943,15 +952,17 @@ func renderInventorySection(out *markdownWriter, report *usageReport) {
 	out.printf("| Flows calling a subflow | %d |\n", totals.FlowsUsingSubflow)
 	out.printf("\n")
 
-	out.printf("### Flows per namespace\n\n")
-	out.printf("| Tenant | Namespace | Flows | Disabled | With triggers |\n| --- | --- | ---: | ---: | ---: |\n")
-	for _, tenant := range report.Tenants {
-		for _, ns := range tenant.Namespaces {
-			out.printf("| `%s` | `%s` | %d | %d | %d |\n",
-				tenant.Tenant, ns.Namespace, ns.FlowCount, ns.DisabledFlows, ns.FlowsWithTriggers)
+	if detailed {
+		out.printf("### Flows per namespace\n\n")
+		out.printf("| Tenant | Namespace | Flows | Disabled | With triggers |\n| --- | --- | ---: | ---: | ---: |\n")
+		for _, tenant := range report.Tenants {
+			for _, ns := range tenant.Namespaces {
+				out.printf("| `%s` | `%s` | %d | %d | %d |\n",
+					tenant.Tenant, ns.Namespace, ns.FlowCount, ns.DisabledFlows, ns.FlowsWithTriggers)
+			}
 		}
+		out.printf("\n")
 	}
-	out.printf("\n")
 
 	renderCountTable(out, "Task types", "Task type", totals.TaskTypeCount, totals.TaskTypeFlowCount)
 	renderCountTable(out, "Trigger types", "Trigger type", totals.TriggerTypeCount, totals.TriggerTypeFlowCount)

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -812,6 +812,8 @@ func renderUsageReportMarkdown(report *usageReport, w io.Writer, detailed bool) 
 	renderPluginDefaultsSection(out, report)
 	renderDeprecatedTaskTypesSection(out, report)
 	renderAffectedFlowsSection(out, report, detailed)
+	renderTriggerTypesSection(out, report)
+	renderPluginFamiliesSection(out, report)
 	renderNotesSection(out, report)
 	renderTaskTypesSection(out, report)
 
@@ -967,16 +969,26 @@ func renderInventorySection(out *markdownWriter, report *usageReport, detailed b
 		}
 		out.printf("\n")
 	}
+}
 
-	renderCountTable(out, "###", "Trigger types", "Trigger type", totals.TriggerTypeCount, totals.TriggerTypeFlowCount)
+// renderTriggerTypesSection renders the trigger-type inventory. Like the task
+// types, it is a standalone section rather than part of ## Inventory.
+func renderTriggerTypesSection(out *markdownWriter, report *usageReport) {
+	renderCountTable(out, "##", "Trigger types", "Trigger type", report.Totals.TriggerTypeCount, report.Totals.TriggerTypeFlowCount)
+}
 
-	out.printf("### Plugin families\n\n")
-	if len(totals.PluginFamilyCount) == 0 {
+// renderPluginFamiliesSection renders the plugin-family roll-up.
+func renderPluginFamiliesSection(out *markdownWriter, report *usageReport) {
+	families := report.Totals.PluginFamilyCount
+
+	out.printf("## Plugin families\n\n")
+	if len(families) == 0 {
 		out.printf("No plugin usage found.\n\n")
 		return
 	}
+
 	out.printf("| Plugin family | Uses |\n| --- | ---: |\n")
-	for _, entry := range sortedCounts(totals.PluginFamilyCount) {
+	for _, entry := range sortedCounts(families) {
 		out.printf("| `%s` | %d |\n", entry.Name, entry.Count)
 	}
 	out.printf("\n")

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -804,12 +804,16 @@ func renderUsageReportMarkdown(report *usageReport, w io.Writer, detailed bool) 
 	out.printf("\nThis report is built from flow sources only: no execution, log or database data is read. ")
 	out.printf("Namespace-level plugin defaults are not part of a flow source and are therefore not visible here.\n\n")
 
+	// The inventory comes first — it answers "how big is this instance?" —
+	// then the migration signals and their detail. The task-type table is long
+	// enough to bury everything after it, so it closes the report.
+	renderInventorySection(out, report, detailed)
 	renderSignalsSection(out, report)
 	renderPluginDefaultsSection(out, report)
 	renderDeprecatedTaskTypesSection(out, report)
 	renderAffectedFlowsSection(out, report, detailed)
-	renderInventorySection(out, report, detailed)
 	renderNotesSection(out, report)
+	renderTaskTypesSection(out, report)
 
 	return out.err
 }
@@ -964,8 +968,7 @@ func renderInventorySection(out *markdownWriter, report *usageReport, detailed b
 		out.printf("\n")
 	}
 
-	renderCountTable(out, "Task types", "Task type", totals.TaskTypeCount, totals.TaskTypeFlowCount)
-	renderCountTable(out, "Trigger types", "Trigger type", totals.TriggerTypeCount, totals.TriggerTypeFlowCount)
+	renderCountTable(out, "###", "Trigger types", "Trigger type", totals.TriggerTypeCount, totals.TriggerTypeFlowCount)
 
 	out.printf("### Plugin families\n\n")
 	if len(totals.PluginFamilyCount) == 0 {
@@ -979,9 +982,17 @@ func renderInventorySection(out *markdownWriter, report *usageReport, detailed b
 	out.printf("\n")
 }
 
-// renderCountTable renders one "type → uses / flows" inventory table.
-func renderCountTable(out *markdownWriter, title, column string, counts, flowCounts map[string]int64) {
-	out.printf("### %s\n\n", title)
+// renderTaskTypesSection closes the report with the task-type inventory. It
+// lives at the end rather than inside ## Inventory because it is by far the
+// longest table, and it is never gated by --detailed.
+func renderTaskTypesSection(out *markdownWriter, report *usageReport) {
+	renderCountTable(out, "##", "Task types", "Task type", report.Totals.TaskTypeCount, report.Totals.TaskTypeFlowCount)
+}
+
+// renderCountTable renders one "type → uses / flows" inventory table under a
+// heading of the given level.
+func renderCountTable(out *markdownWriter, level, title, column string, counts, flowCounts map[string]int64) {
+	out.printf("%s %s\n\n", level, title)
 	if len(counts) == 0 {
 		out.printf("None found.\n\n")
 		return

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -57,8 +57,13 @@ type usageTotals struct {
 	TriggerTypeCount     map[string]int64 `json:"trigger_type_count"`
 	TriggerTypeFlowCount map[string]int64 `json:"trigger_type_flow_count"`
 	PluginFamilyCount    map[string]int64 `json:"plugin_family_count"`
-	SubflowTaskCount     int64            `json:"subflow_task_count"`
-	FlowsUsingSubflow    int              `json:"flows_using_subflow"`
+	// Pebble function usage, extracted from the expression blocks of the flow
+	// sources. Unrecognized calls are counted without their names.
+	PebbleFunctionCount        map[string]int64 `json:"pebble_function_count"`
+	PebbleFunctionFlowCount    map[string]int64 `json:"pebble_function_flow_count"`
+	PebbleUnknownFunctionCount int64            `json:"pebble_unknown_function_count"`
+	SubflowTaskCount           int64            `json:"subflow_task_count"`
+	FlowsUsingSubflow          int              `json:"flows_using_subflow"`
 }
 
 // signalCount is one migration signal: how often it occurs, in how many flows,
@@ -179,6 +184,11 @@ type flowAnalysis struct {
 	ConditionProperty int64
 	PebbleJSON        int64
 	FsLocalDelete     int64
+
+	// PebbleFunctions only ever holds allowlisted function names; everything
+	// else a flow calls is counted anonymously in PebbleUnknownFunctions.
+	PebbleFunctions        map[string]int64
+	PebbleUnknownFunctions int64
 }
 
 // taskContainerKeys are the flow-level keys walked in task context. inputs,
@@ -205,6 +215,82 @@ const fsLocalDeleteType = "io.kestra.plugin.fs.local.Delete"
 // flows that mention `json (` in prose.
 var pebbleJSONPattern = regexp.MustCompile(`(^|[^\w.])json\s*\(`)
 
+// pebbleFunctionNames is the function reference of the Kestra docs. Only these
+// names are ever recorded: anything else a flow calls could be a customer
+// macro, and is counted anonymously instead.
+var pebbleFunctionNames = []string{
+	"render", "renderOnce", "fetchContext", "printContext", "block", "parent", "macro", "i18n",
+	"secret", "credential", "read", "fileURI", "kv", "encrypt", "decrypt",
+	"fromJson", "fromIon", "yaml", "json",
+	"errorLogs", "currentEachOutput", "tasksWithState", "iterationOutput", "parentOutput", "appLink",
+	"now", "max", "min", "range", "uuid", "id", "ksuid", "nanoId", "randomInt", "randomPort",
+	"http", "fileSize", "fileExists", "isFileEmpty",
+	"isWeekend", "isPublicHoliday", "isDayWeekInMonth",
+	"dayOfWeek", "dayOfMonth", "monthOfYear", "hourOfDay",
+}
+
+// pebbleFunctions indexes the allowlist by lowercase name — Pebble resolves
+// function names case-insensitively.
+var pebbleFunctions = newPebbleFunctionIndex(pebbleFunctionNames)
+
+func newPebbleFunctionIndex(names []string) map[string]string {
+	index := make(map[string]string, len(names))
+	for _, name := range names {
+		index[strings.ToLower(name)] = name
+	}
+	return index
+}
+
+// pebbleExpressionPatterns match the two kinds of Pebble block, across lines.
+var pebbleExpressionPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?s)\{\{(.*?)\}\}`),
+	regexp.MustCompile(`(?s)\{%(.*?)%\}`),
+}
+
+// pebbleCallPattern matches an identifier used as a function call. The
+// preceding character is checked separately: Go's regexp has no lookbehind,
+// and consuming the boundary would hide the inner call of render(kv('K')).
+var pebbleCallPattern = regexp.MustCompile(`([A-Za-z_]\w*)\s*\(`)
+
+// collectPebbleFunctions counts the function calls of every expression block in
+// the raw source. Like the `json(` heuristic it works on text, so it still
+// reports something for a flow whose YAML does not parse.
+func (a *flowAnalysis) collectPebbleFunctions(raw string) {
+	for _, pattern := range pebbleExpressionPatterns {
+		for _, block := range pattern.FindAllStringSubmatch(raw, -1) {
+			a.countPebbleCalls(block[1])
+		}
+	}
+}
+
+func (a *flowAnalysis) countPebbleCalls(block string) {
+	for _, match := range pebbleCallPattern.FindAllStringSubmatchIndex(block, -1) {
+		start, end := match[2], match[3]
+		if start > 0 {
+			// A call is only a call when it does not continue a word and is
+			// not a method access (`payload.json(...)`).
+			if previous := block[start-1]; previous == '.' || isWordByte(previous) {
+				continue
+			}
+		}
+
+		if canonical, ok := pebbleFunctions[strings.ToLower(block[start:end])]; ok {
+			a.PebbleFunctions[canonical]++
+			continue
+		}
+		// An unrecognized identifier is never recorded by name: it may be a
+		// customer macro, and the report must stay shareable.
+		a.PebbleUnknownFunctions++
+	}
+}
+
+func isWordByte(char byte) bool {
+	return char == '_' ||
+		(char >= '0' && char <= '9') ||
+		(char >= 'a' && char <= 'z') ||
+		(char >= 'A' && char <= 'Z')
+}
+
 // analyzeFlowSource walks one flow's YAML source and returns the signals it
 // carries. On a YAML parse failure it still returns a usable analysis with
 // ParseFailed set and the raw-text signals filled in, alongside the error.
@@ -214,10 +300,12 @@ func analyzeFlowSource(raw string) (flowAnalysis, error) {
 		TriggerTypes:        map[string]int64{},
 		PluginDefaultsTypes: map[string]int64{},
 		RemovedTasks:        map[string]int64{},
+		PebbleFunctions:     map[string]int64{},
 	}
 
 	// Raw-text signals first: they must survive a YAML parse failure.
 	analysis.PebbleJSON = int64(len(pebbleJSONPattern.FindAllStringIndex(raw, -1)))
+	analysis.collectPebbleFunctions(raw)
 
 	var root map[string]any
 	if err := yaml.Unmarshal([]byte(raw), &root); err != nil {
@@ -625,6 +713,17 @@ func aggregateReport(scans []tenantScan, anon *anonymizer, generatedAt time.Time
 				}
 				acc.add(count, ref)
 			}
+			// The Pebble extraction is text-based, so it also covers flows
+			// whose YAML did not parse; only the per-flow tally needs an
+			// identified flow.
+			for name, occurrences := range flow.PebbleFunctions {
+				tenant.Totals.PebbleFunctionCount[name] += occurrences
+				if ref != "" {
+					tenant.Totals.PebbleFunctionFlowCount[name]++
+				}
+			}
+			tenant.Totals.PebbleUnknownFunctionCount += flow.PebbleUnknownFunctions
+
 			triggerConditions.add(flow.TriggerConditions, ref)
 			conditionProperty.add(flow.ConditionProperty, ref)
 			pebbleJSON.add(flow.PebbleJSON, ref)
@@ -712,11 +811,13 @@ func aggregateReport(scans []tenantScan, anon *anonymizer, generatedAt time.Time
 
 func newUsageTotals() usageTotals {
 	return usageTotals{
-		TaskTypeCount:        map[string]int64{},
-		TaskTypeFlowCount:    map[string]int64{},
-		TriggerTypeCount:     map[string]int64{},
-		TriggerTypeFlowCount: map[string]int64{},
-		PluginFamilyCount:    map[string]int64{},
+		TaskTypeCount:           map[string]int64{},
+		TaskTypeFlowCount:       map[string]int64{},
+		TriggerTypeCount:        map[string]int64{},
+		TriggerTypeFlowCount:    map[string]int64{},
+		PluginFamilyCount:       map[string]int64{},
+		PebbleFunctionCount:     map[string]int64{},
+		PebbleFunctionFlowCount: map[string]int64{},
 	}
 }
 
@@ -735,6 +836,9 @@ func mergeTotals(into *usageTotals, from usageTotals) {
 	mergeCounts(into.TriggerTypeCount, from.TriggerTypeCount)
 	mergeCounts(into.TriggerTypeFlowCount, from.TriggerTypeFlowCount)
 	mergeCounts(into.PluginFamilyCount, from.PluginFamilyCount)
+	mergeCounts(into.PebbleFunctionCount, from.PebbleFunctionCount)
+	mergeCounts(into.PebbleFunctionFlowCount, from.PebbleFunctionFlowCount)
+	into.PebbleUnknownFunctionCount += from.PebbleUnknownFunctionCount
 }
 
 func mergeCounts(into, from map[string]int64) {
@@ -816,6 +920,7 @@ func renderUsageReportMarkdown(report *usageReport, w io.Writer, detailed bool) 
 	renderAffectedFlowsSection(out, report, detailed)
 	renderTriggerTypesSection(out, report)
 	renderPluginFamiliesSection(out, report)
+	renderPebbleFunctionsSection(out, report)
 	renderNotesSection(out, report)
 	renderTaskTypesSection(out, report)
 
@@ -1024,6 +1129,28 @@ func renderCountTable(out *markdownWriter, level, title, column string, counts, 
 	table.render(out)
 }
 
+// renderPebbleFunctionsSection lists the Pebble functions the flows call.
+// Calls that are not part of the documented function set are reported as a
+// single count, never by name.
+func renderPebbleFunctionsSection(out *markdownWriter, report *usageReport) {
+	totals := report.Totals
+
+	out.printf("## Pebble functions\n\n")
+	if len(totals.PebbleFunctionCount) == 0 && totals.PebbleUnknownFunctionCount == 0 {
+		out.printf("None found.\n\n")
+		return
+	}
+
+	table := newMarkdownTable([]string{"Function", "Uses", "Flows"}, []bool{false, true, true})
+	for _, entry := range sortedCounts(totals.PebbleFunctionCount) {
+		table.row(code(entry.Name), count(entry.Count), count(totals.PebbleFunctionFlowCount[entry.Name]))
+	}
+	if totals.PebbleUnknownFunctionCount > 0 {
+		table.row("(unrecognized function-like calls)", count(totals.PebbleUnknownFunctionCount), "-")
+	}
+	table.render(out)
+}
+
 func renderNotesSection(out *markdownWriter, report *usageReport) {
 	out.printf("## Scan notes\n\n")
 	if len(report.Notes) == 0 {
@@ -1034,6 +1161,9 @@ func renderNotesSection(out *markdownWriter, report *usageReport) {
 	}
 	out.printf("- Namespace-level plugin defaults are stored outside flow sources and are not covered by this report.\n")
 	out.printf("- The Pebble `json()` count is a text heuristic over the flow source.\n")
+	out.printf("- Pebble functions are extracted from the `{{ }}` and `{%% %%}` expression blocks of the sources, also a text heuristic; calls that are not documented Kestra functions are counted without their names.\n")
+	// The next section follows straight after: markdown needs the blank line.
+	out.printf("\n")
 }
 
 // markdownTable builds a column-aligned pipe table. The padding is

--- a/src/cli/flows_usage_analysis_test.go
+++ b/src/cli/flows_usage_analysis_test.go
@@ -485,6 +485,67 @@ tasks:
 			unknown: 1,
 		},
 		{
+			name: "quoted arguments are not scanned as pebble",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ outputs.q | jq('.[] | select(.name) | map(.id) | sort_by(.x)') }}"
+`,
+			want:        map[string]int64{},
+			wantFilters: map[string]int64{"jq": 1},
+		},
+		{
+			name: "prose inside a quoted argument counts nothing",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ inputs.note ?? \"managed fields (see docs)\" }}"
+`,
+			want: map[string]int64{},
+		},
+		{
+			name: "a call needs its parenthesis attached",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ now() }} {{ version (2) }}"
+`,
+			want: map[string]int64{"now": 1},
+		},
+		{
+			name: "language keywords are never calls",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{% if(true) %}{{ (a) and(b) or not(c) }}{% endif %}"
+`,
+			want: map[string]int64{},
+		},
+		{
+			name: "a function keeps its name when its argument is stripped",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ secret('MY_KEY') }}"
+`,
+			want: map[string]int64{"secret": 1},
+		},
+		{
 			name: "engine-registered functions are recognized",
 			source: `
 id: f
@@ -1303,7 +1364,7 @@ tasks:
     tasks:
       - id: log
         type: io.kestra.plugin.core.log.Log
-        message: "SENTINEL-SECRET-VALUE {{ sentinelSecretMacro(now()) }} {{ x | sentinelSecretFilter('y') }}"
+        message: "SENTINEL-SECRET-VALUE {{ sentinelSecretMacro(now()) }} {{ x | sentinelSecretFilter('y') }} {{ z | jq('.sentinelJqName(w)') }}"
 pluginDefaults:
   - type: io.kestra.plugin.core.log.Log
     values:
@@ -1336,13 +1397,18 @@ func TestUsageReport_DoesNotLeakFlowValues(t *testing.T) {
 
 			// An undocumented function name may be a customer macro: it is
 			// counted, never named.
-			for _, name := range []string{"sentinelSecretMacro", "sentinelSecretFilter"} {
+			for _, name := range []string{"sentinelSecretMacro", "sentinelSecretFilter", "sentinelJqName"} {
 				if strings.Contains(markdown.String(), name) || strings.Contains(string(data), name) {
 					t.Errorf("the report leaked the unrecognized Pebble name %q", name)
 				}
 			}
+			// The jq program is a quoted argument: it is stripped before the
+			// scan, so it inflates neither bucket.
 			if report.Totals.PebbleUnknownFilterCount != 1 {
 				t.Errorf("unknown pebble filters: got %d, want 1", report.Totals.PebbleUnknownFilterCount)
+			}
+			if report.Totals.PebbleFilterCount["jq"] != 1 {
+				t.Errorf("expected the jq filter itself to be counted, got %v", report.Totals.PebbleFilterCount)
 			}
 			if report.Totals.PebbleUnknownFunctionCount != 1 {
 				t.Errorf("unknown pebble functions: got %d, want 1", report.Totals.PebbleUnknownFunctionCount)

--- a/src/cli/flows_usage_analysis_test.go
+++ b/src/cli/flows_usage_analysis_test.go
@@ -677,6 +677,7 @@ func TestRenderUsageReportMarkdown(t *testing.T) {
 		"| Trigger conditions/preconditions | 3 | 1 |",
 		"io.kestra.plugin.core.trigger.Schedule",
 		"Scope: single-tenant",
+		"- Kestra version: unknown",
 		"The deprecation endpoint could not be read",
 	} {
 		if !strings.Contains(out, want) {

--- a/src/cli/flows_usage_analysis_test.go
+++ b/src/cli/flows_usage_analysis_test.go
@@ -407,6 +407,107 @@ triggers:
 	}
 }
 
+func TestAnalyzeFlowSource_PebbleFunctions(t *testing.T) {
+	cases := []struct {
+		name    string
+		source  string
+		want    map[string]int64
+		unknown int64
+	}{
+		{
+			name: "nested calls in one block",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ render(kv('K')) }}"
+`,
+			want: map[string]int64{"render": 1, "kv": 1},
+		},
+		{
+			name: "functions inside a tag block",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{% if now() %}{{ uuid() }}{% endif %}"
+`,
+			want: map[string]int64{"now": 1, "uuid": 1},
+		},
+		{
+			name:   "multiline expression",
+			source: "id: f\nnamespace: ns\ntasks:\n  - id: log\n    type: io.kestra.plugin.core.log.Log\n    message: |\n      {{ secret(\n        'MY_KEY'\n      ) }}\n",
+			want:   map[string]int64{"secret": 1},
+		},
+		{
+			name: "function names are case-insensitive",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ fromjson(inputs.raw) }} {{ FROMJSON(inputs.other) }}"
+`,
+			want: map[string]int64{"fromJson": 2},
+		},
+		{
+			name: "method calls and text outside expression blocks are ignored",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: query
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    sql: SELECT COUNT(*) FROM orders
+    message: myfunc(1)
+    other: "{{ payload.json(x) }}"
+`,
+			want: map[string]int64{},
+		},
+		{
+			name: "unknown identifiers are counted without their name",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ mycompanyhelper(now()) }}"
+`,
+			want:    map[string]int64{"now": 1},
+			unknown: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			analysis := mustAnalyze(t, tc.source)
+
+			if len(analysis.PebbleFunctions) != len(tc.want) {
+				t.Fatalf("pebble functions: got %v, want %v", analysis.PebbleFunctions, tc.want)
+			}
+			for name, want := range tc.want {
+				if got := analysis.PebbleFunctions[name]; got != want {
+					t.Errorf("function %s: got %d, want %d", name, got, want)
+				}
+			}
+			if analysis.PebbleUnknownFunctions != tc.unknown {
+				t.Errorf("unknown functions: got %d, want %d", analysis.PebbleUnknownFunctions, tc.unknown)
+			}
+			for name := range analysis.PebbleFunctions {
+				if _, ok := pebbleFunctions[strings.ToLower(name)]; !ok {
+					t.Errorf("%q is not an allowlisted function name", name)
+				}
+			}
+		})
+	}
+}
+
 func TestAnalyzeFlowSource_ParseFailureKeepsTextSignals(t *testing.T) {
 	analysis, err := analyzeFlowSource("id: broken\n\ttabs: are: not: yaml\n{{ json(x) }}")
 	if err == nil {
@@ -417,6 +518,9 @@ func TestAnalyzeFlowSource_ParseFailureKeepsTextSignals(t *testing.T) {
 	}
 	if analysis.PebbleJSON != 1 {
 		t.Errorf("pebble json: got %d, want 1", analysis.PebbleJSON)
+	}
+	if analysis.PebbleFunctions["json"] != 1 {
+		t.Errorf("pebble functions: got %v, want one json call", analysis.PebbleFunctions)
 	}
 }
 
@@ -859,6 +963,7 @@ func TestRenderUsageReportMarkdown_SectionOrder(t *testing.T) {
 		"## Affected flows",
 		"## Trigger types",
 		"## Plugin families",
+		"## Pebble functions",
 		"## Scan notes",
 		"## Task types",
 	}
@@ -905,6 +1010,50 @@ func TestRenderUsageReportMarkdown_EmptyReportKeepsTrailingSections(t *testing.T
 		if !strings.Contains(out, want) {
 			t.Errorf("the empty report is missing %q", want)
 		}
+	}
+}
+
+func TestRenderUsageReportMarkdown_PebbleFunctionsSection(t *testing.T) {
+	source := `
+id: pebble-flow
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ render(kv('K')) }} {{ mycompanyhelper(x) }}"
+`
+	report := testReport(t, true, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{mustAnalyze(t, source)}}})
+
+	var buf bytes.Buffer
+	if err := renderUsageReportMarkdown(report, &buf, false); err != nil {
+		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
+	}
+	out := collapseSpaces(buf.String())
+
+	for _, want := range []string{
+		"## Pebble functions",
+		"| Function | Uses | Flows |",
+		"| `kv` | 1 | 1 |",
+		"| `render` | 1 | 1 |",
+		"| (unrecognized function-like calls) | 1 | - |",
+		"Pebble functions are extracted from the `{{ }}` and `{% %}` expression blocks",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the report is missing %q", want)
+		}
+	}
+	if strings.Contains(out, "mycompanyhelper") {
+		t.Error("the report must not name an unrecognized function")
+	}
+
+	// A report without any expression renders the empty case.
+	empty := testReport(t, true, []tenantScan{{Tenant: "main"}})
+	buf.Reset()
+	if err := renderUsageReportMarkdown(empty, &buf, false); err != nil {
+		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
+	}
+	if !strings.Contains(collapseSpaces(buf.String()), "## Pebble functions\n\nNone found.") {
+		t.Error("expected the empty Pebble functions case")
 	}
 }
 
@@ -972,6 +1121,15 @@ func TestUsageReportJSONRoundTrip(t *testing.T) {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		t.Fatalf("failed to unmarshal into a map: %v", err)
 	}
+	totals, ok := raw["totals"].(map[string]any)
+	if !ok {
+		t.Fatal("the totals object is missing from the JSON report")
+	}
+	for _, key := range []string{"pebble_function_count", "pebble_function_flow_count", "pebble_unknown_function_count"} {
+		if _, ok := totals[key]; !ok {
+			t.Errorf("missing JSON totals key %q", key)
+		}
+	}
 	for _, key := range []string{"generated_at", "kestractl_version", "anonymized", "scope", "totals", "signals", "tenants"} {
 		if _, ok := raw[key]; !ok {
 			t.Errorf("missing JSON key %q", key)
@@ -999,7 +1157,7 @@ tasks:
     tasks:
       - id: log
         type: io.kestra.plugin.core.log.Log
-        message: SENTINEL-SECRET-VALUE
+        message: "SENTINEL-SECRET-VALUE {{ sentinelSecretMacro(now()) }}"
 pluginDefaults:
   - type: io.kestra.plugin.core.log.Log
     values:
@@ -1028,6 +1186,19 @@ func TestUsageReport_DoesNotLeakFlowValues(t *testing.T) {
 			}
 			if strings.Contains(string(data), sentinel) {
 				t.Error("the JSON report leaked a flow property value")
+			}
+
+			// An undocumented function name may be a customer macro: it is
+			// counted, never named.
+			const macro = "sentinelSecretMacro"
+			if strings.Contains(markdown.String(), macro) || strings.Contains(string(data), macro) {
+				t.Error("the report leaked an unrecognized Pebble function name")
+			}
+			if report.Totals.PebbleUnknownFunctionCount != 1 {
+				t.Errorf("unknown pebble functions: got %d, want 1", report.Totals.PebbleUnknownFunctionCount)
+			}
+			if report.Totals.PebbleFunctionCount["now"] != 1 {
+				t.Errorf("expected the documented call to be counted, got %v", report.Totals.PebbleFunctionCount)
 			}
 
 			// Sanity check: the signal itself is still reported.

--- a/src/cli/flows_usage_analysis_test.go
+++ b/src/cli/flows_usage_analysis_test.go
@@ -672,6 +672,7 @@ func TestRenderUsageReportMarkdown(t *testing.T) {
 		"## Affected flows",
 		"## Inventory",
 		"## Scan notes",
+		"## Task types",
 		"| Task ForEachItem | 1 | 1 |",
 		"| Task ForEach | 0 | 0 |",
 		"| Trigger conditions/preconditions | 3 | 1 |",
@@ -737,6 +738,46 @@ func TestRenderUsageReportMarkdown_ServerDeprecations(t *testing.T) {
 	}
 }
 
+func TestRenderUsageReportMarkdown_SectionOrder(t *testing.T) {
+	analysis := mustAnalyze(t, nestedFlowSource)
+	report := testReport(t, true, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{analysis}}})
+
+	var buf bytes.Buffer
+	if err := renderUsageReportMarkdown(report, &buf, true); err != nil {
+		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
+	}
+	out := buf.String()
+
+	// The inventory opens the report and the long task-type table closes it.
+	sections := []string{
+		"## Inventory",
+		"## Migration signals",
+		"## pluginDefaults detail",
+		"## Affected flows",
+		"## Scan notes",
+		"## Task types",
+	}
+	previous := -1
+	for _, section := range sections {
+		index := strings.Index(out, section)
+		if index < 0 {
+			t.Fatalf("the report is missing %q", section)
+		}
+		if index <= previous {
+			t.Errorf("%q is out of order (index %d, previous section ended at %d)", section, index, previous)
+		}
+		previous = index
+	}
+
+	// Trigger types and plugin families stay inside the inventory section.
+	if strings.Index(out, "### Trigger types") > strings.Index(out, "## Migration signals") {
+		t.Error("### Trigger types must stay inside ## Inventory")
+	}
+	if strings.Index(out, "### Plugin families") > strings.Index(out, "## Migration signals") {
+		t.Error("### Plugin families must stay inside ## Inventory")
+	}
+}
+
 func TestRenderUsageReportMarkdown_DetailedGating(t *testing.T) {
 	analysis := mustAnalyze(t, nestedFlowSource)
 	report := testReport(t, true, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{analysis}}})
@@ -760,7 +801,7 @@ func TestRenderUsageReportMarkdown_DetailedGating(t *testing.T) {
 		t.Error("expected the summary report to point at --detailed")
 	}
 	// Everything else is unchanged by the flag.
-	for _, want := range []string{"## Migration signals", "| Task ForEachItem | 1 | 1 |", "| Namespaces | 1 |", "### Task types"} {
+	for _, want := range []string{"## Migration signals", "| Task ForEachItem | 1 | 1 |", "| Namespaces | 1 |", "## Task types"} {
 		if !strings.Contains(summary, want) {
 			t.Errorf("the summary report is missing %q", want)
 		}

--- a/src/cli/flows_usage_analysis_test.go
+++ b/src/cli/flows_usage_analysis_test.go
@@ -485,6 +485,31 @@ tasks:
 			unknown: 1,
 		},
 		{
+			name: "engine-registered functions are recognized",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ subflow('ns', 'flow') }} {{ assets('id') }}"
+`,
+			want: map[string]int64{"subflow": 1, "assets": 1},
+		},
+		{
+			name: "the deprecated json filter and the raw filter are recognized",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ inputs.payload | json }} {{ inputs.text | raw }}"
+`,
+			want:        map[string]int64{},
+			wantFilters: map[string]int64{"json": 1, "raw": 1},
+		},
+		{
 			name: "filters with arguments are filters, not unknown functions",
 			source: `
 id: f

--- a/src/cli/flows_usage_analysis_test.go
+++ b/src/cli/flows_usage_analysis_test.go
@@ -409,10 +409,12 @@ triggers:
 
 func TestAnalyzeFlowSource_PebbleFunctions(t *testing.T) {
 	cases := []struct {
-		name    string
-		source  string
-		want    map[string]int64
-		unknown int64
+		name          string
+		source        string
+		want          map[string]int64
+		unknown       int64
+		wantFilters   map[string]int64
+		unknownFilter int64
 	}{
 		{
 			name: "nested calls in one block",
@@ -482,6 +484,97 @@ tasks:
 			want:    map[string]int64{"now": 1},
 			unknown: 1,
 		},
+		{
+			name: "filters with arguments are filters, not unknown functions",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ now() | date('yyyy-MM-dd') }}"
+`,
+			want:        map[string]int64{"now": 1},
+			wantFilters: map[string]int64{"date": 1},
+		},
+		{
+			name: "bare and chained filters are counted",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ inputs.name | trim | lower }}"
+`,
+			want:        map[string]int64{},
+			wantFilters: map[string]int64{"trim": 1, "lower": 1},
+		},
+		{
+			name: "a parenthesized filter is counted exactly once",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ items | join(',') }}"
+`,
+			want:        map[string]int64{},
+			wantFilters: map[string]int64{"join": 1},
+		},
+		{
+			name: "filter names are case-insensitive",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ x | DATE('x') }} {{ y | Upper }}"
+`,
+			want:        map[string]int64{},
+			wantFilters: map[string]int64{"date": 1, "upper": 1},
+		},
+		{
+			name: "a boolean or is not a filter",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ a || b(1) }}"
+`,
+			want:    map[string]int64{},
+			unknown: 1,
+		},
+		{
+			name: "unknown filters go to their own anonymous bucket",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ y | customFilter(2) }}"
+`,
+			want:          map[string]int64{},
+			unknownFilter: 1,
+		},
+		{
+			name: "foreign templating stays in the unknown function bucket",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: query
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    sql: "SELECT * FROM {{ ref('my_model') }}"
+`,
+			want:    map[string]int64{},
+			unknown: 1,
+		},
 	}
 
 	for _, tc := range cases {
@@ -499,9 +592,25 @@ tasks:
 			if analysis.PebbleUnknownFunctions != tc.unknown {
 				t.Errorf("unknown functions: got %d, want %d", analysis.PebbleUnknownFunctions, tc.unknown)
 			}
+			if len(analysis.PebbleFilters) != len(tc.wantFilters) {
+				t.Fatalf("pebble filters: got %v, want %v", analysis.PebbleFilters, tc.wantFilters)
+			}
+			for name, want := range tc.wantFilters {
+				if got := analysis.PebbleFilters[name]; got != want {
+					t.Errorf("filter %s: got %d, want %d", name, got, want)
+				}
+			}
+			if analysis.PebbleUnknownFilters != tc.unknownFilter {
+				t.Errorf("unknown filters: got %d, want %d", analysis.PebbleUnknownFilters, tc.unknownFilter)
+			}
 			for name := range analysis.PebbleFunctions {
 				if _, ok := pebbleFunctions[strings.ToLower(name)]; !ok {
 					t.Errorf("%q is not an allowlisted function name", name)
+				}
+			}
+			for name := range analysis.PebbleFilters {
+				if _, ok := pebbleFilters[strings.ToLower(name)]; !ok {
+					t.Errorf("%q is not an allowlisted filter name", name)
 				}
 			}
 		})
@@ -963,7 +1072,7 @@ func TestRenderUsageReportMarkdown_SectionOrder(t *testing.T) {
 		"## Affected flows",
 		"## Trigger types",
 		"## Plugin families",
-		"## Pebble functions",
+		"## Pebble functions and filters",
 		"## Scan notes",
 		"## Task types",
 	}
@@ -1020,7 +1129,7 @@ namespace: ns
 tasks:
   - id: log
     type: io.kestra.plugin.core.log.Log
-    message: "{{ render(kv('K')) }} {{ mycompanyhelper(x) }}"
+    message: "{{ render(kv('K')) }} {{ mycompanyhelper(x) }} {{ y | date('yyyy') | trim }} {{ z | customFilter(1) }}"
 `
 	report := testReport(t, true, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{mustAnalyze(t, source)}}})
 
@@ -1031,19 +1140,27 @@ tasks:
 	out := collapseSpaces(buf.String())
 
 	for _, want := range []string{
-		"## Pebble functions",
+		"## Pebble functions and filters",
+		"### Functions",
 		"| Function | Uses | Flows |",
 		"| `kv` | 1 | 1 |",
 		"| `render` | 1 | 1 |",
 		"| (unrecognized function-like calls) | 1 | - |",
-		"Pebble functions are extracted from the `{{ }}` and `{% %}` expression blocks",
+		"### Filters",
+		"| Filter | Uses | Flows |",
+		"| `date` | 1 | 1 |",
+		"| `trim` | 1 | 1 |",
+		"| (unrecognized filters) | 1 | - |",
+		"Pebble functions and filters are extracted from the `{{ }}` and `{% %}` expression blocks",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("the report is missing %q", want)
 		}
 	}
-	if strings.Contains(out, "mycompanyhelper") {
-		t.Error("the report must not name an unrecognized function")
+	for _, unwanted := range []string{"mycompanyhelper", "customFilter"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("the report must not name %q", unwanted)
+		}
 	}
 
 	// A report without any expression renders the empty case.
@@ -1052,8 +1169,9 @@ tasks:
 	if err := renderUsageReportMarkdown(empty, &buf, false); err != nil {
 		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
 	}
-	if !strings.Contains(collapseSpaces(buf.String()), "## Pebble functions\n\nNone found.") {
-		t.Error("expected the empty Pebble functions case")
+	empty2 := collapseSpaces(buf.String())
+	if !strings.Contains(empty2, "### Functions\n\nNone found.") || !strings.Contains(empty2, "### Filters\n\nNone found.") {
+		t.Error("expected the empty Pebble functions and filters case")
 	}
 }
 
@@ -1125,7 +1243,10 @@ func TestUsageReportJSONRoundTrip(t *testing.T) {
 	if !ok {
 		t.Fatal("the totals object is missing from the JSON report")
 	}
-	for _, key := range []string{"pebble_function_count", "pebble_function_flow_count", "pebble_unknown_function_count"} {
+	for _, key := range []string{
+		"pebble_function_count", "pebble_function_flow_count", "pebble_unknown_function_count",
+		"pebble_filter_count", "pebble_filter_flow_count", "pebble_unknown_filter_count",
+	} {
 		if _, ok := totals[key]; !ok {
 			t.Errorf("missing JSON totals key %q", key)
 		}
@@ -1157,7 +1278,7 @@ tasks:
     tasks:
       - id: log
         type: io.kestra.plugin.core.log.Log
-        message: "SENTINEL-SECRET-VALUE {{ sentinelSecretMacro(now()) }}"
+        message: "SENTINEL-SECRET-VALUE {{ sentinelSecretMacro(now()) }} {{ x | sentinelSecretFilter('y') }}"
 pluginDefaults:
   - type: io.kestra.plugin.core.log.Log
     values:
@@ -1190,9 +1311,13 @@ func TestUsageReport_DoesNotLeakFlowValues(t *testing.T) {
 
 			// An undocumented function name may be a customer macro: it is
 			// counted, never named.
-			const macro = "sentinelSecretMacro"
-			if strings.Contains(markdown.String(), macro) || strings.Contains(string(data), macro) {
-				t.Error("the report leaked an unrecognized Pebble function name")
+			for _, name := range []string{"sentinelSecretMacro", "sentinelSecretFilter"} {
+				if strings.Contains(markdown.String(), name) || strings.Contains(string(data), name) {
+					t.Errorf("the report leaked the unrecognized Pebble name %q", name)
+				}
+			}
+			if report.Totals.PebbleUnknownFilterCount != 1 {
+				t.Errorf("unknown pebble filters: got %d, want 1", report.Totals.PebbleUnknownFilterCount)
 			}
 			if report.Totals.PebbleUnknownFunctionCount != 1 {
 				t.Errorf("unknown pebble functions: got %d, want 1", report.Totals.PebbleUnknownFunctionCount)

--- a/src/cli/flows_usage_analysis_test.go
+++ b/src/cli/flows_usage_analysis_test.go
@@ -740,7 +740,15 @@ func TestRenderUsageReportMarkdown_ServerDeprecations(t *testing.T) {
 
 func TestRenderUsageReportMarkdown_SectionOrder(t *testing.T) {
 	analysis := mustAnalyze(t, nestedFlowSource)
-	report := testReport(t, true, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{analysis}}})
+	report := testReport(t, true, []tenantScan{{
+		Tenant:              "main",
+		Flows:               []flowAnalysis{analysis},
+		DeprecatedAvailable: true,
+		Deprecated: []deprecatedFlow{{
+			Namespace: "prod.team.data", FlowID: "nested-flow", TaskCount: 1,
+			Tasks: []deprecatedTask{{TaskType: "io.kestra.core.tasks.flows.EachSequential"}},
+		}},
+	}})
 
 	var buf bytes.Buffer
 	if err := renderUsageReportMarkdown(report, &buf, true); err != nil {
@@ -753,7 +761,10 @@ func TestRenderUsageReportMarkdown_SectionOrder(t *testing.T) {
 		"## Inventory",
 		"## Migration signals",
 		"## pluginDefaults detail",
+		"## Deprecated task types (server-reported)",
 		"## Affected flows",
+		"## Trigger types",
+		"## Plugin families",
 		"## Scan notes",
 		"## Task types",
 	}
@@ -769,12 +780,37 @@ func TestRenderUsageReportMarkdown_SectionOrder(t *testing.T) {
 		previous = index
 	}
 
-	// Trigger types and plugin families stay inside the inventory section.
-	if strings.Index(out, "### Trigger types") > strings.Index(out, "## Migration signals") {
-		t.Error("### Trigger types must stay inside ## Inventory")
+	// Only the per-namespace table is left nested under ## Inventory.
+	if index := strings.Index(out, "### Flows per namespace"); index < 0 || index > strings.Index(out, "## Migration signals") {
+		t.Error("### Flows per namespace must stay inside ## Inventory")
 	}
-	if strings.Index(out, "### Plugin families") > strings.Index(out, "## Migration signals") {
-		t.Error("### Plugin families must stay inside ## Inventory")
+	for _, unwanted := range []string{"### Trigger types", "### Plugin families", "### Task types"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("%q must be a top-level section now", unwanted)
+		}
+	}
+}
+
+// A report with nothing in it must still render every trailing section: the
+// empty plugin-families case returns early from its own renderer only.
+func TestRenderUsageReportMarkdown_EmptyReportKeepsTrailingSections(t *testing.T) {
+	report := testReport(t, true, []tenantScan{{Tenant: "main"}})
+
+	var buf bytes.Buffer
+	if err := renderUsageReportMarkdown(report, &buf, false); err != nil {
+		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"## Plugin families",
+		"No plugin usage found.",
+		"## Scan notes",
+		"## Task types",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the empty report is missing %q", want)
+		}
 	}
 }
 

--- a/src/cli/flows_usage_analysis_test.go
+++ b/src/cli/flows_usage_analysis_test.go
@@ -660,7 +660,7 @@ func TestRenderUsageReportMarkdown(t *testing.T) {
 	report := testReport(t, true, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{analysis}}})
 
 	var buf bytes.Buffer
-	if err := renderUsageReportMarkdown(report, &buf); err != nil {
+	if err := renderUsageReportMarkdown(report, &buf, true); err != nil {
 		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
 	}
 	out := buf.String()
@@ -713,7 +713,7 @@ func TestRenderUsageReportMarkdown_ServerDeprecations(t *testing.T) {
 	report := testReport(t, true, []tenantScan{scan})
 
 	var buf bytes.Buffer
-	if err := renderUsageReportMarkdown(report, &buf); err != nil {
+	if err := renderUsageReportMarkdown(report, &buf, true); err != nil {
 		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
 	}
 	out := buf.String()
@@ -734,6 +734,46 @@ func TestRenderUsageReportMarkdown_ServerDeprecations(t *testing.T) {
 	// Task ids are user identifiers and must never be rendered.
 	if strings.Contains(out, "taskId") {
 		t.Error("the report must not carry task ids")
+	}
+}
+
+func TestRenderUsageReportMarkdown_DetailedGating(t *testing.T) {
+	analysis := mustAnalyze(t, nestedFlowSource)
+	report := testReport(t, true, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{analysis}}})
+
+	render := func(detailed bool) string {
+		t.Helper()
+		var buf bytes.Buffer
+		if err := renderUsageReportMarkdown(report, &buf, detailed); err != nil {
+			t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
+		}
+		return buf.String()
+	}
+
+	summary := render(false)
+	for _, unwanted := range []string{"### Flows per namespace", "## Affected flows"} {
+		if strings.Contains(summary, unwanted) {
+			t.Errorf("the summary report must not contain %q", unwanted)
+		}
+	}
+	if !strings.Contains(summary, "_Run with --detailed to list the affected flows._") {
+		t.Error("expected the summary report to point at --detailed")
+	}
+	// Everything else is unchanged by the flag.
+	for _, want := range []string{"## Migration signals", "| Task ForEachItem | 1 | 1 |", "| Namespaces | 1 |", "### Task types"} {
+		if !strings.Contains(summary, want) {
+			t.Errorf("the summary report is missing %q", want)
+		}
+	}
+
+	detailed := render(true)
+	for _, want := range []string{"### Flows per namespace", "## Affected flows"} {
+		if !strings.Contains(detailed, want) {
+			t.Errorf("the detailed report is missing %q", want)
+		}
+	}
+	if strings.Contains(detailed, "_Run with --detailed") {
+		t.Error("the detailed report must not point at --detailed")
 	}
 }
 
@@ -804,7 +844,7 @@ func TestUsageReport_DoesNotLeakFlowValues(t *testing.T) {
 			report := testReport(t, anonymize, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{analysis}}})
 
 			var markdown bytes.Buffer
-			if err := renderUsageReportMarkdown(report, &markdown); err != nil {
+			if err := renderUsageReportMarkdown(report, &markdown, true); err != nil {
 				t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
 			}
 			data, err := json.Marshal(report)

--- a/src/cli/flows_usage_analysis_test.go
+++ b/src/cli/flows_usage_analysis_test.go
@@ -1,0 +1,886 @@
+package cli
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// nestedFlowSource exercises the walker end to end: nested flowables, the
+// error/finally/afterExecution containers, trigger conditions and
+// preconditions, an SLA condition and pluginDefaults.
+const nestedFlowSource = `
+id: nested-flow
+namespace: prod.team.data
+disabled: true
+inputs:
+  - id: target
+    type: STRING
+tasks:
+  - id: branch
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ inputs.target == 'a' }}"
+    then:
+      - id: each
+        type: io.kestra.core.tasks.flows.EachSequential
+        tasks:
+          - id: log
+            type: io.kestra.plugin.core.log.Log
+    else:
+      - id: switch
+        type: io.kestra.plugin.core.flow.Switch
+        cases:
+          a:
+            - id: call
+              type: io.kestra.plugin.core.flow.Subflow
+  - id: loop
+    type: io.kestra.plugin.core.flow.ForEachItem
+    tasks:
+      - id: purge
+        type: io.kestra.plugin.fs.local.Delete
+errors:
+  - id: on-error
+    type: io.kestra.plugin.core.log.Log
+finally:
+  - id: cleanup
+    type: io.kestra.plugin.core.log.Log
+afterExecution:
+  - id: after
+    type: io.kestra.plugin.core.log.Log
+triggers:
+  - id: schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 * * * *"
+    conditions:
+      - type: io.kestra.plugin.core.condition.DayWeekInMonth
+      - type: io.kestra.plugin.core.condition.WeekendCondition
+  - id: on-flow
+    type: io.kestra.plugin.core.trigger.Flow
+    preconditions:
+      flows:
+        - namespace: prod.team.data
+checks:
+  - id: freshness
+    condition: "{{ trigger.date }}"
+sla:
+  - id: max-duration
+    type: MAX_DURATION
+    condition: "{{ execution.duration > 60 }}"
+pluginDefaults:
+  - type: io.kestra.plugin.core.log.Log
+    forced: true
+    values:
+      level: INFO
+  - type: io.kestra.plugin.jdbc.postgresql.Query
+    values:
+      url: jdbc:postgresql://db/app
+`
+
+func mustAnalyze(t *testing.T, source string) flowAnalysis {
+	t.Helper()
+	analysis, err := analyzeFlowSource(source)
+	if err != nil {
+		t.Fatalf("analyzeFlowSource returned an error: %v", err)
+	}
+	return analysis
+}
+
+func TestAnalyzeFlowSource_Walker(t *testing.T) {
+	analysis := mustAnalyze(t, nestedFlowSource)
+
+	if analysis.Namespace != "prod.team.data" || analysis.FlowID != "nested-flow" {
+		t.Fatalf("unexpected flow identity: %q/%q", analysis.Namespace, analysis.FlowID)
+	}
+	if !analysis.Disabled || !analysis.HasInputs || !analysis.HasTriggers {
+		t.Fatalf("unexpected flags: %+v", analysis)
+	}
+
+	wantTasks := map[string]int64{
+		"io.kestra.plugin.core.flow.If":             1,
+		"io.kestra.core.tasks.flows.EachSequential": 1,
+		"io.kestra.plugin.core.flow.Switch":         1,
+		"io.kestra.plugin.core.flow.Subflow":        1,
+		"io.kestra.plugin.core.flow.ForEachItem":    1,
+		"io.kestra.plugin.fs.local.Delete":          1,
+		// error, finally, afterExecution and the nested EachSequential task.
+		"io.kestra.plugin.core.log.Log": 4,
+	}
+	for typeName, want := range wantTasks {
+		if got := analysis.TaskTypes[typeName]; got != want {
+			t.Errorf("task type %s: got %d, want %d", typeName, got, want)
+		}
+	}
+	if len(analysis.TaskTypes) != len(wantTasks) {
+		t.Errorf("unexpected task types collected: %v", analysis.TaskTypes)
+	}
+	if analysis.TaskTypes["STRING"] != 0 {
+		t.Error("input declarations must not be counted as tasks")
+	}
+
+	wantTriggers := map[string]int64{
+		"io.kestra.plugin.core.trigger.Schedule": 1,
+		"io.kestra.plugin.core.trigger.Flow":     1,
+	}
+	for typeName, want := range wantTriggers {
+		if got := analysis.TriggerTypes[typeName]; got != want {
+			t.Errorf("trigger type %s: got %d, want %d", typeName, got, want)
+		}
+	}
+	if len(analysis.TriggerTypes) != len(wantTriggers) {
+		t.Errorf("unexpected trigger types collected: %v", analysis.TriggerTypes)
+	}
+	if analysis.TaskTypes["io.kestra.plugin.core.condition.DayWeekInMonth"] != 0 {
+		t.Error("trigger conditions must not be counted as tasks")
+	}
+
+	if analysis.RemovedTasks["EachSequential"] != 1 || analysis.RemovedTasks["ForEachItem"] != 1 {
+		t.Errorf("unexpected removed tasks: %v", analysis.RemovedTasks)
+	}
+	if analysis.SubflowTasks != 1 {
+		t.Errorf("subflow tasks: got %d, want 1", analysis.SubflowTasks)
+	}
+	if analysis.FsLocalDelete != 1 {
+		t.Errorf("fs.local.Delete: got %d, want 1", analysis.FsLocalDelete)
+	}
+	// Two `conditions` entries plus one `preconditions` entry.
+	if analysis.TriggerConditions != 3 {
+		t.Errorf("trigger conditions: got %d, want 3", analysis.TriggerConditions)
+	}
+	// The check and the SLA carry a `condition`; the If task's own `condition`
+	// survives in 2.0 and must not be counted.
+	if analysis.ConditionProperty != 2 {
+		t.Errorf("condition property: got %d, want 2", analysis.ConditionProperty)
+	}
+	if analysis.PluginDefaultsEntries != 2 || analysis.PluginDefaultsForced != 1 {
+		t.Errorf("plugin defaults: %d entries, %d forced", analysis.PluginDefaultsEntries, analysis.PluginDefaultsForced)
+	}
+	if analysis.PluginDefaultsTypes["io.kestra.plugin.jdbc.postgresql.Query"] != 1 {
+		t.Errorf("unexpected plugin default types: %v", analysis.PluginDefaultsTypes)
+	}
+}
+
+func TestAnalyzeFlowSource_Signals(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+		check  func(t *testing.T, a flowAnalysis)
+	}{
+		{
+			name: "modern subflow spelling",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: call
+    type: io.kestra.plugin.core.flow.Subflow
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if a.SubflowTasks != 1 {
+					t.Errorf("subflow tasks: got %d, want 1", a.SubflowTasks)
+				}
+			},
+		},
+		{
+			name: "legacy subflow spelling",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: call
+    type: io.kestra.core.tasks.flows.Flow
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if a.SubflowTasks != 1 {
+					t.Errorf("subflow tasks: got %d, want 1", a.SubflowTasks)
+				}
+			},
+		},
+		{
+			name: "legacy each parallel is a removed task",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: fan
+    type: io.kestra.core.tasks.flows.EachParallel
+    tasks:
+      - id: inner
+        type: io.kestra.plugin.core.log.Log
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if a.RemovedTasks["EachParallel"] != 1 {
+					t.Errorf("unexpected removed tasks: %v", a.RemovedTasks)
+				}
+				if a.TaskTypes["io.kestra.plugin.core.log.Log"] != 1 {
+					t.Error("nested task under a removed flowable must still be counted")
+				}
+			},
+		},
+		{
+			name: "pebble json positives",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ json(inputs.raw) }} {{ json (inputs.other) }}"
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if a.PebbleJSON != 2 {
+					t.Errorf("pebble json: got %d, want 2", a.PebbleJSON)
+				}
+			},
+		},
+		{
+			name: "pebble json negatives",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    message: "{{ fromJson(x) }} {{ toJson(y) }} {{ vars.payload.json(z) }}"
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if a.PebbleJSON != 0 {
+					t.Errorf("pebble json: got %d, want 0", a.PebbleJSON)
+				}
+			},
+		},
+		{
+			name: "input declarations are not tasks",
+			source: `
+id: f
+namespace: ns
+inputs:
+  - id: name
+    type: STRING
+  - id: count
+    type: INT
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+    format: STRING
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if len(a.TaskTypes) != 1 || a.TaskTypes["io.kestra.plugin.core.log.Log"] != 1 {
+					t.Errorf("unexpected task types: %v", a.TaskTypes)
+				}
+				if !a.HasInputs {
+					t.Error("expected the flow to be flagged as having inputs")
+				}
+			},
+		},
+		{
+			name: "dotless types inside task properties are ignored",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: query
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    fetchType: FETCH
+    columns:
+      - name: id
+        type: INTEGER
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if len(a.TaskTypes) != 1 {
+					t.Errorf("unexpected task types: %v", a.TaskTypes)
+				}
+			},
+		},
+		{
+			name: "taskDefaults alias is out of scope",
+			source: `
+id: f
+namespace: ns
+taskDefaults:
+  - type: io.kestra.plugin.core.log.Log
+    forced: true
+    values:
+      level: INFO
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if a.PluginDefaultsEntries != 0 {
+					t.Errorf("taskDefaults must not be counted, got %d entries", a.PluginDefaultsEntries)
+				}
+			},
+		},
+		{
+			name: "task condition properties are not counted",
+			source: `
+id: f
+namespace: ns
+tasks:
+  - id: branch
+    type: io.kestra.plugin.core.flow.If
+    condition: "{{ inputs.flag }}"
+    then:
+      - id: log
+        type: io.kestra.plugin.core.log.Log
+        condition: "{{ inputs.other }}"
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if a.ConditionProperty != 0 {
+					t.Errorf("condition property: got %d, want 0 (the If task keeps `condition` in 2.0)", a.ConditionProperty)
+				}
+			},
+		},
+		{
+			name: "flow-level checks and triggers carry the condition signal",
+			source: `
+id: f
+namespace: ns
+checks:
+  - id: freshness
+    condition: "{{ trigger.date }}"
+triggers:
+  - id: schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 * * * *"
+    condition: "{{ flow.namespace }}"
+tasks:
+  - id: log
+    type: io.kestra.plugin.core.log.Log
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if a.ConditionProperty != 2 {
+					t.Errorf("condition property: got %d, want 2", a.ConditionProperty)
+				}
+			},
+		},
+		{
+			name: "trigger conditions are counted per entry",
+			source: `
+id: f
+namespace: ns
+triggers:
+  - id: schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 * * * *"
+    conditions:
+      - type: io.kestra.plugin.core.condition.DayWeekInMonth
+      - type: io.kestra.plugin.core.condition.WeekendCondition
+      - type: io.kestra.plugin.core.condition.DateTimeBetween
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if a.TriggerConditions != 3 {
+					t.Errorf("trigger conditions: got %d, want 3", a.TriggerConditions)
+				}
+			},
+		},
+		{
+			name: "triggers without conditions raise no signal",
+			source: `
+id: f
+namespace: ns
+triggers:
+  - id: schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 * * * *"
+`,
+			check: func(t *testing.T, a flowAnalysis) {
+				if a.TriggerConditions != 0 || a.ConditionProperty != 0 {
+					t.Errorf("unexpected condition signals: %+v", a)
+				}
+				if !a.HasTriggers {
+					t.Error("expected the flow to be flagged as having triggers")
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.check(t, mustAnalyze(t, tc.source))
+		})
+	}
+}
+
+func TestAnalyzeFlowSource_ParseFailureKeepsTextSignals(t *testing.T) {
+	analysis, err := analyzeFlowSource("id: broken\n\ttabs: are: not: yaml\n{{ json(x) }}")
+	if err == nil {
+		t.Fatal("expected a parse error")
+	}
+	if !analysis.ParseFailed {
+		t.Error("expected ParseFailed to be set")
+	}
+	if analysis.PebbleJSON != 1 {
+		t.Errorf("pebble json: got %d, want 1", analysis.PebbleJSON)
+	}
+}
+
+func TestPluginFamily(t *testing.T) {
+	cases := map[string]string{
+		"io.kestra.plugin.core.log.Log":             "io.kestra.plugin.core",
+		"io.kestra.plugin.jdbc.postgresql.Query":    "io.kestra.plugin.jdbc",
+		"io.kestra.core.tasks.flows.EachSequential": "io.kestra.plugin.core",
+		"com.acme.internal.tasks.DoSomething":       "com.acme.internal.tasks",
+		"io.kestra.plugin.fs.local.Delete":          "io.kestra.plugin.fs",
+		"io.kestra.plugin.ee.jdbc.snowflake.Query":  "io.kestra.plugin.ee.jdbc",
+		"io.kestra.plugin.ee.kafka.Produce":         "io.kestra.plugin.ee.kafka",
+	}
+
+	for typeName, want := range cases {
+		if got := pluginFamily(typeName); got != want {
+			t.Errorf("pluginFamily(%q): got %q, want %q", typeName, got, want)
+		}
+	}
+}
+
+func TestAnonymizer_StableAndKindSeparated(t *testing.T) {
+	first := newAnonymizer(true)
+	second := newAnonymizer(true)
+
+	if first.namespace("prod.team") != second.namespace("prod.team") {
+		t.Error("expected the same label across anonymizer instances")
+	}
+	if !strings.HasPrefix(first.namespace("prod.team"), "ns-") {
+		t.Error("expected the ns- prefix")
+	}
+	if first.flow("prod.team") == first.namespace("prod.team") {
+		t.Error("expected different kinds to hash differently")
+	}
+	if strings.Contains(first.namespace("prod.team"), "prod") {
+		t.Error("the namespace name must not survive anonymization")
+	}
+	if first.flowRef("main", "prod.team", "my-flow") != first.tenant("main")+"/"+first.namespace("prod.team")+"/"+first.flow("my-flow") {
+		t.Error("unexpected flow reference format")
+	}
+}
+
+func TestAnonymizer_CollisionLengthensLabel(t *testing.T) {
+	anon := newAnonymizer(true)
+
+	label := anon.namespace("alpha")
+	// Simulate another identifier having claimed the short label already.
+	delete(anon.cache, "namespace:alpha")
+	anon.used[label] = "namespace:squatter"
+
+	relabeled := anon.namespace("alpha")
+	if relabeled == label {
+		t.Fatal("expected the colliding label to be lengthened")
+	}
+	if len(relabeled) <= len(label) || !strings.HasPrefix(relabeled, "ns-") {
+		t.Fatalf("unexpected relabeled value %q", relabeled)
+	}
+}
+
+func TestAnonymizer_IdentityWhenDisabled(t *testing.T) {
+	anon := newAnonymizer(false)
+
+	if anon.namespace("prod.team") != "prod.team" || anon.tenant("main") != "main" {
+		t.Error("expected identity mapping when anonymization is disabled")
+	}
+	if anon.flowRef("main", "prod.team", "my-flow") != "main/prod.team/my-flow" {
+		t.Error("unexpected flow reference when anonymization is disabled")
+	}
+}
+
+// flowFor builds a minimal analyzed flow for aggregation tests.
+func flowFor(namespace, id string, mutate func(a *flowAnalysis)) flowAnalysis {
+	analysis := flowAnalysis{
+		Namespace:           namespace,
+		FlowID:              id,
+		TaskTypes:           map[string]int64{},
+		TriggerTypes:        map[string]int64{},
+		PluginDefaultsTypes: map[string]int64{},
+		RemovedTasks:        map[string]int64{},
+	}
+	if mutate != nil {
+		mutate(&analysis)
+	}
+	return analysis
+}
+
+func testReport(t *testing.T, anonymize bool, scans []tenantScan) *usageReport {
+	t.Helper()
+	report := aggregateReport(scans, newAnonymizer(anonymize), time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC))
+	report.Scope = usageReportScope
+	return report
+}
+
+func TestAggregateReport_MergesTenantsAndOrders(t *testing.T) {
+	scans := []tenantScan{
+		{
+			Tenant: "main",
+			Flows: []flowAnalysis{
+				flowFor("ns.a", "f1", func(a *flowAnalysis) {
+					a.HasTriggers = true
+					a.TaskTypes["io.kestra.plugin.core.log.Log"] = 3
+					a.TriggerTypes["io.kestra.plugin.core.trigger.Schedule"] = 1
+					a.RemovedTasks["ForEach"] = 2
+					a.PluginDefaultsEntries = 1
+					a.PluginDefaultsForced = 1
+					a.PluginDefaultsTypes["io.kestra.plugin.core.log.Log"] = 1
+				}),
+				flowFor("ns.a", "f2", func(a *flowAnalysis) {
+					a.Disabled = true
+					a.TaskTypes["io.kestra.plugin.jdbc.postgresql.Query"] = 1
+					a.SubflowTasks = 2
+				}),
+			},
+			Deprecated: []deprecatedFlow{{
+				Namespace: "ns.a",
+				FlowID:    "f1",
+				TaskCount: 2,
+				Tasks: []deprecatedTask{
+					{TaskType: "io.kestra.core.tasks.flows.EachSequential", Replacement: "io.kestra.plugin.core.flow.ForEach"},
+					{TaskType: "io.kestra.core.tasks.flows.EachSequential", Replacement: "io.kestra.plugin.core.flow.ForEach"},
+				},
+			}},
+			DeprecatedAvailable: true,
+		},
+		{
+			Tenant: "other",
+			Flows: []flowAnalysis{
+				flowFor("ns.b", "f3", func(a *flowAnalysis) {
+					a.HasInputs = true
+					a.TaskTypes["io.kestra.plugin.core.log.Log"] = 1
+					a.PebbleJSON = 4
+				}),
+				// A flow whose YAML did not parse keeps its text signals but
+				// contributes no identity.
+				flowFor("", "", func(a *flowAnalysis) {
+					a.ParseFailed = true
+					a.PebbleJSON = 1
+				}),
+			},
+			Notes: []string{"used the fallback"},
+		},
+	}
+
+	report := testReport(t, true, scans)
+
+	if report.Totals.TenantsScanned != 2 || report.Totals.Count != 3 {
+		t.Fatalf("unexpected totals: %+v", report.Totals)
+	}
+	if report.Totals.NamespacesCount != 2 {
+		t.Errorf("namespaces: got %d, want 2", report.Totals.NamespacesCount)
+	}
+	if report.Totals.DisabledFlows != 1 || report.Totals.FlowsWithInputs != 1 || report.Totals.FlowsWithTriggers != 1 {
+		t.Errorf("unexpected flow flags in totals: %+v", report.Totals)
+	}
+	if report.Totals.TaskTypeCount["io.kestra.plugin.core.log.Log"] != 4 {
+		t.Errorf("task type count not merged across tenants: %v", report.Totals.TaskTypeCount)
+	}
+	if report.Totals.TaskTypeFlowCount["io.kestra.plugin.core.log.Log"] != 2 {
+		t.Errorf("task type flow count: %v", report.Totals.TaskTypeFlowCount)
+	}
+	if report.Totals.PluginFamilyCount["io.kestra.plugin.core"] != 5 {
+		t.Errorf("plugin families: %v", report.Totals.PluginFamilyCount)
+	}
+	if report.Totals.SubflowTaskCount != 2 || report.Totals.FlowsUsingSubflow != 1 {
+		t.Errorf("unexpected subflow totals: %+v", report.Totals)
+	}
+
+	if report.Signals.PebbleJsonFunction.Occurrences != 5 || report.Signals.PebbleJsonFunction.Flows != 1 {
+		t.Errorf("unexpected pebble signal: %+v", report.Signals.PebbleJsonFunction)
+	}
+	if report.Signals.PluginDefaults.Entries != 1 || report.Signals.PluginDefaults.ForcedEntries != 1 {
+		t.Errorf("unexpected plugin defaults signal: %+v", report.Signals.PluginDefaults)
+	}
+	// Every removed task must have a row, even the unused ones.
+	for _, class := range removedTaskClasses {
+		if _, ok := report.Signals.RemovedTasks[class]; !ok {
+			t.Errorf("missing removed task row for %s", class)
+		}
+	}
+	if report.Signals.RemovedTasks["ForEach"].Occurrences != 2 {
+		t.Errorf("unexpected ForEach signal: %+v", report.Signals.RemovedTasks["ForEach"])
+	}
+	if !report.Signals.ServerDeprecationsAvailable || len(report.Signals.ServerDeprecations) != 1 {
+		t.Errorf("unexpected server deprecations: %+v", report.Signals.ServerDeprecations)
+	}
+	if len(report.Signals.DeprecatedTaskTypes) != 1 {
+		t.Fatalf("unexpected deprecated task types: %+v", report.Signals.DeprecatedTaskTypes)
+	}
+	deprecated := report.Signals.DeprecatedTaskTypes[0]
+	if deprecated.TaskType != "io.kestra.core.tasks.flows.EachSequential" || deprecated.Count != 2 {
+		t.Errorf("unexpected deprecated task type: %+v", deprecated)
+	}
+	if deprecated.Replacement != "io.kestra.plugin.core.flow.ForEach" {
+		t.Errorf("unexpected replacement: %q", deprecated.Replacement)
+	}
+
+	if len(report.Tenants) != 2 || report.Tenants[0].ParseFails != 0 || report.Tenants[1].ParseFails != 1 {
+		t.Errorf("unexpected per-tenant reports: %+v", report.Tenants)
+	}
+	if len(report.Tenants[0].Namespaces) != 1 || report.Tenants[0].Namespaces[0].FlowCount != 2 {
+		t.Errorf("unexpected namespace breakdown: %+v", report.Tenants[0].Namespaces)
+	}
+
+	joinedNotes := strings.Join(report.Notes, "\n")
+	if !strings.Contains(joinedNotes, "used the fallback") || !strings.Contains(joinedNotes, "could not be parsed") {
+		t.Errorf("unexpected notes: %v", report.Notes)
+	}
+
+	// Ordering must be deterministic: descending count, then name.
+	entries := sortedCounts(report.Totals.TaskTypeCount)
+	if entries[0].Name != "io.kestra.plugin.core.log.Log" || entries[1].Name != "io.kestra.plugin.jdbc.postgresql.Query" {
+		t.Errorf("unexpected count ordering: %+v", entries)
+	}
+}
+
+func TestAggregateReport_CapsFlowReferences(t *testing.T) {
+	scan := tenantScan{Tenant: "main"}
+	for i := 0; i < maxFlowRefs+10; i++ {
+		scan.Flows = append(scan.Flows, flowFor("ns", fmt.Sprintf("flow-%02d", i), func(a *flowAnalysis) {
+			a.RemovedTasks["ForEach"] = 1
+		}))
+	}
+
+	report := testReport(t, false, []tenantScan{scan})
+	signal := report.Signals.RemovedTasks["ForEach"]
+
+	if signal.Flows != maxFlowRefs+10 {
+		t.Errorf("flows: got %d, want %d", signal.Flows, maxFlowRefs+10)
+	}
+	if len(signal.FlowRefs) != maxFlowRefs {
+		t.Fatalf("flow refs: got %d, want %d", len(signal.FlowRefs), maxFlowRefs)
+	}
+	for i := 1; i < len(signal.FlowRefs); i++ {
+		if signal.FlowRefs[i-1] > signal.FlowRefs[i] {
+			t.Fatal("expected the flow references to be sorted")
+		}
+	}
+}
+
+func TestRenderUsageReportMarkdown(t *testing.T) {
+	analysis := mustAnalyze(t, nestedFlowSource)
+	report := testReport(t, true, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{analysis}}})
+
+	var buf bytes.Buffer
+	if err := renderUsageReportMarkdown(report, &buf); err != nil {
+		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
+	}
+	out := buf.String()
+
+	for _, want := range []string{
+		"# Kestra usage report",
+		"## Migration signals",
+		"## pluginDefaults detail",
+		"## Affected flows",
+		"## Inventory",
+		"## Scan notes",
+		"| Task ForEachItem | 1 | 1 |",
+		"| Task ForEach | 0 | 0 |",
+		"| Trigger conditions/preconditions | 3 | 1 |",
+		"io.kestra.plugin.core.trigger.Schedule",
+		"Scope: single-tenant",
+		"The deprecation endpoint could not be read",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("markdown is missing %q", want)
+		}
+	}
+	if !strings.Contains(out, "Anonymization: on") {
+		t.Error("expected the anonymization note")
+	}
+}
+
+func TestRenderUsageReportMarkdown_ServerDeprecations(t *testing.T) {
+	scan := tenantScan{
+		Tenant:              "main",
+		Flows:               []flowAnalysis{flowFor("ns.a", "f1", nil)},
+		DeprecatedAvailable: true,
+		Deprecated: []deprecatedFlow{
+			{
+				Namespace: "ns.a", FlowID: "f1", TaskCount: 2,
+				Tasks: []deprecatedTask{
+					{TaskType: "io.kestra.core.tasks.flows.EachSequential", Replacement: "io.kestra.plugin.core.flow.ForEach"},
+					{TaskType: "io.kestra.plugin.core.flow.Worker"},
+				},
+			},
+			{
+				Namespace: "ns.a", FlowID: "f2", TaskCount: 1,
+				Tasks: []deprecatedTask{
+					{TaskType: "io.kestra.core.tasks.flows.EachSequential", Replacement: "io.kestra.plugin.core.flow.ForEach"},
+				},
+			},
+		},
+	}
+	report := testReport(t, true, []tenantScan{scan})
+
+	var buf bytes.Buffer
+	if err := renderUsageReportMarkdown(report, &buf); err != nil {
+		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
+	}
+	out := buf.String()
+
+	// Occurrences is the deprecated-task total, Flows the number of flows.
+	if !strings.Contains(out, "| Server-reported deprecations | 3 | 2 |") {
+		t.Error("unexpected server deprecation signal row")
+	}
+	for _, want := range []string{
+		"## Deprecated task types (server-reported)",
+		"| `io.kestra.core.tasks.flows.EachSequential` | `io.kestra.plugin.core.flow.ForEach` | 2 |",
+		"| `io.kestra.plugin.core.flow.Worker` | - | 1 |",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("markdown is missing %q", want)
+		}
+	}
+	// Task ids are user identifiers and must never be rendered.
+	if strings.Contains(out, "taskId") {
+		t.Error("the report must not carry task ids")
+	}
+}
+
+func TestUsageReportJSONRoundTrip(t *testing.T) {
+	analysis := mustAnalyze(t, nestedFlowSource)
+	report := testReport(t, true, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{analysis}}})
+
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("failed to marshal the report: %v", err)
+	}
+
+	var decoded usageReport
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal the report: %v", err)
+	}
+	if decoded.Scope != usageReportScope || !decoded.Anonymized {
+		t.Errorf("unexpected decoded header: %+v", decoded)
+	}
+	if decoded.Totals.Count != 1 || decoded.Signals.RemovedTasks["ForEachItem"].Occurrences != 1 {
+		t.Errorf("unexpected decoded body: %+v", decoded)
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("failed to unmarshal into a map: %v", err)
+	}
+	for _, key := range []string{"generated_at", "kestractl_version", "anonymized", "scope", "totals", "signals", "tenants"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("missing JSON key %q", key)
+		}
+	}
+}
+
+const secretFlowSource = `
+id: leaky-flow
+namespace: prod.secrets
+inputs:
+  - id: token
+    type: STRING
+    defaults: SENTINEL-SECRET-VALUE
+variables:
+  password: SENTINEL-SECRET-VALUE
+tasks:
+  - id: query
+    type: io.kestra.plugin.jdbc.postgresql.Query
+    url: jdbc:postgresql://db/app?password=SENTINEL-SECRET-VALUE
+    sql: SELECT * FROM customers WHERE email = 'SENTINEL-SECRET-VALUE'
+  - id: each
+    type: io.kestra.plugin.core.flow.ForEach
+    values: SENTINEL-SECRET-VALUE
+    tasks:
+      - id: log
+        type: io.kestra.plugin.core.log.Log
+        message: SENTINEL-SECRET-VALUE
+pluginDefaults:
+  - type: io.kestra.plugin.core.log.Log
+    values:
+      level: SENTINEL-SECRET-VALUE
+`
+
+func TestUsageReport_DoesNotLeakFlowValues(t *testing.T) {
+	const sentinel = "SENTINEL-SECRET-VALUE"
+
+	for _, anonymize := range []bool{true, false} {
+		t.Run(fmt.Sprintf("anonymize=%t", anonymize), func(t *testing.T) {
+			analysis := mustAnalyze(t, secretFlowSource)
+			report := testReport(t, anonymize, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{analysis}}})
+
+			var markdown bytes.Buffer
+			if err := renderUsageReportMarkdown(report, &markdown); err != nil {
+				t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
+			}
+			data, err := json.Marshal(report)
+			if err != nil {
+				t.Fatalf("failed to marshal the report: %v", err)
+			}
+
+			if strings.Contains(markdown.String(), sentinel) {
+				t.Error("the markdown report leaked a flow property value")
+			}
+			if strings.Contains(string(data), sentinel) {
+				t.Error("the JSON report leaked a flow property value")
+			}
+
+			// Sanity check: the signal itself is still reported.
+			if report.Signals.RemovedTasks["ForEach"].Occurrences != 1 {
+				t.Error("expected the ForEach signal to be counted")
+			}
+
+			names := strings.Contains(markdown.String(), "prod.secrets") || strings.Contains(markdown.String(), "leaky-flow")
+			if anonymize && names {
+				t.Error("anonymized report must not contain real names")
+			}
+			if !anonymize && !names {
+				t.Error("non-anonymized report should contain the real names")
+			}
+		})
+	}
+}
+
+// buildFlowZip assembles an in-memory export archive from name/content pairs.
+func buildFlowZip(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	writer := zip.NewWriter(&buf)
+	for name, content := range entries {
+		file, err := writer.Create(name)
+		if err != nil {
+			t.Fatalf("failed to create the zip entry %q: %v", name, err)
+		}
+		if _, err := file.Write([]byte(content)); err != nil {
+			t.Fatalf("failed to write the zip entry %q: %v", name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("failed to close the archive: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestFlowsFromZip(t *testing.T) {
+	archive := buildFlowZip(t, map[string]string{
+		"ns/first.yml":   "id: first\nnamespace: ns\n",
+		"ns/second.yaml": "id: second\nnamespace: ns\n",
+		"ns/readme.txt":  "not a flow",
+	})
+
+	sources, skipped, err := flowsFromZip(archive)
+	if err != nil {
+		t.Fatalf("flowsFromZip returned an error: %v", err)
+	}
+	if len(sources) != 2 {
+		t.Fatalf("sources: got %d, want 2", len(sources))
+	}
+	if skipped != 0 {
+		t.Errorf("skipped: got %d, want 0", skipped)
+	}
+	for _, source := range sources {
+		if !strings.Contains(source, "namespace: ns") {
+			t.Errorf("unexpected source content: %q", source)
+		}
+	}
+}
+
+func TestFlowsFromZip_InvalidArchive(t *testing.T) {
+	if _, _, err := flowsFromZip([]byte("not a zip file")); err == nil {
+		t.Fatal("expected an error for an invalid archive")
+	}
+}

--- a/src/cli/flows_usage_analysis_test.go
+++ b/src/cli/flows_usage_analysis_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -663,7 +664,7 @@ func TestRenderUsageReportMarkdown(t *testing.T) {
 	if err := renderUsageReportMarkdown(report, &buf, true); err != nil {
 		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
 	}
-	out := buf.String()
+	out := collapseSpaces(buf.String())
 
 	for _, want := range []string{
 		"# Kestra usage report",
@@ -717,7 +718,7 @@ func TestRenderUsageReportMarkdown_ServerDeprecations(t *testing.T) {
 	if err := renderUsageReportMarkdown(report, &buf, true); err != nil {
 		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
 	}
-	out := buf.String()
+	out := collapseSpaces(buf.String())
 
 	// Occurrences is the deprecated-task total, Flows the number of flows.
 	if !strings.Contains(out, "| Server-reported deprecations | 3 | 2 |") {
@@ -736,6 +737,99 @@ func TestRenderUsageReportMarkdown_ServerDeprecations(t *testing.T) {
 	if strings.Contains(out, "taskId") {
 		t.Error("the report must not carry task ids")
 	}
+}
+
+// spaceRuns matches the column padding of the aligned tables.
+var spaceRuns = regexp.MustCompile(` {2,}`)
+
+// collapseSpaces squeezes the alignment padding out of a rendered report so
+// assertions can be written about table content rather than column widths.
+func collapseSpaces(markdown string) string {
+	return spaceRuns.ReplaceAllString(markdown, " ")
+}
+
+// tableLines returns the pipe-table rows that follow the given heading.
+func tableLines(t *testing.T, markdown, heading string) []string {
+	t.Helper()
+
+	index := strings.Index(markdown, heading)
+	if index < 0 {
+		t.Fatalf("the report is missing %q", heading)
+	}
+
+	var rows []string
+	for _, line := range strings.Split(markdown[index:], "\n") {
+		if strings.HasPrefix(line, "|") {
+			rows = append(rows, line)
+			continue
+		}
+		if len(rows) > 0 {
+			break
+		}
+	}
+	if len(rows) < 3 {
+		t.Fatalf("expected a table under %q, got %d row(s)", heading, len(rows))
+	}
+	return rows
+}
+
+func TestRenderUsageReportMarkdown_TablesAreColumnAligned(t *testing.T) {
+	analysis := mustAnalyze(t, nestedFlowSource)
+	report := testReport(t, true, []tenantScan{{Tenant: "main", Flows: []flowAnalysis{analysis}}})
+
+	var buf bytes.Buffer
+	if err := renderUsageReportMarkdown(report, &buf, true); err != nil {
+		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
+	}
+	out := buf.String()
+
+	// The task-type table is pure ASCII, so byte length equals column width.
+	rows := tableLines(t, out, "## Task types")
+	width := len(rows[0])
+	pipes := pipeColumns(rows[0])
+	for _, row := range rows[1:] {
+		if len(row) != width {
+			t.Errorf("row %q is %d bytes wide, want %d", row, len(row), width)
+		}
+		if got := pipeColumns(row); !equalInts(got, pipes) {
+			t.Errorf("row %q has pipes at %v, want %v", row, got, pipes)
+		}
+	}
+
+	// The separator keeps its alignment colon and at least three dashes.
+	if !strings.Contains(rows[1], "-:") || !strings.Contains(rows[1], "---") {
+		t.Errorf("unexpected separator row %q", rows[1])
+	}
+	// Counts are padded on the left.
+	if !regexp.MustCompile(`\|\s{2,}1 \|`).MatchString(out) {
+		t.Error("expected right-aligned counts to be padded on the left")
+	}
+	// Alignment must never be done with ANSI escapes.
+	if strings.Contains(out, "\x1b[") {
+		t.Error("the report must not contain ANSI escape sequences")
+	}
+}
+
+func pipeColumns(row string) []int {
+	var columns []int
+	for i, char := range row {
+		if char == '|' {
+			columns = append(columns, i)
+		}
+	}
+	return columns
+}
+
+func equalInts(left, right []int) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestRenderUsageReportMarkdown_SectionOrder(t *testing.T) {
@@ -800,7 +894,7 @@ func TestRenderUsageReportMarkdown_EmptyReportKeepsTrailingSections(t *testing.T
 	if err := renderUsageReportMarkdown(report, &buf, false); err != nil {
 		t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
 	}
-	out := buf.String()
+	out := collapseSpaces(buf.String())
 
 	for _, want := range []string{
 		"## Plugin families",
@@ -824,7 +918,7 @@ func TestRenderUsageReportMarkdown_DetailedGating(t *testing.T) {
 		if err := renderUsageReportMarkdown(report, &buf, detailed); err != nil {
 			t.Fatalf("renderUsageReportMarkdown returned an error: %v", err)
 		}
-		return buf.String()
+		return collapseSpaces(buf.String())
 	}
 
 	summary := render(false)

--- a/src/cli/flows_usage_report.go
+++ b/src/cli/flows_usage_report.go
@@ -88,6 +88,13 @@ func runFlowsUsageReport(client *Client, opts usageReportOptions, renderer *Rend
 	anonymizer := newAnonymizer(opts.Anonymize)
 	report := aggregateReport(scans, anonymizer, time.Now())
 	report.Scope = usageReportScope
+	// The instance version is a nice-to-have header field: read it once, and
+	// note the failure rather than losing the whole report over it.
+	kestraVersion, err := fetchKestraVersion(client)
+	if err != nil {
+		report.Notes = append(report.Notes, "the Kestra server version could not be read: "+err.Error())
+	}
+	report.KestraVersion = kestraVersion
 	if tenantNote != "" {
 		report.Notes = append([]string{tenantNote}, report.Notes...)
 	}
@@ -251,6 +258,21 @@ func fetchTenantDeprecations(client *Client, tenant, namespace string) ([]deprec
 		})
 	}
 	return result, nil
+}
+
+// fetchKestraVersion reads the instance version from the (tenant-independent)
+// configuration endpoint.
+func fetchKestraVersion(client *Client) (string, error) {
+	config, err := client.Kestra.Misc().Configuration(client.Ctx)
+	if err != nil {
+		return "", formatSDKError(err)
+	}
+
+	version, ok := config["version"].(string)
+	if !ok || version == "" {
+		return "", fmt.Errorf("the configuration endpoint returned no version")
+	}
+	return version, nil
 }
 
 // buildUsageReportSearchFilters assembles the filter list for the flow export.

--- a/src/cli/flows_usage_report.go
+++ b/src/cli/flows_usage_report.go
@@ -1,0 +1,268 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/spf13/cobra"
+)
+
+// usageReportScope labels what the report covers. kestractl v1 talks to a
+// single tenant (the v1 SDK has no tenant listing), so the scope is fixed here
+// and only changes together with usageReportTenants.
+const usageReportScope = "single-tenant"
+
+// usageReportOptions are the command's selectors.
+type usageReportOptions struct {
+	Namespace string
+	Anonymize bool
+}
+
+func newFlowsUsageReportCommand() *cobra.Command {
+	opts := usageReportOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "usage-report",
+		Short: "Build a migration usage report from the flow sources.",
+		Long: `Export every flow source and summarize how the tenant uses Kestra.
+
+The report is a markdown document listing the flow inventory (namespaces, task
+and trigger types, plugin families) together with the migration signals that
+matter for a Kestra 1.x to 2.0 upgrade: pluginDefaults, removed flow tasks such
+as ForEach, trigger 'conditions'/'preconditions', the 'condition' property, the
+Pebble 'json()' function and 'fs.local.Delete'.
+
+Only flow sources are read — no execution, log or database data. Tenant,
+namespace and flow names are replaced by stable hashes unless --anonymize=false
+is given, so the report can be shared as-is.`,
+		Example: `  # Markdown report for the active tenant
+	  kestractl flows usage-report
+
+	  # Machine-readable report
+	  kestractl flows usage-report --output json
+
+	  # Restrict to one namespace and keep the real names
+	  kestractl flows usage-report --namespace my.namespace --anonymize=false`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			client, err := NewClient()
+			if err != nil {
+				return err
+			}
+
+			return runFlowsUsageReport(client, opts, renderer)
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "Only report on flows in this namespace")
+	cmd.Flags().BoolVar(&opts.Anonymize, "anonymize", true, "Replace tenant, namespace and flow names with stable hashes")
+
+	return cmd
+}
+
+func runFlowsUsageReport(client *Client, opts usageReportOptions, renderer *Renderer) error {
+	tenants, tenantNote := usageReportTenants(client)
+
+	scans := make([]tenantScan, 0, len(tenants))
+	failed := 0
+	for _, tenant := range tenants {
+		scan := scanTenant(client, tenant, opts.Namespace)
+		if len(scan.Errors) > 0 && len(scan.Flows) == 0 {
+			failed++
+		}
+		scans = append(scans, scan)
+	}
+
+	// A single failing tenant only degrades the report; every tenant failing
+	// means there is nothing to report on.
+	if failed == len(scans) && len(scans) > 0 {
+		return fmt.Errorf("failed to collect flow sources: %s", strings.Join(scans[len(scans)-1].Errors, "; "))
+	}
+
+	anonymizer := newAnonymizer(opts.Anonymize)
+	report := aggregateReport(scans, anonymizer, time.Now())
+	report.Scope = usageReportScope
+	if tenantNote != "" {
+		report.Notes = append([]string{tenantNote}, report.Notes...)
+	}
+
+	if renderer.IsJSON() {
+		return renderer.RenderJSON(report)
+	}
+	return renderUsageReportMarkdown(report, renderer.Writer())
+}
+
+// usageReportTenants resolves the tenants to scan. It is the single
+// version-specific seam of this command: kestractl v1 targets the configured
+// tenant, while the v2 port enumerates every tenant it can see.
+func usageReportTenants(client *Client) ([]string, string) {
+	return []string{client.Tenant}, ""
+}
+
+// scanTenant fetches and analyzes one tenant's flows, degrading into notes
+// rather than failing whenever part of the data cannot be read.
+func scanTenant(client *Client, tenant, namespace string) tenantScan {
+	scan := tenantScan{Tenant: tenant}
+
+	sources, notes, err := fetchTenantFlowSources(client, tenant, namespace)
+	scan.Notes = append(scan.Notes, notes...)
+	if err != nil {
+		scan.Errors = append(scan.Errors, err.Error())
+		return scan
+	}
+
+	for _, source := range sources {
+		// A parse failure is not fatal: analyzeFlowSource still returns the
+		// text-based signals and flags the flow as unparsed.
+		analysis, _ := analyzeFlowSource(source)
+		scan.Flows = append(scan.Flows, analysis)
+	}
+
+	deprecated, err := fetchTenantDeprecations(client, tenant, namespace)
+	if err != nil {
+		scan.Notes = append(scan.Notes, "the server-side deprecation check is unavailable: "+err.Error())
+	} else {
+		scan.Deprecated = deprecated
+		scan.DeprecatedAvailable = true
+	}
+
+	return scan
+}
+
+// fetchTenantFlowSources returns every flow source of a tenant. The export
+// endpoint answers with a ZIP of all sources in one request; when it is not
+// available the flows are listed and fetched one by one instead, which is
+// slower but works with narrower permissions.
+func fetchTenantFlowSources(client *Client, tenant, namespace string) ([]string, []string, error) {
+	var notes []string
+
+	archive, err := client.Kestra.Flows().ExportFlowsByQuery(client.Ctx, tenant, buildUsageReportSearchFilters(namespace))
+	if err == nil {
+		sources, skipped, zipErr := flowsFromZip(archive)
+		if zipErr == nil {
+			if skipped > 0 {
+				notes = append(notes, fmt.Sprintf("%d archive entry/entries were skipped (unreadable or larger than %d MiB)", skipped, maxZipEntrySize>>20))
+			}
+			return sources, notes, nil
+		}
+		err = zipErr
+	} else {
+		err = formatSDKError(err)
+	}
+
+	notes = append(notes, "the flow export endpoint could not be used ("+err.Error()+"); fell back to fetching flow sources one by one")
+
+	sources, fallbackNotes, fallbackErr := fetchFlowSourcesIndividually(client, tenant, namespace)
+	notes = append(notes, fallbackNotes...)
+	if fallbackErr != nil {
+		return nil, notes, fallbackErr
+	}
+	return sources, notes, nil
+}
+
+// fetchFlowSourcesIndividually is the export fallback: list the flows, then
+// read each source. Individual flows that cannot be read are reported as notes
+// so a partial report is still produced.
+func fetchFlowSourcesIndividually(client *Client, tenant, namespace string) ([]string, []string, error) {
+	flows, err := listAllFlowsForTenant(client, tenant)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var notes []string
+	sources := make([]string, 0, len(flows))
+	unreadable := 0
+	for _, flow := range flows {
+		if namespace != "" && flow.Namespace != namespace {
+			continue
+		}
+
+		source, err := fetchFlowSource(client, tenant, flow.Namespace, flow.ID)
+		if err != nil {
+			unreadable++
+			continue
+		}
+		sources = append(sources, source)
+	}
+
+	if unreadable > 0 {
+		notes = append(notes, fmt.Sprintf("%d flow source(s) could not be read and are missing from this report", unreadable))
+	}
+	return sources, notes, nil
+}
+
+// fetchFlowSource reads a single flow's YAML source.
+func fetchFlowSource(client *Client, tenant, namespace, flowID string) (string, error) {
+	flow, _, err := client.API.FlowsAPI.Flow(client.Ctx, namespace, flowID, tenant).
+		Source(true).
+		AllowDeleted(false).
+		Execute()
+	if err != nil {
+		// The generated client cannot decode array-format labels (#83);
+		// recover the flow from the raw response body.
+		parsed, ok := tryParseFlowFromError(err)
+		if !ok {
+			return "", formatSDKError(err)
+		}
+		return parsed.Source, nil
+	}
+	if flow == nil {
+		return "", fmt.Errorf("flow not found")
+	}
+	return flow.GetSource(), nil
+}
+
+// fetchTenantDeprecations cross-checks the client-side signals with the
+// deprecations the instance itself reports.
+func fetchTenantDeprecations(client *Client, tenant, namespace string) ([]deprecatedFlow, error) {
+	var ns *string
+	if namespace != "" {
+		ns = &namespace
+	}
+
+	flows, err := client.Kestra.Flows().ListDeprecated(client.Ctx, tenant, ns)
+	if err != nil {
+		return nil, formatSDKError(err)
+	}
+
+	result := make([]deprecatedFlow, 0, len(flows))
+	for _, flow := range flows {
+		deprecated := flow.GetDeprecatedTasks()
+		// Only the plugin type and its replacement are kept: the task id the
+		// server also returns is a user-chosen identifier.
+		tasks := make([]deprecatedTask, 0, len(deprecated))
+		for _, task := range deprecated {
+			tasks = append(tasks, deprecatedTask{
+				TaskType:    task.GetTaskType(),
+				Replacement: task.GetReplacement(),
+			})
+		}
+		result = append(result, deprecatedFlow{
+			Namespace: flow.GetNamespace(),
+			FlowID:    flow.GetFlowId(),
+			TaskCount: len(deprecated),
+			Tasks:     tasks,
+		})
+	}
+	return result, nil
+}
+
+// buildUsageReportSearchFilters assembles the filter list for the flow export.
+// The hand-written client takes SearchFilter values, not the QueryFilter values
+// buildFlowExportFilters produces.
+func buildUsageReportSearchFilters(namespace string) []kestra.SearchFilter {
+	if namespace == "" {
+		return nil
+	}
+	return []kestra.SearchFilter{{
+		Field:     kestra.FilterNamespace,
+		Operation: kestra.OpEquals,
+		Value:     namespace,
+	}}
+}

--- a/src/cli/flows_usage_report.go
+++ b/src/cli/flows_usage_report.go
@@ -18,6 +18,7 @@ const usageReportScope = "single-tenant"
 type usageReportOptions struct {
 	Namespace string
 	Anonymize bool
+	Detailed  bool
 }
 
 func newFlowsUsageReportCommand() *cobra.Command {
@@ -36,7 +37,11 @@ Pebble 'json()' function and 'fs.local.Delete'.
 
 Only flow sources are read — no execution, log or database data. Tenant,
 namespace and flow names are replaced by stable hashes unless --anonymize=false
-is given, so the report can be shared as-is.`,
+is given, so the report can be shared as-is.
+
+The markdown report is a summary; --detailed adds the per-namespace table and
+the affected-flow list of every signal. '--output json' always contains the
+full data, whether or not --detailed is given.`,
 		Example: `  # Markdown report for the active tenant
 	  kestractl flows usage-report
 
@@ -44,7 +49,10 @@ is given, so the report can be shared as-is.`,
 	  kestractl flows usage-report --output json
 
 	  # Restrict to one namespace and keep the real names
-	  kestractl flows usage-report --namespace my.namespace --anonymize=false`,
+	  kestractl flows usage-report --namespace my.namespace --anonymize=false
+
+	  # Add the per-namespace table and the affected-flow lists
+	  kestractl flows usage-report --detailed`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
@@ -62,6 +70,7 @@ is given, so the report can be shared as-is.`,
 
 	cmd.Flags().StringVarP(&opts.Namespace, "namespace", "n", "", "Only report on flows in this namespace")
 	cmd.Flags().BoolVar(&opts.Anonymize, "anonymize", true, "Replace tenant, namespace and flow names with stable hashes")
+	cmd.Flags().BoolVar(&opts.Detailed, "detailed", false, "Add the per-namespace table and the affected-flow lists to the markdown report (JSON output always contains them)")
 
 	return cmd
 }
@@ -102,7 +111,7 @@ func runFlowsUsageReport(client *Client, opts usageReportOptions, renderer *Rend
 	if renderer.IsJSON() {
 		return renderer.RenderJSON(report)
 	}
-	return renderUsageReportMarkdown(report, renderer.Writer())
+	return renderUsageReportMarkdown(report, renderer.Writer(), opts.Detailed)
 }
 
 // usageReportTenants resolves the tenants to scan. It is the single

--- a/src/cli/flows_usage_report_test.go
+++ b/src/cli/flows_usage_report_test.go
@@ -51,6 +51,7 @@ type usageReportServer struct {
 	deprecated http.HandlerFunc
 	search     http.HandlerFunc
 	flow       http.HandlerFunc
+	configs    http.HandlerFunc
 }
 
 func newUsageReportServer(t *testing.T, routes usageReportServer) *httptest.Server {
@@ -65,6 +66,8 @@ func newUsageReportServer(t *testing.T, routes usageReportServer) *httptest.Serv
 			handler = routes.deprecated
 		case strings.HasSuffix(r.URL.Path, "/flows/search"):
 			handler = routes.search
+		case strings.HasSuffix(r.URL.Path, "/configs"):
+			handler = routes.configs
 		default:
 			handler = routes.flow
 		}
@@ -146,6 +149,7 @@ func TestRunFlowsUsageReport_HappyPathMarkdown(t *testing.T) {
 		"prod.reports/nightly.yml":   usageReportFlowB,
 	})
 	server := newUsageReportServer(t, usageReportServer{
+		configs:    jsonHandler(http.StatusOK, `{"uuid":"abc","version":"1.3.2","edition":"EE"}`),
 		export:     zipHandler(archive),
 		deprecated: jsonHandler(http.StatusOK, `[{"namespace":"prod.orders","flowId":"order-sync","revision":2,"deprecatedTasks":[{"taskId":"each","taskType":"io.kestra.plugin.core.flow.ForEach","replacement":"io.kestra.plugin.core.flow.ForEachItem"}]}]`),
 	})
@@ -164,6 +168,7 @@ func TestRunFlowsUsageReport_HappyPathMarkdown(t *testing.T) {
 		"| Flows | 2 |",
 		"Server-reported deprecations",
 		"io.kestra.plugin.core.flow.Subflow",
+		"- Kestra version: 1.3.2",
 		"## Deprecated task types (server-reported)",
 		"| `io.kestra.plugin.core.flow.ForEach` | `io.kestra.plugin.core.flow.ForEachItem` | 1 |",
 	} {
@@ -184,6 +189,7 @@ func TestRunFlowsUsageReport_HappyPathMarkdown(t *testing.T) {
 func TestRunFlowsUsageReport_JSONAndAnonymizeOff(t *testing.T) {
 	archive := buildFlowZip(t, map[string]string{"prod.orders/order-sync.yml": usageReportFlowA})
 	server := newUsageReportServer(t, usageReportServer{
+		configs:    jsonHandler(http.StatusOK, `{"version":"1.3.2"}`),
 		export:     zipHandler(archive),
 		deprecated: jsonHandler(http.StatusOK, `[]`),
 	})
@@ -200,6 +206,9 @@ func TestRunFlowsUsageReport_JSONAndAnonymizeOff(t *testing.T) {
 	}
 	if report.Anonymized {
 		t.Error("expected the report to be flagged as not anonymized")
+	}
+	if report.KestraVersion != "1.3.2" {
+		t.Errorf("kestra version: got %q, want \"1.3.2\"", report.KestraVersion)
 	}
 	if report.Scope != usageReportScope || report.Totals.Count != 1 {
 		t.Fatalf("unexpected report: %+v", report)
@@ -319,6 +328,33 @@ func TestRunFlowsUsageReport_DeprecationEndpointUnavailable(t *testing.T) {
 	}
 	if !strings.Contains(strings.Join(report.Notes, "\n"), "deprecation check is unavailable") {
 		t.Errorf("expected a deprecation note, got %v", report.Notes)
+	}
+}
+
+func TestRunFlowsUsageReport_ServerVersionUnavailable(t *testing.T) {
+	archive := buildFlowZip(t, map[string]string{"prod.orders/order-sync.yml": usageReportFlowA})
+	server := newUsageReportServer(t, usageReportServer{
+		configs:    jsonHandler(http.StatusNotFound, `{"message":"not found"}`),
+		export:     zipHandler(archive),
+		deprecated: jsonHandler(http.StatusOK, `[]`),
+	})
+
+	var out bytes.Buffer
+	err := runFlowsUsageReport(newTestClient(t, server.URL), usageReportOptions{Anonymize: true}, newTableRenderer(&out))
+	if err != nil {
+		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
+	}
+
+	markdown := out.String()
+	if !strings.Contains(markdown, "- Kestra version: unknown") {
+		t.Error("expected the Kestra version to render as unknown")
+	}
+	if !strings.Contains(markdown, "the Kestra server version could not be read") {
+		t.Error("expected a scan note about the unreadable server version")
+	}
+	// The rest of the report is unaffected.
+	if !strings.Contains(markdown, "| Flows | 1 |") {
+		t.Error("expected the report to be produced anyway")
 	}
 }
 

--- a/src/cli/flows_usage_report_test.go
+++ b/src/cli/flows_usage_report_test.go
@@ -1,0 +1,343 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+)
+
+const usageReportFlowA = `
+id: order-sync
+namespace: prod.orders
+tasks:
+  - id: each
+    type: io.kestra.plugin.core.flow.ForEach
+    tasks:
+      - id: log
+        type: io.kestra.plugin.core.log.Log
+        message: "{{ json(inputs.payload) }}"
+pluginDefaults:
+  - type: io.kestra.plugin.core.log.Log
+    forced: true
+    values:
+      level: INFO
+`
+
+const usageReportFlowB = `
+id: nightly
+namespace: prod.reports
+triggers:
+  - id: schedule
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "0 2 * * *"
+    conditions:
+      - type: io.kestra.plugin.core.condition.DayWeekInMonth
+tasks:
+  - id: call
+    type: io.kestra.plugin.core.flow.Subflow
+    namespace: prod.orders
+    flowId: order-sync
+`
+
+// usageReportServer serves the endpoints `flows usage-report` calls. Handlers
+// that are nil answer 500, which is how the degradation cases are built.
+type usageReportServer struct {
+	export     http.HandlerFunc
+	deprecated http.HandlerFunc
+	search     http.HandlerFunc
+	flow       http.HandlerFunc
+}
+
+func newUsageReportServer(t *testing.T, routes usageReportServer) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var handler http.HandlerFunc
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/flows/export/by-query"):
+			handler = routes.export
+		case strings.HasSuffix(r.URL.Path, "/flows/deprecated"):
+			handler = routes.deprecated
+		case strings.HasSuffix(r.URL.Path, "/flows/search"):
+			handler = routes.search
+		default:
+			handler = routes.flow
+		}
+		if handler == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		handler(w, r)
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func zipHandler(archive []byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(archive)
+	}
+}
+
+func jsonHandler(status int, body string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+func TestNewFlowsUsageReportCommand_Structure(t *testing.T) {
+	cmd := newFlowsUsageReportCommand()
+
+	if cmd.Use != "usage-report" {
+		t.Errorf("use: got %q", cmd.Use)
+	}
+	if cmd.Args == nil {
+		t.Error("expected the command to reject positional arguments")
+	}
+
+	namespace := cmd.Flags().Lookup("namespace")
+	if namespace == nil || namespace.Shorthand != "n" {
+		t.Fatalf("unexpected --namespace flag: %+v", namespace)
+	}
+
+	anonymize := cmd.Flags().Lookup("anonymize")
+	if anonymize == nil {
+		t.Fatal("missing the --anonymize flag")
+	}
+	if anonymize.DefValue != "true" {
+		t.Errorf("--anonymize default: got %q, want \"true\"", anonymize.DefValue)
+	}
+}
+
+func TestFlowsUsageReportCommandIsRegistered(t *testing.T) {
+	for _, cmd := range newFlowsCommand().Commands() {
+		if cmd.Name() == "usage-report" {
+			return
+		}
+	}
+	t.Fatal("usage-report is not registered under the flows command")
+}
+
+func TestBuildUsageReportSearchFilters(t *testing.T) {
+	if filters := buildUsageReportSearchFilters(""); len(filters) != 0 {
+		t.Errorf("expected no filter without a namespace, got %+v", filters)
+	}
+
+	filters := buildUsageReportSearchFilters("prod.orders")
+	if len(filters) != 1 {
+		t.Fatalf("filters: got %d, want 1", len(filters))
+	}
+	if filters[0].Field != kestra.FilterNamespace || filters[0].Operation != kestra.OpEquals || filters[0].Value != "prod.orders" {
+		t.Errorf("unexpected filter: %+v", filters[0])
+	}
+}
+
+func TestRunFlowsUsageReport_HappyPathMarkdown(t *testing.T) {
+	archive := buildFlowZip(t, map[string]string{
+		"prod.orders/order-sync.yml": usageReportFlowA,
+		"prod.reports/nightly.yml":   usageReportFlowB,
+	})
+	server := newUsageReportServer(t, usageReportServer{
+		export:     zipHandler(archive),
+		deprecated: jsonHandler(http.StatusOK, `[{"namespace":"prod.orders","flowId":"order-sync","revision":2,"deprecatedTasks":[{"taskId":"each","taskType":"io.kestra.plugin.core.flow.ForEach","replacement":"io.kestra.plugin.core.flow.ForEachItem"}]}]`),
+	})
+
+	var out bytes.Buffer
+	err := runFlowsUsageReport(newTestClient(t, server.URL), usageReportOptions{Anonymize: true}, newTableRenderer(&out))
+	if err != nil {
+		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
+	}
+
+	markdown := out.String()
+	for _, want := range []string{
+		"# Kestra usage report",
+		"| Task ForEach | 1 | 1 |",
+		"| Trigger conditions/preconditions | 1 | 1 |",
+		"| Flows | 2 |",
+		"Server-reported deprecations",
+		"io.kestra.plugin.core.flow.Subflow",
+		"## Deprecated task types (server-reported)",
+		"| `io.kestra.plugin.core.flow.ForEach` | `io.kestra.plugin.core.flow.ForEachItem` | 1 |",
+	} {
+		if !strings.Contains(markdown, want) {
+			t.Errorf("markdown is missing %q", want)
+		}
+	}
+	// The server also returns the task id; it is a user identifier and is
+	// dropped on the way into the report.
+	if strings.Contains(markdown, "each") && strings.Contains(markdown, "taskId") {
+		t.Error("the report must not carry task ids")
+	}
+	if strings.Contains(markdown, "prod.orders") {
+		t.Error("the anonymized report leaked a namespace name")
+	}
+}
+
+func TestRunFlowsUsageReport_JSONAndAnonymizeOff(t *testing.T) {
+	archive := buildFlowZip(t, map[string]string{"prod.orders/order-sync.yml": usageReportFlowA})
+	server := newUsageReportServer(t, usageReportServer{
+		export:     zipHandler(archive),
+		deprecated: jsonHandler(http.StatusOK, `[]`),
+	})
+
+	var out bytes.Buffer
+	err := runFlowsUsageReport(newTestClient(t, server.URL), usageReportOptions{Anonymize: false}, newJSONRenderer(&out))
+	if err != nil {
+		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
+	}
+
+	var report usageReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("failed to decode the JSON report: %v", err)
+	}
+	if report.Anonymized {
+		t.Error("expected the report to be flagged as not anonymized")
+	}
+	if report.Scope != usageReportScope || report.Totals.Count != 1 {
+		t.Fatalf("unexpected report: %+v", report)
+	}
+	if len(report.Tenants) != 1 || report.Tenants[0].Tenant != "main" {
+		t.Fatalf("unexpected tenant breakdown: %+v", report.Tenants)
+	}
+	if report.Tenants[0].Namespaces[0].Namespace != "prod.orders" {
+		t.Errorf("expected the real namespace with --anonymize=false, got %q", report.Tenants[0].Namespaces[0].Namespace)
+	}
+	if report.Signals.PluginDefaults.Entries != 1 || report.Signals.PluginDefaults.ForcedEntries != 1 {
+		t.Errorf("unexpected plugin defaults signal: %+v", report.Signals.PluginDefaults)
+	}
+	if report.Signals.PebbleJsonFunction.Occurrences != 1 {
+		t.Errorf("unexpected pebble signal: %+v", report.Signals.PebbleJsonFunction)
+	}
+}
+
+func TestRunFlowsUsageReport_ExportForbiddenFallsBack(t *testing.T) {
+	server := newUsageReportServer(t, usageReportServer{
+		export:     jsonHandler(http.StatusForbidden, `{"message":"insufficient permissions"}`),
+		search:     jsonHandler(http.StatusOK, `{"results":[{"id":"order-sync","namespace":"prod.orders"}],"total":1}`),
+		flow:       jsonHandler(http.StatusOK, `{"id":"order-sync","namespace":"prod.orders","revision":1,"source":`+mustJSONString(t, usageReportFlowA)+`}`),
+		deprecated: jsonHandler(http.StatusOK, `[]`),
+	})
+
+	var out bytes.Buffer
+	err := runFlowsUsageReport(newTestClient(t, server.URL), usageReportOptions{Anonymize: true}, newJSONRenderer(&out))
+	if err != nil {
+		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
+	}
+
+	var report usageReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("failed to decode the JSON report: %v", err)
+	}
+	if report.Totals.Count != 1 {
+		t.Fatalf("expected the fallback to recover 1 flow, got %d", report.Totals.Count)
+	}
+	if report.Signals.RemovedTasks["ForEach"].Occurrences != 1 {
+		t.Error("expected the fallback sources to be analyzed")
+	}
+	if !strings.Contains(strings.Join(report.Notes, "\n"), "fell back to fetching flow sources one by one") {
+		t.Errorf("expected a fallback note, got %v", report.Notes)
+	}
+}
+
+func TestRunFlowsUsageReport_AllSourcesUnavailable(t *testing.T) {
+	server := newUsageReportServer(t, usageReportServer{
+		export: jsonHandler(http.StatusForbidden, `{"message":"insufficient permissions"}`),
+	})
+
+	var out bytes.Buffer
+	err := runFlowsUsageReport(newTestClient(t, server.URL), usageReportOptions{Anonymize: true}, newTableRenderer(&out))
+	if err == nil {
+		t.Fatal("expected an error when no flow source could be collected")
+	}
+	if !strings.Contains(err.Error(), "failed to collect flow sources") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunFlowsUsageReport_UnparsableFlowIsNoted(t *testing.T) {
+	archive := buildFlowZip(t, map[string]string{
+		"prod.orders/order-sync.yml": usageReportFlowA,
+		"prod.broken/broken.yml":     "id: broken\n\tmessage: \"{{ json(x) }}\"\n",
+	})
+	server := newUsageReportServer(t, usageReportServer{
+		export:     zipHandler(archive),
+		deprecated: jsonHandler(http.StatusOK, `[]`),
+	})
+
+	var out bytes.Buffer
+	err := runFlowsUsageReport(newTestClient(t, server.URL), usageReportOptions{Anonymize: true}, newJSONRenderer(&out))
+	if err != nil {
+		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
+	}
+
+	var report usageReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("failed to decode the JSON report: %v", err)
+	}
+	if report.Totals.Count != 1 {
+		t.Errorf("only the parsable flow should be inventoried, got %d", report.Totals.Count)
+	}
+	if report.Tenants[0].ParseFails != 1 {
+		t.Errorf("parse fails: got %d, want 1", report.Tenants[0].ParseFails)
+	}
+	if !strings.Contains(strings.Join(report.Notes, "\n"), "could not be parsed as YAML") {
+		t.Errorf("expected a parse-failure note, got %v", report.Notes)
+	}
+	// The text heuristic runs even on sources that failed to parse.
+	if report.Signals.PebbleJsonFunction.Occurrences != 2 {
+		t.Errorf("pebble json occurrences: got %d, want 2", report.Signals.PebbleJsonFunction.Occurrences)
+	}
+}
+
+func TestRunFlowsUsageReport_DeprecationEndpointUnavailable(t *testing.T) {
+	archive := buildFlowZip(t, map[string]string{"prod.orders/order-sync.yml": usageReportFlowA})
+	server := newUsageReportServer(t, usageReportServer{
+		export:     zipHandler(archive),
+		deprecated: jsonHandler(http.StatusNotFound, `{"message":"not found"}`),
+	})
+
+	var out bytes.Buffer
+	err := runFlowsUsageReport(newTestClient(t, server.URL), usageReportOptions{Anonymize: true}, newJSONRenderer(&out))
+	if err != nil {
+		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
+	}
+
+	var report usageReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatalf("failed to decode the JSON report: %v", err)
+	}
+	if report.Signals.ServerDeprecationsAvailable {
+		t.Error("expected the server deprecation cross-check to be unavailable")
+	}
+	if !strings.Contains(strings.Join(report.Notes, "\n"), "deprecation check is unavailable") {
+		t.Errorf("expected a deprecation note, got %v", report.Notes)
+	}
+}
+
+func TestUsageReportTenants_SingleTenantOnV1(t *testing.T) {
+	tenants, note := usageReportTenants(&Client{Tenant: "acme"})
+
+	if len(tenants) != 1 || tenants[0] != "acme" {
+		t.Errorf("unexpected tenants: %v", tenants)
+	}
+	if note != "" {
+		t.Errorf("unexpected note: %q", note)
+	}
+}
+
+func mustJSONString(t *testing.T, value string) string {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("failed to encode %q: %v", value, err)
+	}
+	return string(encoded)
+}

--- a/src/cli/flows_usage_report_test.go
+++ b/src/cli/flows_usage_report_test.go
@@ -118,6 +118,14 @@ func TestNewFlowsUsageReportCommand_Structure(t *testing.T) {
 	if anonymize.DefValue != "true" {
 		t.Errorf("--anonymize default: got %q, want \"true\"", anonymize.DefValue)
 	}
+
+	detailed := cmd.Flags().Lookup("detailed")
+	if detailed == nil {
+		t.Fatal("missing the --detailed flag")
+	}
+	if detailed.DefValue != "false" {
+		t.Errorf("--detailed default: got %q, want \"false\"", detailed.DefValue)
+	}
 }
 
 func TestFlowsUsageReportCommandIsRegistered(t *testing.T) {
@@ -155,7 +163,7 @@ func TestRunFlowsUsageReport_HappyPathMarkdown(t *testing.T) {
 	})
 
 	var out bytes.Buffer
-	err := runFlowsUsageReport(newTestClient(t, server.URL), usageReportOptions{Anonymize: true}, newTableRenderer(&out))
+	err := runFlowsUsageReport(newTestClient(t, server.URL), usageReportOptions{Anonymize: true, Detailed: true}, newTableRenderer(&out))
 	if err != nil {
 		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
 	}
@@ -163,6 +171,8 @@ func TestRunFlowsUsageReport_HappyPathMarkdown(t *testing.T) {
 	markdown := out.String()
 	for _, want := range []string{
 		"# Kestra usage report",
+		"### Flows per namespace",
+		"## Affected flows",
 		"| Task ForEach | 1 | 1 |",
 		"| Trigger conditions/preconditions | 1 | 1 |",
 		"| Flows | 2 |",
@@ -224,6 +234,14 @@ func TestRunFlowsUsageReport_JSONAndAnonymizeOff(t *testing.T) {
 	}
 	if report.Signals.PebbleJsonFunction.Occurrences != 1 {
 		t.Errorf("unexpected pebble signal: %+v", report.Signals.PebbleJsonFunction)
+	}
+
+	// The JSON dump is complete regardless of --detailed.
+	if len(report.Signals.RemovedTasks["ForEach"].FlowRefs) != 1 {
+		t.Errorf("expected flow refs in the JSON output, got %+v", report.Signals.RemovedTasks["ForEach"])
+	}
+	if len(report.Tenants[0].Namespaces) != 1 {
+		t.Errorf("expected the per-namespace breakdown in the JSON output, got %+v", report.Tenants[0].Namespaces)
 	}
 }
 
@@ -328,6 +346,35 @@ func TestRunFlowsUsageReport_DeprecationEndpointUnavailable(t *testing.T) {
 	}
 	if !strings.Contains(strings.Join(report.Notes, "\n"), "deprecation check is unavailable") {
 		t.Errorf("expected a deprecation note, got %v", report.Notes)
+	}
+}
+
+func TestRunFlowsUsageReport_SummaryOmitsDetailedBlocks(t *testing.T) {
+	archive := buildFlowZip(t, map[string]string{"prod.orders/order-sync.yml": usageReportFlowA})
+	server := newUsageReportServer(t, usageReportServer{
+		configs:    jsonHandler(http.StatusOK, `{"version":"1.3.2"}`),
+		export:     zipHandler(archive),
+		deprecated: jsonHandler(http.StatusOK, `[]`),
+	})
+
+	var out bytes.Buffer
+	err := runFlowsUsageReport(newTestClient(t, server.URL), usageReportOptions{Anonymize: true}, newTableRenderer(&out))
+	if err != nil {
+		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
+	}
+
+	markdown := out.String()
+	for _, unwanted := range []string{"### Flows per namespace", "## Affected flows"} {
+		if strings.Contains(markdown, unwanted) {
+			t.Errorf("the default report must not contain %q", unwanted)
+		}
+	}
+	if !strings.Contains(markdown, "_Run with --detailed to list the affected flows._") {
+		t.Error("expected the default report to point at --detailed")
+	}
+	// The signal counts are unaffected by the flag.
+	if !strings.Contains(markdown, "| Task ForEach | 1 | 1 |") || !strings.Contains(markdown, "| Namespaces | 1 |") {
+		t.Error("the default report lost data that --detailed must not gate")
 	}
 }
 

--- a/src/cli/flows_usage_report_test.go
+++ b/src/cli/flows_usage_report_test.go
@@ -168,7 +168,7 @@ func TestRunFlowsUsageReport_HappyPathMarkdown(t *testing.T) {
 		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
 	}
 
-	markdown := out.String()
+	markdown := collapseSpaces(out.String())
 	for _, want := range []string{
 		"# Kestra usage report",
 		"### Flows per namespace",
@@ -363,7 +363,7 @@ func TestRunFlowsUsageReport_SummaryOmitsDetailedBlocks(t *testing.T) {
 		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
 	}
 
-	markdown := out.String()
+	markdown := collapseSpaces(out.String())
 	for _, unwanted := range []string{"### Flows per namespace", "## Affected flows"} {
 		if strings.Contains(markdown, unwanted) {
 			t.Errorf("the default report must not contain %q", unwanted)
@@ -392,7 +392,7 @@ func TestRunFlowsUsageReport_ServerVersionUnavailable(t *testing.T) {
 		t.Fatalf("runFlowsUsageReport returned an error: %v", err)
 	}
 
-	markdown := out.String()
+	markdown := collapseSpaces(out.String())
 	if !strings.Contains(markdown, "- Kestra version: unknown") {
 		t.Error("expected the Kestra version to render as unknown")
 	}


### PR DESCRIPTION
Ref kestra-io/kestra-ee#10594 — targets `releases/v1` (customers run kestractl v1 against Kestra 1.3; the port to `main`/v2 is a follow-up, recipe below).

## What

`kestractl flows usage-report` exports every flow source of the tenant (one `flows/export/by-query` ZIP request, with a `SearchFlows` + per-flow `?source=true` fallback), analyzes the YAML client-side, and prints a **shareable markdown report** (or `-o json`) that surfaces the signals needed to recommend a 1.3 → 2.0 migration strategy:

- `pluginDefaults` blocks (count, forced entries, types) — removed in 2.0
- Removed flow tasks: `ForEach`, `ForEachItem`, `EachSequential`, `EachParallel`, `Dag`, `Template`, `Worker` (both modern and legacy package spellings)
- Trigger `conditions:`/`preconditions:` (→ `when`), `condition` property on triggers/checks/SLAs (→ `when`; task-level `condition` like `If`'s is deliberately NOT counted — it survives in 2.0)
- Pebble `json(` usage (text heuristic, → `fromJson()`)
- `io.kestra.plugin.fs.local.Delete` (recursive default change)
- Cross-check against the server's own `/flows/deprecated` report (task types + replacements)
- Inventory: flows/namespaces distribution, task/trigger type counts, plugin families, subflows, disabled flows

## Privacy

- **Anonymization on by default**: tenant/namespace/flow names become stable short hashes (`t-`/`ns-`/`f-`, unsalted SHA-256 so reports stay diffable across runs); `--anonymize=false` shows real names.
- **No flow property value ever reaches the report** in either mode — the analysis struct is structurally incapable of carrying them, and a sentinel-leak test enforces it.

## Degradation

Export endpoint unavailable → per-flow fallback with a scan note; unparseable YAML → counted + text signals still run; deprecation endpoint unavailable → `n/a` row; the command only errors when nothing at all could be fetched.

## Testing

- 25 test funcs / 42 cases: pure walker/anonymizer/aggregation/rendering tests + httptest integration (real in-test ZIP, fallback, degradation paths).
- **Live QA against Kestra 1.3 EE** (docker-compose-ci.yml, `v1.3-no-plugins`): deployed fixture flows with `pluginDefaults` (forced), `EachSequential`, `If`+`condition`, Schedule trigger with `conditions`, `json()` usage, a disabled `Subflow` caller — verified default/JSON/`--anonymize=false`/`-n` variants, export fast path (no fallback notes), server deprecation cross-check (1.3 reports `EachSequential`), zero sentinel leaks in both modes, `If.condition` correctly not counted.
- E2E test file (`e2e_tests/flows_usage_report_usecases_test.go`) deferred to a follow-up.

## Port-to-main (v2) recipe

Cherry-pick, then: import path `go-sdk` → `go-sdk/v2`; swap the `usageReportTenants()` body for all-tenants enumeration via `TenantsAPI` with fallback to the configured tenant (+ scope note); `flows_usage_analysis.go` is byte-identical by design.
