### PR TITLE
ci: run tests on push to releases/v1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
 on:
+  push:
+    branches:
+      - releases/v1
   pull_request:
   workflow_dispatch:
   workflow_call:


### PR DESCRIPTION
The `Tests` workflow on `releases/v1` only triggers on `pull_request`, `workflow_dispatch`, and `workflow_call` — direct pushes and merges to the branch never run tests (push-triggered workflows use the workflow file on the pushed branch, so `main`'s `push:` trigger doesn't apply here).

This adds a `push` trigger scoped to `releases/v1`, so every merge/push to the release branch runs unit tests, installer checks, and the E2E matrix. Failures notify Slack via the existing `notify-failure` job, which already fires for non-PR events.