### PR TITLE
feat(cli): best-effort Kestra 1.x compatibility for the v2 binary

### DIFF
--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"sync"
 
 	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/spf13/viper"
@@ -23,6 +24,11 @@ type Client struct {
 	Kestra *kestra.KestraClient
 	Ctx    context.Context
 	Tenant string
+
+	// Kestra version reported by the server, resolved lazily by ServerVersion.
+	serverVersion     string
+	serverVersionErr  error
+	serverVersionOnce sync.Once
 }
 
 // newClientFunc is the client factory function. Override in tests.
@@ -67,6 +73,11 @@ func newClientDefault() (*Client, error) {
 	}
 	cfg.Debug = isVerbose
 
+	// One HTTP client for both SDK clients, so the Kestra 1.x response shim
+	// (see compat.go) applies to generated and hand-written endpoints alike.
+	httpClient, compat := newCompatHTTPClient()
+	cfg.HTTPClient = httpClient
+
 	parsed, err := parseHeaders(globalFlags.Headers)
 	if err != nil {
 		return nil, err
@@ -79,7 +90,7 @@ func newClientDefault() (*Client, error) {
 
 	// The hand-written client shares the same resolved host, headers, and debug
 	// setting; auth is appended per-branch below.
-	opts := []kestra.ClientOption{kestra.WithDebug(isVerbose)}
+	opts := []kestra.ClientOption{kestra.WithDebug(isVerbose), kestra.WithHTTPClient(httpClient)}
 	if len(parsed) > 0 {
 		opts = append(opts, kestra.WithHeaders(parsed))
 	}
@@ -98,12 +109,14 @@ func newClientDefault() (*Client, error) {
 		return nil, fmt.Errorf("could not init client without any auth, at least token or username+password is required")
 	}
 
-	return &Client{
+	c := &Client{
 		API:    client,
 		Kestra: kestra.NewClient(host, opts...),
 		Ctx:    ctx,
 		Tenant: tenant,
-	}, nil
+	}
+	compat.legacyServer = c.isLegacyServer
+	return c, nil
 }
 
 // resolveConfig returns (host, tenant, token, error) using Viper for precedence: flags > env > config file.

--- a/src/cli/compat.go
+++ b/src/cli/compat.go
@@ -1,0 +1,194 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+)
+
+// Kestra 1.x compatibility.
+//
+// kestractl v2 targets Kestra 2.x, and stays usable against a 1.3 server on a
+// best-effort basis. Two things make that work:
+//
+//   - compatTransport fills in response fields the 2.0 SDK marks as required
+//     but a 1.x server never emits (a 1.x flow has no `draft`, a 1.x execution
+//     summary has no `tenantId`). Without it the generated decoder rejects the
+//     whole body with "no value given for required property draft".
+//   - requireKestra2 refuses features that do not exist server-side before 2.0,
+//     instead of letting the server silently ignore the field (a 1.x server
+//     drops an unknown `instanceOwner` or `quotas` from the request body and
+//     returns 200).
+
+// newCompatHTTPClient returns the HTTP client shared by both SDK clients, so the
+// response shim applies to generated and hand-written endpoints alike.
+//
+// legacyServer reports whether the server runs Kestra 1.x; it is wired to
+// Client.ServerVersion once the client exists, and the shim stays inert until
+// then and against 2.x servers.
+func newCompatHTTPClient() (*http.Client, *compatTransport) {
+	transport := &compatTransport{base: http.DefaultTransport, legacyServer: func() bool { return false }}
+	return &http.Client{Transport: transport}, transport
+}
+
+type compatTransport struct {
+	base         http.RoundTripper
+	legacyServer func() bool
+}
+
+// compatMarkers are the keys a body must contain for fillCompatDefaults to have
+// anything to do. Checking them before anything else keeps the shim off the hot
+// path: most responses are returned without being decoded at all.
+var compatMarkers = [][]byte{[]byte(`"tasks"`), []byte(`"flowRevision"`)}
+
+func (t *compatTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 || !isJSONResponse(resp) {
+		return resp, err
+	}
+	tenant, shimmed := shimmedEndpoint(req.URL.Path)
+	if !shimmed {
+		return resp, nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	// The version probe runs through this same transport, so check the cheap
+	// marker scan first and only then ask which server we are talking to.
+	if containsAny(body, compatMarkers) && t.legacyServer() {
+		// UseNumber keeps integers verbatim: decoding into float64 would round
+		// anything above 2^53 (epoch nanos, counters) on the way back out.
+		dec := json.NewDecoder(bytes.NewReader(body))
+		dec.UseNumber()
+		var payload any
+		if dec.Decode(&payload) == nil && fillCompatDefaults(payload, tenant) {
+			if patched, err := json.Marshal(payload); err == nil {
+				body = patched
+				resp.Header.Del("Content-Length")
+			}
+		}
+	}
+
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.ContentLength = int64(len(body))
+	return resp, nil
+}
+
+func isJSONResponse(resp *http.Response) bool {
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		return false
+	}
+	return mediaType == "application/json" || strings.HasSuffix(mediaType, "+json")
+}
+
+func containsAny(body []byte, needles [][]byte) bool {
+	for _, n := range needles {
+		if bytes.Contains(body, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// shimmedEndpoint reports whether a request path is one whose response can
+// carry flows or executions — /api/v1/{tenant}/flows/... and
+// /api/v1/{tenant}/executions/... — and returns that tenant. Restricting the
+// shim to these keeps it away from bodies that merely look like a flow, such
+// as a user's own JSON stored in the KV store. The tenant comes from the path
+// rather than the client because flows usage-report walks several tenants.
+func shimmedEndpoint(path string) (tenant string, ok bool) {
+	rest := strings.TrimPrefix(path, "/api/v1/")
+	if rest == path {
+		return "", false
+	}
+	tenant, rest, _ = strings.Cut(rest, "/")
+	resource, _, _ := strings.Cut(rest, "/")
+	return tenant, resource == "flows" || resource == "executions"
+}
+
+// fillCompatDefaults walks a decoded JSON payload and adds the fields a 2.0
+// decoder requires but a 1.x server omits. It reports whether anything changed.
+//
+// A flow is recognised by its id/namespace/tasks triple (Flow, FlowWithSource,
+// FlowForExecution, in a list or a page). An execution by flowId/flowRevision/
+// state (Execution, ApiExecution). A flow on a 1.x server is never a draft.
+func fillCompatDefaults(v any, tenant string) bool {
+	changed := false
+	switch node := v.(type) {
+	case map[string]any:
+		if jsonHasKeys(node, "id", "namespace", "tasks") {
+			changed = setJSONDefault(node, "draft", false) || changed
+		}
+		if jsonHasKeys(node, "flowId", "flowRevision", "state") {
+			changed = setJSONDefault(node, "tenantId", tenant) || changed
+		}
+		for _, child := range node {
+			changed = fillCompatDefaults(child, tenant) || changed
+		}
+	case []any:
+		for _, child := range node {
+			changed = fillCompatDefaults(child, tenant) || changed
+		}
+	}
+	return changed
+}
+
+func jsonHasKeys(m map[string]any, keys ...string) bool {
+	for _, k := range keys {
+		if _, ok := m[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func setJSONDefault(m map[string]any, key string, value any) bool {
+	if _, ok := m[key]; ok {
+		return false
+	}
+	m[key] = value
+	return true
+}
+
+// ServerVersion returns the Kestra version reported by the configuration
+// endpoint. It is fetched once per process; a failure is cached too, since a
+// CLI invocation has no later point at which a retry would help.
+func (c *Client) ServerVersion() (string, error) {
+	c.serverVersionOnce.Do(func() {
+		c.serverVersion, c.serverVersionErr = fetchKestraVersion(c)
+	})
+	return c.serverVersion, c.serverVersionErr
+}
+
+// isLegacyServer reports whether the server is known to run Kestra 1.x. An
+// unreachable or unparseable version (develop builds, snapshots) counts as
+// current: the shims exist for 1.x servers, not for unknown ones.
+func (c *Client) isLegacyServer() bool {
+	version, err := c.ServerVersion()
+	if err != nil {
+		return false
+	}
+	core, _ := splitVersion(version)
+	return core != [3]int{} && core[0] < 2
+}
+
+// requireKestra2 fails when the server is known to run Kestra 1.x, naming the
+// feature that needs 2.0. It does not block unknown servers — a real auth or
+// network problem surfaces on the very next call anyway; it exists to turn a
+// silent no-op on 1.x into an error.
+func requireKestra2(client *Client, feature string) error {
+	if !client.isLegacyServer() {
+		return nil
+	}
+	version, _ := client.ServerVersion()
+	return fmt.Errorf("%s is only available on Kestra 2.0 or later (the server runs %s)", feature, version)
+}

--- a/src/cli/compat_test.go
+++ b/src/cli/compat_test.go
@@ -1,0 +1,350 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// flow13 is a flow as a Kestra 1.3 server returns it: no `draft`.
+const flow13 = `{"id":"f","namespace":"ns","revision":1,"disabled":false,"deleted":false,"tasks":[],"source":"id: f"}`
+
+// execution13 is an execution summary as a Kestra 1.3 server returns it: no `tenantId`.
+const execution13 = `{"id":"e","originalId":"e","deleted":false,"metadata":{"attemptNumber":1,"originalCreatedDate":"2026-09-03T12:54:30Z"},"namespace":"ns","flowId":"f","flowRevision":1,"state":{"current":"SUCCESS","histories":[],"duration":"PT1S"}}`
+
+func TestFillCompatDefaults(t *testing.T) {
+	tests := []struct {
+		name    string
+		in      string
+		want    string
+		changed bool
+	}{
+		{
+			name:    "flow without draft gets draft=false",
+			in:      `{"id":"f","namespace":"ns","tasks":[]}`,
+			want:    `{"draft":false,"id":"f","namespace":"ns","tasks":[]}`,
+			changed: true,
+		},
+		{
+			name:    "flow with draft is left alone",
+			in:      `{"id":"f","namespace":"ns","tasks":[],"draft":true}`,
+			want:    `{"draft":true,"id":"f","namespace":"ns","tasks":[]}`,
+			changed: false,
+		},
+		{
+			name:    "flows nested in a page and in a list",
+			in:      `{"results":[{"id":"a","namespace":"ns","tasks":[]}],"total":1}`,
+			want:    `{"results":[{"draft":false,"id":"a","namespace":"ns","tasks":[]}],"total":1}`,
+			changed: true,
+		},
+		{
+			name:    "execution without tenantId gets the request tenant",
+			in:      `{"id":"e","flowId":"f","flowRevision":1,"state":{"current":"SUCCESS"}}`,
+			want:    `{"flowId":"f","flowRevision":1,"id":"e","state":{"current":"SUCCESS"},"tenantId":"acme"}`,
+			changed: true,
+		},
+		{
+			name:    "namespace is not a flow",
+			in:      `{"id":"ns","deleted":false}`,
+			want:    `{"deleted":false,"id":"ns"}`,
+			changed: false,
+		},
+		{
+			name:    "trigger is not an execution",
+			in:      `{"flowId":"f","namespace":"ns","triggerId":"t"}`,
+			want:    `{"flowId":"f","namespace":"ns","triggerId":"t"}`,
+			changed: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var v any
+			if err := json.Unmarshal([]byte(tt.in), &v); err != nil {
+				t.Fatal(err)
+			}
+			if got := fillCompatDefaults(v, "acme"); got != tt.changed {
+				t.Fatalf("changed = %v, want %v", got, tt.changed)
+			}
+			out, _ := json.Marshal(v)
+			if string(out) != tt.want {
+				t.Fatalf("got  %s\nwant %s", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestShimmedEndpoint(t *testing.T) {
+	tests := []struct {
+		path   string
+		tenant string
+		ok     bool
+	}{
+		{"/api/v1/acme/executions/search", "acme", true},
+		{"/api/v1/main/flows/ns/f", "main", true},
+		{"/api/v1/main/executions/flows/ns/f", "main", true},
+		{"/api/v1/main/namespaces/ns/kv/key", "main", false},
+		{"/api/v1/main/triggers/search", "main", false},
+		{"/api/v1/configs", "configs", false},
+		{"/api/v1/blueprints/community/flow/x", "blueprints", false},
+		{"/health", "", false},
+	}
+	for _, tt := range tests {
+		tenant, ok := shimmedEndpoint(tt.path)
+		if tenant != tt.tenant || ok != tt.ok {
+			t.Errorf("shimmedEndpoint(%q) = (%q, %v), want (%q, %v)", tt.path, tenant, ok, tt.tenant, tt.ok)
+		}
+	}
+}
+
+// versionHandler answers the /api/v1/configs probe with the given version and
+// delegates everything else.
+func versionHandler(version string, next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/configs" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"` + version + `"}`))
+			return
+		}
+		next(w, r)
+	}
+}
+
+func TestCompatTransport_DecodesKestra13Flows(t *testing.T) {
+	server := httptest.NewServer(versionHandler("1.3.35", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/revisions"):
+			_, _ = w.Write([]byte("[" + flow13 + "]"))
+		case strings.HasSuffix(r.URL.Path, "/flows/search"):
+			_, _ = w.Write([]byte(`{"results":[` + flow13 + `],"total":1}`))
+		default:
+			_, _ = w.Write([]byte(flow13))
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL)
+
+	revisions, _, err := client.API.FlowsAPI.ListFlowRevisions(client.Ctx, "ns", "f", "main").Execute()
+	if err != nil {
+		t.Fatalf("revisions: %v", err)
+	}
+	if len(revisions) != 1 || revisions[0].GetId() != "f" || revisions[0].GetDraft() {
+		t.Fatalf("unexpected revisions: %+v", revisions)
+	}
+
+	page, _, err := client.API.FlowsAPI.SearchFlows(client.Ctx, "main").Execute()
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if page.GetTotal() != 1 || len(page.GetResults()) != 1 {
+		t.Fatalf("unexpected page: %+v", page)
+	}
+
+	flow, _, err := client.API.FlowsAPI.Flow(client.Ctx, "ns", "f", "main").Execute()
+	if err != nil {
+		t.Fatalf("flow: %v", err)
+	}
+	if flow.GetSource() != "id: f" {
+		t.Fatalf("unexpected flow: %+v", flow)
+	}
+}
+
+func TestCompatTransport_DecodesKestra13ExecutionPageWithRequestTenant(t *testing.T) {
+	server := httptest.NewServer(versionHandler("1.3.35", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"results":[` + execution13 + `],"total":1}`))
+	}))
+	t.Cleanup(server.Close)
+	client := newTestClient(t, server.URL)
+
+	// The client's own tenant is "main"; the executions belong to the tenant
+	// in the request path.
+	page, err := client.Kestra.Executions().SearchExecutions(client.Ctx, "acme", nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("search executions: %v", err)
+	}
+	results := page.GetResults()
+	if len(results) != 1 || results[0].GetTenantId() != "acme" {
+		t.Fatalf("unexpected results: %+v", results)
+	}
+}
+
+func TestCompatTransport_PassesBodiesThroughUntouched(t *testing.T) {
+	// Bodies come back byte-identical, large integers included, whenever the
+	// shim has no business touching them: non-JSON, error statuses, endpoints
+	// other than flows/executions (a KV value may look exactly like a flow),
+	// and every response from a 2.x server.
+	flowish := `{"id":"x","namespace":"y","tasks":[{"id":"t"}],"big":9007199254740993}`
+	logs := `{"results":[{"executionId":"e","timestamp":1756789012345678901,"level":"INFO"}],"total":1}`
+	sse := "data: {\"id\":\"e\",\"flowId\":\"f\",\"flowRevision\":1,\"state\":{}}\n\n"
+	zip := "PK\x03\x04not-json"
+
+	newServer := func(version string) *httptest.Server {
+		server := httptest.NewServer(versionHandler(version, func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case strings.HasSuffix(r.URL.Path, "/sse"):
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(sse))
+			case strings.HasSuffix(r.URL.Path, "/zip"):
+				w.Header().Set("Content-Type", "application/zip")
+				_, _ = w.Write([]byte(zip))
+			case strings.HasSuffix(r.URL.Path, "/logs"):
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(logs))
+			case strings.HasSuffix(r.URL.Path, "/missing"):
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(flowish))
+			default:
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(flowish))
+			}
+		}))
+		t.Cleanup(server.Close)
+		return server
+	}
+
+	cases := []struct {
+		name, version, path, want string
+	}{
+		{"1.x kv value shaped like a flow", "1.3.35", "/api/v1/main/namespaces/ns/kv/k", flowish},
+		{"1.x logs page", "1.3.35", "/api/v1/main/logs", logs},
+		{"1.x SSE on an executions endpoint", "1.3.35", "/api/v1/main/executions/e/sse", sse},
+		{"1.x zip on a flows endpoint", "1.3.35", "/api/v1/main/flows/zip", zip},
+		{"1.x error body on a flows endpoint", "1.3.35", "/api/v1/main/flows/missing", flowish},
+		{"2.x flow endpoint", "2.0.0-rc13", "/api/v1/main/flows/ns/f", flowish},
+		{"2.x executions endpoint", "2.0.0-rc13", "/api/v1/main/executions/search", flowish},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			server := newServer(tt.version)
+			client := newTestClient(t, server.URL)
+			resp, err := client.API.GetConfig().HTTPClient.Get(server.URL + tt.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(body) != tt.want {
+				t.Errorf("body altered\ngot  %q\nwant %q", body, tt.want)
+			}
+		})
+	}
+}
+
+func TestCompatTransport_KeepsLargeIntegersWhenPatching(t *testing.T) {
+	server := httptest.NewServer(versionHandler("1.3.35", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"f","namespace":"ns","tasks":[],"big":9007199254740993}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClient(t, server.URL)
+	resp, err := client.API.GetConfig().HTTPClient.Get(server.URL + "/api/v1/main/flows/ns/f")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if !strings.Contains(string(body), `"big":9007199254740993`) || !strings.Contains(string(body), `"draft":false`) {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestRequireKestra2(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		status  int
+		wantErr string
+	}{
+		{name: "1.3 is refused", version: "1.3.35", status: 200, wantErr: "quotas is only available on Kestra 2.0 or later (the server runs 1.3.35)"},
+		{name: "2.0 rc is allowed", version: "2.0.0-rc13", status: 200},
+		{name: "2.1 is allowed", version: "2.1.0", status: 200},
+		{name: "develop build is not blocked", version: "develop-SNAPSHOT", status: 200},
+		{name: "unreachable version endpoint is not blocked", status: 500},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte(`{"version":"` + tt.version + `"}`))
+			}))
+			t.Cleanup(server.Close)
+			client := newTestClient(t, server.URL)
+
+			err := requireKestra2(client, "quotas")
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || err.Error() != tt.wantErr) {
+				t.Fatalf("got %v, want %q", err, tt.wantErr)
+			}
+
+			// The version is fetched once per client, not once per guard.
+			_ = requireKestra2(client, "quotas")
+			if calls.Load() != 1 {
+				t.Fatalf("configuration endpoint called %d times, want 1", calls.Load())
+			}
+		})
+	}
+}
+
+// newKestra13Server answers the version probe as a 1.3 server and fails the
+// test on any other request, proving a guarded command never reaches the API.
+func newKestra13Server(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/configs" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version":"1.3.35"}`))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestGuardedCommands_RefuseKestra2FeaturesOn13(t *testing.T) {
+	concurrency, err := parseConcurrencyFlags(10, true, "QUEUE", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	superAdmin := userMutation{superAdmin: true, superAdminSet: true}
+
+	tests := map[string]func(*Client) error{
+		"tenants create --concurrency-limit": func(c *Client) error {
+			return runTenantsCreate(c, "t", "t", concurrency, nil, newTableRenderer(io.Discard))
+		},
+		"namespaces create --concurrency-limit": func(c *Client) error {
+			return runNamespacesCreate(c, "ns", "", nil, concurrency, nil, newTableRenderer(io.Discard))
+		},
+		"users create --superadmin": func(c *Client) error {
+			return runUsersCreate(c, superAdmin, newTableRenderer(io.Discard))
+		},
+		"users set-super-admin": func(c *Client) error {
+			return runUsersPatchSuperAdmin(c, "u1", true, newTableRenderer(io.Discard))
+		},
+		"invitations create --superadmin": func(c *Client) error {
+			return runInvitationsCreate(c, "a@b.c", nil, nil, true, false, newTableRenderer(io.Discard))
+		},
+	}
+	for name, run := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := run(newTestClient(t, newKestra13Server(t).URL))
+			if err == nil || !strings.Contains(err.Error(), "only available on Kestra 2.0 or later") {
+				t.Fatalf("expected a Kestra 2.0 guard error, got %v", err)
+			}
+		})
+	}
+}

--- a/src/cli/flows_test.go
+++ b/src/cli/flows_test.go
@@ -1513,6 +1513,12 @@ const flowWithArrayLabelsJSON = `{"id":"my-flow","namespace":"my.namespace","rev
 
 func TestRunFlowsGet_ArrayLabels(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The version probe is answered 404 so the shim stays off and the
+		// raw-body fallback under test is what actually decodes the flow.
+		if r.URL.Path == "/api/v1/configs" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		if !strings.HasSuffix(r.URL.Path, "/flows/my.namespace/my-flow") {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
@@ -1560,6 +1566,12 @@ func TestRunFlowsGet_ArrayLabels_JSON(t *testing.T) {
 
 func TestRunFlowsList_Namespace_ArrayLabels(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The version probe is answered 404 so the shim stays off and the
+		// raw-body fallback under test is what actually decodes the flow.
+		if r.URL.Path == "/api/v1/configs" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		if !strings.HasSuffix(r.URL.Path, "/flows/my.namespace") {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}
@@ -1582,6 +1594,12 @@ func TestRunFlowsList_Namespace_ArrayLabels(t *testing.T) {
 
 func TestListAllFlows_Search_ArrayLabels(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The version probe is answered 404 so the shim stays off and the
+		// raw-body fallback under test is what actually decodes the flow.
+		if r.URL.Path == "/api/v1/configs" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		if !strings.HasSuffix(r.URL.Path, "/flows/search") {
 			t.Errorf("unexpected path: %s", r.URL.Path)
 		}

--- a/src/cli/invitations.go
+++ b/src/cli/invitations.go
@@ -277,6 +277,11 @@ of sending an invitation.`,
 }
 
 func runInvitationsCreate(client *Client, email string, roles, groups []string, superAdmin, createUserIfNotExist bool, renderer *Renderer) error {
+	if superAdmin {
+		if err := requireKestra2(client, "--superadmin"); err != nil {
+			return err
+		}
+	}
 	req := kestra.IAMInvitationControllerApiInvitationCreateRequest{Email: email, Groups: groups}
 	for _, roleID := range roles {
 		req.Roles = append(req.Roles, kestra.IAMInvitationControllerApiInvitationRole{Id: roleID})

--- a/src/cli/namespaces.go
+++ b/src/cli/namespaces.go
@@ -267,6 +267,11 @@ func newNamespacesCreateCommand() *cobra.Command {
 }
 
 func runNamespacesCreate(client *Client, id, description string, variables map[string]interface{}, concurrency *kestra.Concurrency, quotas []kestra.Quota, renderer *Renderer) error {
+	if concurrency != nil || quotas != nil {
+		if err := requireKestra2(client, "setting concurrency limits and quotas"); err != nil {
+			return err
+		}
+	}
 	ns := kestra.NewNamespace(id, false)
 	if description != "" {
 		ns.SetDescription(description)
@@ -416,6 +421,11 @@ previously set on the namespace.`,
 }
 
 func runNamespacesUpdate(client *Client, id, description string, descriptionSet bool, variables map[string]interface{}, concurrency *kestra.Concurrency, quotas []kestra.Quota, renderer *Renderer) error {
+	if concurrency != nil || quotas != nil {
+		if err := requireKestra2(client, "setting concurrency limits and quotas"); err != nil {
+			return err
+		}
+	}
 	// UpdateNamespace is a full-replace PUT: start from the current namespace
 	// so fields not passed on this invocation aren't wiped.
 	ns, _, err := client.API.NamespacesAPI.Namespace(client.Ctx, id, client.Tenant).Execute()

--- a/src/cli/nsfiles_test.go
+++ b/src/cli/nsfiles_test.go
@@ -13,14 +13,20 @@ import (
 
 func newTestClient(t *testing.T, serverURL string) *Client {
 	t.Helper()
+	// Wired like newClientDefault: one HTTP client with the Kestra 1.x response
+	// shim in front of both SDK clients.
+	httpClient, compat := newCompatHTTPClient()
 	cfg := kestra.NewConfiguration()
 	cfg.Servers = kestra.ServerConfigurations{{URL: serverURL}}
-	return &Client{
+	cfg.HTTPClient = httpClient
+	c := &Client{
 		API:    kestra.NewAPIClient(cfg),
-		Kestra: kestra.NewClient(serverURL),
+		Kestra: kestra.NewClient(serverURL, kestra.WithHTTPClient(httpClient)),
 		Ctx:    context.Background(),
 		Tenant: "main",
 	}
+	compat.legacyServer = c.isLegacyServer
+	return c
 }
 
 func TestNamespaceExists_OSSResponseMissingDeleted(t *testing.T) {

--- a/src/cli/service_accounts.go
+++ b/src/cli/service_accounts.go
@@ -220,6 +220,11 @@ Names must be lowercase alphanumeric, optionally separated by dashes.`,
 }
 
 func runServiceAccountsCreate(client *Client, m serviceAccountMutation, renderer *Renderer) error {
+	if m.superAdminSet && m.superAdmin {
+		if err := requireKestra2(client, "--superadmin"); err != nil {
+			return err
+		}
+	}
 	body := kestra.IAMServiceAccountControllerApiCreateServiceAccountRequest{Name: m.name}
 	if m.descriptionSet {
 		body.Description = &m.description
@@ -557,6 +562,9 @@ func newServiceAccountsSetSuperAdminCommand() *cobra.Command {
 }
 
 func runServiceAccountsSetSuperAdmin(client *Client, id string, superAdmin bool, renderer *Renderer) error {
+	if err := requireKestra2(client, "service-accounts set-super-admin"); err != nil {
+		return err
+	}
 	body := map[string]any{"instanceOwner": superAdmin}
 	if err := client.Kestra.ServiceAccount().PatchServiceAccountInstanceOwner(client.Ctx, id, body); err != nil {
 		return formatSDKError(err)

--- a/src/cli/tenants.go
+++ b/src/cli/tenants.go
@@ -180,6 +180,11 @@ func newTenantsCreateCommand() *cobra.Command {
 }
 
 func runTenantsCreate(client *Client, id, name string, concurrency *kestra.Concurrency, quotas []kestra.Quota, renderer *Renderer) error {
+	if concurrency != nil || quotas != nil {
+		if err := requireKestra2(client, "setting concurrency limits and quotas"); err != nil {
+			return err
+		}
+	}
 	if name == "" {
 		name = id
 	}
@@ -258,6 +263,11 @@ previously set on the tenant.`,
 }
 
 func runTenantsUpdate(client *Client, id, name string, nameSet bool, concurrency *kestra.Concurrency, quotas []kestra.Quota, renderer *Renderer) error {
+	if concurrency != nil || quotas != nil {
+		if err := requireKestra2(client, "setting concurrency limits and quotas"); err != nil {
+			return err
+		}
+	}
 	// UpdateTenant is a full-replace PUT: start from the current tenant so
 	// fields not passed on this invocation aren't wiped.
 	tenant, err := client.Kestra.Tenants().Tenant(client.Ctx, id)

--- a/src/cli/tenants_test.go
+++ b/src/cli/tenants_test.go
@@ -315,6 +315,11 @@ func TestRunTenantsGet_RendersConcurrencyAndQuotas(t *testing.T) {
 func TestRunTenantsCreate_SendsConcurrencyAndQuotas(t *testing.T) {
 	var gotBody map[string]interface{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/configs" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"2.0.0"}`))
+			return
+		}
 		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/tenants") {
 			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 		}

--- a/src/cli/users.go
+++ b/src/cli/users.go
@@ -332,6 +332,11 @@ func newUsersCreateCommand() *cobra.Command {
 }
 
 func runUsersCreate(client *Client, m userMutation, renderer *Renderer) error {
+	if m.superAdminSet && m.superAdmin {
+		if err := requireKestra2(client, "--superadmin"); err != nil {
+			return err
+		}
+	}
 	user, _, err := client.API.UsersAPI.CreateUser(client.Ctx).
 		IAMUserControllerApiCreateOrUpdateUserRequest(m.toRequest()).
 		Execute()
@@ -373,6 +378,11 @@ changed fields are merged on top before saving.`,
 }
 
 func runUsersUpdate(client *Client, id string, m userMutation, renderer *Renderer) error {
+	if m.superAdminSet && m.superAdmin {
+		if err := requireKestra2(client, "--superadmin"); err != nil {
+			return err
+		}
+	}
 	// The update endpoint is a full-replace PUT, so fetch the current user and
 	// overlay only the changed flags — otherwise unspecified attributes (e.g.
 	// superAdmin, groups) would be reset to their defaults.
@@ -869,6 +879,9 @@ func newUsersPatchSuperAdminCommand() *cobra.Command {
 }
 
 func runUsersPatchSuperAdmin(client *Client, id string, superAdmin bool, renderer *Renderer) error {
+	if err := requireKestra2(client, "users set-super-admin"); err != nil {
+		return err
+	}
 	body := map[string]any{"instanceOwner": superAdmin}
 	if err := client.Kestra.Users().PatchUserInstanceOwner(client.Ctx, id, body); err != nil {
 		return formatSDKError(err)


### PR DESCRIPTION
## Why

We want **one kestractl binary**: focused on Kestra 2.x, but best-effort usable against Kestra 1.3 for the everyday commands (deploy/validate/get flows, run executions, nsfiles, kv, namespaces). The wire protocol barely moved between 1.3 and 2.0 (same `/api/v1/{tenant}` endpoints, no enum removed, flow YAML is passed through as raw source), so what actually broke was narrow, and all of it lives in how the generated Go SDK decodes 1.x responses and in 2.0-only request fields a 1.x server silently drops.

## Behaviour on a Kestra 1.3 instance with this PR

Everyday commands work as on 2.0: `flows deploy/validate/get/list/search/revisions/export/import/delete/disable/enable`, `executions run/get/list/latest/watch/kill/replay/flow-info`, `logs`, `nsfiles`, `kv`, `namespaces list/get/create/update/delete`, `tenants list/create/update`, `users`/`service-accounts`/`invitations` reads and non-superadmin writes, `flows usage-report`. Flow YAML is passed through as raw source, so 1.3 syntax (`pluginDefaults`, `json()`, …) deploys and validates according to the server you target.

Notable differences on 1.3:

- **2.0-only writes are refused instead of silently ignored.** `users/service-accounts/invitations … --superadmin`, `users/service-accounts set-super-admin`, and `--concurrency-limit/--concurrency-behavior/--quota` on `namespaces`/`tenants` exit with `<feature> is only available on Kestra 2.0 or later (the server runs 1.3.x)`. Nothing is sent to the server. `--superadmin=false` and the same commands without those flags work.
- **Superadmin status displays as `false` for everyone.** 1.3 reports it as `superAdmin`, the v2 model reads `instanceOwner`. Read-only cosmetic gap; managing superadmins on 1.3 needs kestractl v1.
- **Namespace `pluginDefaults` / `workerGroup` are not shown** by `namespaces get`, and there is no command to manage them (removed in v2, #103). `namespaces update` does not wipe them — verified: 1.3 keeps fields absent from the PUT.
- **`executions eval-expression` fails** (403): it already uses the 2.0 `/actions/eval` path; see #117.
- One extra `GET /api/v1/configs` per invocation, only on the guarded write commands and on flow/execution reads, to learn the server version.

## What

`src/cli/compat.go`:

**`compatTransport`** — one `http.RoundTripper` shared by both SDK clients (generated `client.API` and hand-written `client.Kestra`). On a 2xx JSON response from `/api/v1/{tenant}/flows/…` or `/api/v1/{tenant}/executions/…`, **and only when the server is known to run 1.x**, it adds `draft:false` to flow objects (`id`+`namespace`+`tasks`) and `tenantId:<tenant from the request path>` to execution objects (`flowId`+`flowRevision`+`state`). Details that matter:
- decodes with `UseNumber` so integers > 2^53 round-trip verbatim;
- cheap `bytes.Contains` pre-filter, so most responses are never decoded;
- non-JSON (SSE, zip), error statuses, other endpoints (a KV value can look exactly like a flow) and every 2.x response come back byte-identical — tested;
- tenant from the path, not the client, because `flows usage-report` walks several tenants.

**`requireKestra2(client, feature)`** — `Client.ServerVersion()` fetches `/api/v1/configs` once per process (`sync.Once`, reusing `fetchKestraVersion`). Guards placed exactly where a 1.x server would silently drop the field:

| Call site | Guarded when |
|---|---|
| `users create/update`, `service-accounts create`, `invitations create` | `--superadmin=true` |
| `users set-super-admin`, `service-accounts set-super-admin` | always |
| `namespaces create/update`, `tenants create/update` | `--concurrency-*` or `--quota` set |

Error: `--superadmin is only available on Kestra 2.0 or later (the server runs 1.3.35)`. An unreachable or unparseable version (develop builds) does not block — the guard turns silent no-ops into errors; it is not a gate on unknown servers.

`newTestClient` now mirrors production wiring, so the whole existing suite exercises the transport.

## Verified

- `go test ./src/...`, `-race`, `go vet`, `gofmt` on touched files.
- Live on **EE 1.3.35**: all four broken commands now pass; guards fire; `--superadmin=false`, plain `namespaces update`, `tenants update --name` still allowed; KV value shaped like a flow comes back untouched; multi-tenant `executions list --tenant acme` stamps `acme`; SSE `executions watch` unbuffered; `flows usage-report` unaffected.
- Live on **EE 2.0.0-rc13**: same commands, no behaviour change; shim provably inert.
- Independent Opus review + Opus QA pass; findings applied (large-integer corruption, whole-body walk scope, tenant source, guard consistency).

## Out of scope — pre-existing, filed separately

The QA pass surfaced bugs that predate this PR, filed separately:
- #117 execution action endpoints (`kill`, `replay`, `restart`, …) use 1.x paths and 403/404 on 2.0
- #118 `triggers list` renders empty rows on 2.0
- #119 `--verbose` prints the raw `Authorization` header on generated-SDK requests
- #120 default-context token overrides `--username/--password`
- #121 `kv get` NUMBER precision loss above 2^53
- #122 `logs list` renders LEVEL with literal quotes
