### PR TITLE
feat(install): make kestractl v2 the default install channel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,11 +32,15 @@ jobs:
       - name: Run tests
         run: go test ./src/...
 
-      - name: Check installer is working
+      - name: Check installer defaults to the v2 line
         run: |
           cat ./install-scripts/install.sh | INSTALL_DIR=./ bash
-          ./kestractl --help
-      - name: Check installer is working when specifying version
+          ./kestractl version | grep -E '(^|[^0-9.])2\.[0-9]+\.[0-9]+'
+      - name: Check installer is working when specifying the v1 line
+        run: |
+          cat ./install-scripts/install.sh | VERSION=1 INSTALL_DIR=./ bash
+          ./kestractl version | grep -E '(^|[^0-9.])1\.[0-9]+\.[0-9]+'
+      - name: Check installer is working when specifying an exact version
         run: |
           cat ./install-scripts/install.sh | VERSION=1.0.0 INSTALL_DIR=./ bash
           ./kestractl --help

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,9 +46,10 @@ checksum:
 release:
   name_template: "{{ .Version }}"
   prerelease: auto
-  # main is the v2 line: never mark its releases as "latest" so the install
-  # script's default (GitHub's latest release) stays on the v1 line.
-  # Flip to "true" when v2 becomes the default install channel.
+  # main is the v2 line. install.sh no longer relies on GitHub's repo-wide
+  # "latest" pointer (it resolves the newest release of a major line), so this
+  # only drives the GitHub UI badge, which stays on the stable v1 line until
+  # 2.0.0 is GA. Flip to "true" (and releases/v1's to "false") at that point.
   make_latest: "false"
 
 changelog:

--- a/README.md
+++ b/README.md
@@ -6,22 +6,22 @@ A Go-based command-line interface for managing Kestra flows, executions, trigger
 
 ### use convenience script installer
 
-Install the latest kestractl v2 release (prereleases included):
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install-v2.sh | bash
-```
-
-Install the latest v1 release (for legacy Kestra v1.x instances):
+Install the latest kestractl v2 release (prereleases included until 2.0.0 is GA). kestractl v2 targets Kestra 2.x and works against Kestra 1.3 for everyday commands (flows, executions, namespace files, KV, namespaces); features that only exist in Kestra 2.0 are refused with a clear error on a 1.x server.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash
 ```
 
+Install the latest v1 release instead (full Kestra 1.x feature set, e.g. namespace plugin defaults and superadmin management):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION=1 bash
+```
+
 Install a specific version or custom directory:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION=1.0.0 INSTALL_DIR=~/.local/bin bash
+curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION=1.18.1 INSTALL_DIR=~/.local/bin bash
 ```
 
 ### or choose and download the proper binary for your OS/arch

--- a/install-scripts/install-v2.sh
+++ b/install-scripts/install-v2.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
-# Installs the latest kestractl v2 release (prereleases included) by default.
-# Thin wrapper around install.sh: defaults VERSION=2, everything else
-# (VERSION, INSTALL_DIR, BINARY_NAME, GITHUB_REPO) can still be overridden
-# via environment variables exactly like install.sh.
+# Installs the latest kestractl v2 release (prereleases included).
+#
+# Kept for links that predate install.sh defaulting to v2 — the two scripts now
+# do the same thing. Thin wrapper around install.sh: defaults VERSION=2,
+# everything else (VERSION, INSTALL_DIR, BINARY_NAME, GITHUB_REPO) can still be
+# overridden via environment variables exactly like install.sh.
 set -euo pipefail
 
 INSTALL_SCRIPT_URL="${INSTALL_SCRIPT_URL:-https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh}"

--- a/install-scripts/install.sh
+++ b/install-scripts/install.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 BINARY_NAME="${BINARY_NAME:-kestractl}"
 GITHUB_REPO="${GITHUB_REPO:-kestra-io/kestractl}"
 INSTALL_DIR="${INSTALL_DIR:-}"
+# The release line installed when VERSION is unset or "latest". kestractl v2
+# targets Kestra 2.x and stays usable against Kestra 1.3, so it is the default;
+# VERSION=1 selects the legacy v1 line, VERSION=x.y.z an exact release.
+DEFAULT_MAJOR="2"
 VERSION="${VERSION:-}"
 
 err() {
@@ -79,10 +83,13 @@ esac
 require awk
 release_json="$(mktemp)"
 if [ -z "$VERSION" ] || [ "$VERSION" = "latest" ]; then
-  download "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" "$release_json"
-elif echo "$VERSION" | grep -qE '^v?[0-9]+$'; then
+  VERSION="$DEFAULT_MAJOR"
+fi
+if echo "$VERSION" | grep -qE '^v?[0-9]+$'; then
   # Bare major version (e.g. VERSION=2 or VERSION=v2): resolve to the newest
-  # release of that major line, prereleases included.
+  # release of that major line, prereleases included. GitHub's own "latest"
+  # release is not used: it is a single repo-wide pointer, and v1 and v2 are
+  # released independently from their own branches.
   major="$(echo "$VERSION" | sed 's/^v//')"
   list_json="$(mktemp)"
   download "https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=100" "$list_json"


### PR DESCRIPTION
## Why

`install.sh` — the script the README points at — installed GitHub's repo-wide **latest** release, which `.goreleaser.yml` deliberately pins to the v1 line; v2 was opt-in via `VERSION=2` or the `install-v2.sh` wrapper. With #116 merged, the v2 binary handles everyday commands against Kestra 1.3 and refuses 2.0-only features with a clear error, so v2 can be the default channel.

## What

**`install-scripts/install.sh`**
- `DEFAULT_MAJOR="2"`: when `VERSION` is unset or `latest`, resolve the newest release of the v2 line (prereleases included, as `VERSION=2` already did).
- `VERSION=1` → newest v1 release; `VERSION=1.18.1` / `v1.18.1` / `1.0.0` → exact release, unchanged.
- GitHub's `/releases/latest` is no longer consulted at all — it is one repo-wide pointer and v1/v2 ship independently from their own branches, so it can only be right for one of them.

**`README.md`** — leads with `install.sh`, documents `VERSION=1` for the full 1.x feature set (plugin defaults, superadmin management), and states what v2 does on a 1.3 server.

**`install-scripts/install-v2.sh`** — kept as an alias so existing links keep working; comment updated.

**`.github/workflows/tests.yml`** — the installer check now asserts the default installs a `2.x.y` binary and `VERSION=1` a `1.x.y` one, plus the existing exact-version check.

**`.goreleaser.yml`** — comment only. `make_latest` stays `"false"` on `main`: it now only drives the GitHub UI "Latest" badge, which should stay on the stable v1 line until 2.0.0 is GA. Flipping it (and `releases/v1`'s to `"false"`) is a separate, deliberate step.

## Verified locally

| Input | Installed |
|---|---|
| *(unset)*, `latest`, `2`, `v2`, `install-v2.sh` | `kestractl v2.0.0-rc1` |
| `1` | `kestractl v1.18.1` |
| `1.0.0`, `v1.18.1` | exact |
| `9` | `Error: No release found for major version v9` |

## ⚠️ Follow-up needed before this is useful

The newest v2 release is **`v2.0.0-rc1` (2026-08-31)**, which predates #116 and everything since. Until a new v2 tag is pushed from `main`, the default install hands users an rc1 without the 1.x compatibility shims. Cut `v2.0.0-rc2` (or GA) right after merging.
