### PR TITLE
chore(ci): auto-tag and release main on every green Tests run

### DIFF
--- a/.github/scripts/check-sdk-pin.sh
+++ b/.github/scripts/check-sdk-pin.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Refuse to release while the Kestra Go SDK is pinned to anything but a clean tag.
+#
+# Per AGENTS.md a floating / pseudo-version / -SNAPSHOT / develop-tracking SDK pin is
+# a release blocker: pseudo-versions sort BELOW tagged releases in Go semver, so a
+# release built from one is not reproducible and `go get -u` can silently move it.
+#
+# Env override, used by check-sdk-pin_test.sh:
+#   GO_MOD  path to the go.mod to check (default: repo root go.mod)
+set -euo pipefail
+
+go_mod="${GO_MOD:-$(cd "$(dirname "$0")/../.." && pwd)/go.mod}"
+[ -f "$go_mod" ] || { printf 'check-sdk-pin: %s not found\n' "$go_mod" >&2; exit 1; }
+
+# Every go-sdk requirement, majors included (go-sdk, go-sdk/v2, ...).
+# A while-read pipeline rather than `mapfile`, which macOS's bash 3.2 lacks.
+pins="$(grep -oE 'github\.com/kestra-io/client-sdk/go-sdk(/v[0-9]+)?[[:space:]]+v[^[:space:]/]+' "$go_mod" || true)"
+
+if [ -z "$pins" ]; then
+  printf 'check-sdk-pin: no kestra-io/client-sdk/go-sdk requirement found in %s\n' "$go_mod" >&2
+  exit 1
+fi
+
+# A here-doc, not a pipe, so the loop runs in this shell and $status survives it.
+status=0
+while IFS= read -r pin; do
+  [ -n "$pin" ] || continue
+  module="${pin%%[[:space:]]*}"
+  version="${pin##*[[:space:]]}"
+
+  reason=""
+  # Pseudo-version. Go writes three shapes, and the timestamp is preceded by "-"
+  # in the bare form but by "." in the two that build on a base version:
+  #   v2.0.0-<ts>-<sha>  |  v1.1.1-0.<ts>-<sha>  |  v1.1.1-rc1.0.<ts>-<sha>
+  if printf '%s' "$version" | grep -qE -- '[-.][0-9]{14}-[0-9a-f]{12}$'; then
+    reason="a pseudo-version (tracks a branch, not a release)"
+  elif printf '%s' "$version" | grep -qiE -- '-SNAPSHOT'; then
+    reason="a -SNAPSHOT build"
+  elif printf '%s' "$version" | grep -qE -- '\+incompatible$'; then
+    reason="an +incompatible version"
+  elif ! printf '%s' "$version" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+    reason="not a vX.Y.Z[-prerelease] version"
+  fi
+
+  if [ -n "$reason" ]; then
+    printf 'check-sdk-pin: %s is pinned to %s, which is %s.\n' "$module" "$version" "$reason" >&2
+    printf '               Pin a released tag before releasing (see AGENTS.md "Branching & Releases").\n' >&2
+    status=1
+  else
+    printf 'check-sdk-pin: %s %s ok\n' "$module" "$version"
+  fi
+done <<PINS
+$pins
+PINS
+
+exit "$status"

--- a/.github/scripts/check-sdk-pin.sh
+++ b/.github/scripts/check-sdk-pin.sh
@@ -12,6 +12,17 @@ set -euo pipefail
 go_mod="${GO_MOD:-$(cd "$(dirname "$0")/../.." && pwd)/go.mod}"
 [ -f "$go_mod" ] || { printf 'check-sdk-pin: %s not found\n' "$go_mod" >&2; exit 1; }
 
+# A `replace` redirecting the SDK defeats the version check below entirely: the
+# `require` line can name a clean tag while the build actually resolves a fork, a
+# pseudo-version, or a local directory. Reject any replace touching the module.
+replaces="$(grep -nE '^[[:space:]]*(replace[[:space:]]+)?github\.com/kestra-io/client-sdk/go-sdk(/v[0-9]+)?[[:space:]]+=>' "$go_mod" || true)"
+if [ -n "$replaces" ]; then
+  printf 'check-sdk-pin: go.mod replaces the Kestra Go SDK:\n' >&2
+  printf '%s\n' "$replaces" | sed 's/^/               /' >&2
+  printf '               A replaced SDK is not what users get. Drop it before releasing.\n' >&2
+  exit 1
+fi
+
 # Every go-sdk requirement, majors included (go-sdk, go-sdk/v2, ...).
 # A while-read pipeline rather than `mapfile`, which macOS's bash 3.2 lacks.
 pins="$(grep -oE 'github\.com/kestra-io/client-sdk/go-sdk(/v[0-9]+)?[[:space:]]+v[^[:space:]/]+' "$go_mod" || true)"

--- a/.github/scripts/check-sdk-pin_test.sh
+++ b/.github/scripts/check-sdk-pin_test.sh
@@ -55,6 +55,18 @@ check 'no go-sdk requirement' reject \
 check 'mixed pins' reject \
   "$(printf 'module m\n\nrequire (\n\tgithub.com/kestra-io/client-sdk/go-sdk v1.3.0\n\tgithub.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-0.20260702143038-8c3851bea2e1\n)\n')"
 
+# A `replace` defeats the require-line check: the pin can read clean while the build
+# resolves something else entirely.
+check 'replace to a pseudo-version' reject \
+  "$(printf 'module m\n\nrequire (\n\tgithub.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3\n)\n\nreplace github.com/kestra-io/client-sdk/go-sdk/v2 => github.com/foo/bar v0.0.0-20260702143038-8c3851bea2e1\n')"
+check 'replace to a local dir' reject \
+  "$(printf 'module m\n\nrequire (\n\tgithub.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3\n)\n\nreplace github.com/kestra-io/client-sdk/go-sdk/v2 => ../client-sdk/go-sdk\n')"
+check 'replace inside a block' reject \
+  "$(printf 'module m\n\nrequire (\n\tgithub.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3\n)\n\nreplace (\n\tgithub.com/kestra-io/client-sdk/go-sdk/v2 => ../go-sdk\n)\n')"
+# An unrelated replace must not block a release.
+check 'unrelated replace' accept \
+  "$(printf 'module m\n\nrequire (\n\tgithub.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3\n)\n\nreplace github.com/spf13/cobra => github.com/fork/cobra v1.9.0\n')"
+
 if [ "$failures" -ne 0 ]; then
   printf '\n%d test(s) failed\n' "$failures"
   exit 1

--- a/.github/scripts/check-sdk-pin_test.sh
+++ b/.github/scripts/check-sdk-pin_test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Tests for check-sdk-pin.sh, the release blocker guarding the Go SDK pin.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+script="$here/check-sdk-pin.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+failures=0
+
+# check <name> <accept|reject> <go.mod body>
+check() {
+  local name="$1" want="$2" body="$3"
+  local f="$tmp/go.mod"
+  printf '%s\n' "$body" >"$f"
+
+  local got=accept
+  GO_MOD="$f" bash "$script" >/dev/null 2>&1 || got=reject
+
+  if [ "$got" != "$want" ]; then
+    printf 'FAIL %s: want %s, got %s\n' "$name" "$want" "$got"
+    failures=$((failures + 1))
+    return
+  fi
+  printf 'ok   %s -> %s\n' "$name" "$got"
+}
+
+req() { printf 'module github.com/kestra-io/kestractl\n\nrequire (\n\t%s\n)\n' "$1"; }
+
+# Clean tags release.
+check 'released tag' accept \
+  "$(req 'github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3')"
+check 'GA tag' accept \
+  "$(req 'github.com/kestra-io/client-sdk/go-sdk/v2 v2.1.0')"
+check 'v1 module path' accept \
+  "$(req 'github.com/kestra-io/client-sdk/go-sdk v1.3.0')"
+
+# The real pin this repo carried on main (commit "fix: pin go-sdk to a
+# develop-tracking pseudo-version") -- exactly what must never be released.
+check 'develop-tracking pseudo-version' reject \
+  "$(req 'github.com/kestra-io/client-sdk/go-sdk v1.1.1-0.20260702143038-8c3851bea2e1')"
+check 'bare pseudo-version' reject \
+  "$(req 'github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-20260702143038-8c3851bea2e1')"
+check 'snapshot' reject \
+  "$(req 'github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-SNAPSHOT')"
+check 'incompatible' reject \
+  "$(req 'github.com/kestra-io/client-sdk/go-sdk v2.0.0+incompatible')"
+
+# A missing requirement means the grep silently matched nothing -- fail loudly
+# rather than release something unverified.
+check 'no go-sdk requirement' reject \
+  "$(req 'github.com/spf13/cobra v1.8.0')"
+
+# One bad pin among good ones must still block.
+check 'mixed pins' reject \
+  "$(printf 'module m\n\nrequire (\n\tgithub.com/kestra-io/client-sdk/go-sdk v1.3.0\n\tgithub.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-0.20260702143038-8c3851bea2e1\n)\n')"
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d test(s) failed\n' "$failures"
+  exit 1
+fi
+printf '\nall check-sdk-pin.sh tests passed\n'

--- a/.github/scripts/next-version.sh
+++ b/.github/scripts/next-version.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Compute the next release tag from the conventional commits since the last tag.
+#
+# Prints the tag to stdout (and appends "tag=<value>" to $GITHUB_OUTPUT when set).
+# Prints nothing and writes an empty value when the range warrants no release.
+#
+# Bump mapping, from each commit's SUBJECT line:
+#   <type>!: / BREAKING CHANGE: in the body    -> major
+#   feat:                                      -> minor
+#   fix: perf: build: refactor: chore(deps):   -> patch
+#   docs: test: chore: ci: style:              -> none
+# The highest bump in the range wins. "[skip release]" in a subject, or alone on
+# its own line, forces none.
+#
+# Only the subject carries the type, per the conventional-commits spec. Bodies are
+# scanned solely for BREAKING CHANGE: and [skip release] -- a body that merely
+# discusses "feat:" or "fix:" must not trigger a release, which is why commits are
+# parsed as NUL-separated records rather than as a flat stream of lines.
+#
+# On a prerelease base (vX.Y.Z-rcN or vX.Y.Z-rc.N) any non-none bump only advances
+# the rc counter and normalises it to the dotted form: the semver triple is frozen
+# until GA is tagged by hand. The dot matters -- "rcN" is a single alphanumeric
+# identifier compared as a string, so rc10 would sort BELOW rc9, whereas the dotted
+# form is a numeric identifier and increments correctly without bound.
+#
+# Env overrides, used by next-version_test.sh:
+#   LATEST_TAG           base tag, instead of `git describe`. Unless
+#                        COMMIT_MESSAGES_FILE is also set, the tag must exist:
+#                        the commit range is still `$LATEST_TAG..HEAD`.
+#   COMMIT_MESSAGES_FILE file of NUL-separated commit messages, instead of `git log`
+#                        (as produced by `git log -z --format=%B`)
+set -euo pipefail
+
+die() {
+  printf 'next-version: %s\n' "$1" >&2
+  exit 1
+}
+
+# Rank so the highest bump across the range wins regardless of commit order.
+rank() {
+  case "$1" in
+    none) echo 0 ;;
+    patch) echo 1 ;;
+    minor) echo 2 ;;
+    major) echo 3 ;;
+    *) die "unknown bump level: $1" ;;
+  esac
+}
+
+# Bump level for one commit's subject line, ignoring any body.
+subject_bump() {
+  local subject="$1" type scope breaking
+
+  # ^type(scope)?!?: subject
+  if ! printf '%s' "$subject" | grep -qE '^[a-z]+(\([^)]*\))?!?:[[:space:]]'; then
+    printf 'none\n'
+    return 0
+  fi
+
+  type="$(printf '%s' "$subject" | sed -E 's/^([a-z]+).*/\1/')"
+  scope="$(printf '%s' "$subject" | sed -nE 's/^[a-z]+\(([^)]*)\).*/\1/p')"
+  breaking="$(printf '%s' "$subject" | sed -nE 's/^[a-z]+(\([^)]*\))?(!):.*/\2/p')"
+
+  if [ -n "$breaking" ]; then
+    printf 'major\n'
+    return 0
+  fi
+
+  case "$type" in
+    feat) printf 'minor\n' ;;
+    fix | perf | build | refactor) printf 'patch\n' ;;
+    # A dependency bump changes runtime behaviour and must ship; a bare chore:
+    # (tidying, metadata, CI) must not.
+    chore)
+      if [ "$scope" = "deps" ]; then printf 'patch\n'; else printf 'none\n'; fi
+      ;;
+    *) printf 'none\n' ;;
+  esac
+}
+
+latest="${LATEST_TAG:-}"
+if [ -z "$latest" ]; then
+  # Nearest tag by commit topology. Deliberately NOT `git tag --sort=-v:refname`:
+  # git's version sort mis-orders prerelease suffixes unless versionsort.suffix is
+  # configured, and this repo's rc tags are exactly that case.
+  latest="$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)"
+  [ -n "$latest" ] || die "no v* tag reachable from HEAD (were tags fetched? needs fetch-depth: 0)"
+fi
+
+if [ -n "${COMMIT_MESSAGES_FILE:-}" ]; then
+  records="$COMMIT_MESSAGES_FILE"
+else
+  records="$(mktemp)"
+  trap 'rm -f "$records"' EXIT
+  # `-z` NUL-TERMINATES each commit. `--format=%B%x00` looks equivalent but is not:
+  # git joins entries with a newline, so every record after the first would begin
+  # with "\n" and its subject line would read as empty -- silently classifying only
+  # the newest commit in the range.
+  git log -z --format=%B "${latest}..HEAD" >"$records"
+fi
+
+bump=none
+skip=0
+# read -d '' consumes the NUL-separated records git log emits.
+while IFS= read -r -d '' record; do
+  # First non-blank line, so a stray leading newline cannot blank out the subject.
+  subject_line="$(printf '%s' "$record" | sed -n '/./{p;q;}')"
+
+  # Honour [skip release] only in the subject or on a line of its own. Matching it
+  # anywhere would let prose that merely mentions the marker -- release notes, a
+  # commit documenting this very feature -- silently suppress a real release.
+  if printf '%s' "$subject_line" | grep -qF '[skip release]' ||
+    printf '%s' "$record" | grep -qE '^[[:space:]]*\[skip release\][[:space:]]*$'; then
+    skip=1
+  fi
+
+  this="$(subject_bump "$subject_line")"
+
+  # A BREAKING CHANGE: footer promotes the commit regardless of its type, but only
+  # if the commit is conventional at all -- otherwise a quoted footer in a merge
+  # blurb would escalate the whole range.
+  if [ "$this" != none ] && printf '%s' "$record" | grep -qE '^BREAKING[ -]CHANGE:'; then
+    this=major
+  fi
+
+  if [ "$(rank "$this")" -gt "$(rank "$bump")" ]; then
+    bump="$this"
+  fi
+done <"$records"
+
+emit() {
+  local tag="${1:-}"
+  [ -n "$tag" ] && printf '%s\n' "$tag"
+  [ -n "${GITHUB_OUTPUT:-}" ] && printf 'tag=%s\n' "$tag" >>"$GITHUB_OUTPUT"
+  return 0
+}
+
+if [ "$skip" -eq 1 ]; then
+  printf 'next-version: [skip release] found in the range; no tag.\n' >&2
+  emit ""
+  exit 0
+fi
+if [ "$bump" = none ]; then
+  printf 'next-version: no release-worthy commits since %s; no tag.\n' "$latest" >&2
+  emit ""
+  exit 0
+fi
+
+printf '%s' "$latest" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-.+)?$' \
+  || die "base tag '$latest' is not a vX.Y.Z[-prerelease] version"
+
+core="$(printf '%s' "$latest" | sed -E 's/^v([0-9]+\.[0-9]+\.[0-9]+).*/\1/')"
+pre="$(printf '%s' "$latest" | sed -nE 's/^v[0-9]+\.[0-9]+\.[0-9]+-(.+)$/\1/p')"
+major="${core%%.*}"
+patch="${core##*.}"
+minor="${core#*.}"
+minor="${minor%%.*}"
+
+if [ -n "$pre" ]; then
+  # Prerelease base: advance the counter only, and normalise rcN -> rc.N.
+  n="$(printf '%s' "$pre" | sed -nE 's/^rc\.?([0-9]+)$/\1/p')"
+  [ -n "$n" ] || die "base tag '$latest' has an unrecognised prerelease suffix '$pre'; expected rcN or rc.N. Refusing to guess -- tag GA by hand first."
+  next="v${core}-rc.$((n + 1))"
+  printf 'next-version: %s bump on prerelease base %s -> advancing rc counter.\n' "$bump" "$latest" >&2
+else
+  case "$bump" in
+    major) next="v$((major + 1)).0.0" ;;
+    minor) next="v${major}.$((minor + 1)).0" ;;
+    patch) next="v${major}.${minor}.$((patch + 1))" ;;
+  esac
+  printf 'next-version: %s bump on release base %s.\n' "$bump" "$latest" >&2
+fi
+
+printf 'next-version: %s -> %s\n' "$latest" "$next" >&2
+emit "$next"

--- a/.github/scripts/next-version.sh
+++ b/.github/scripts/next-version.sh
@@ -9,8 +9,8 @@
 #   feat:                                      -> minor
 #   fix: perf: build: refactor: chore(deps):   -> patch
 #   docs: test: chore: ci: style:              -> none
-# The highest bump in the range wins. "[skip release]" in a subject, or alone on
-# its own line, forces none.
+# The highest bump in the range wins. "[skip release]" on the head commit -- in its
+# subject, or alone on its own line -- forces none.
 #
 # Only the subject carries the type, per the conventional-commits spec. Bodies are
 # scanned solely for BREAKING CHANGE: and [skip release] -- a body that merely
@@ -101,16 +101,26 @@ fi
 
 bump=none
 skip=0
+# Records arrive newest-first, so index 0 is the commit a release would be cut at.
+index=0
 # read -d '' consumes the NUL-separated records git log emits.
 while IFS= read -r -d '' record; do
   # First non-blank line, so a stray leading newline cannot blank out the subject.
   subject_line="$(printf '%s' "$record" | sed -n '/./{p;q;}')"
 
-  # Honour [skip release] only in the subject or on a line of its own. Matching it
-  # anywhere would let prose that merely mentions the marker -- release notes, a
-  # commit documenting this very feature -- silently suppress a real release.
-  if printf '%s' "$subject_line" | grep -qF '[skip release]' ||
-    printf '%s' "$record" | grep -qE '^[[:space:]]*\[skip release\][[:space:]]*$'; then
+  # Honour [skip release] only on the HEAD commit -- the one a release would be cut
+  # at -- and only in its subject or alone on a line of its own.
+  #
+  # Head-only matters: skipping does not push a tag, so the base tag does not
+  # advance and a marked commit stays inside `$latest..HEAD` on every later run.
+  # Matching it anywhere in the range therefore latched the whole release line off
+  # permanently after one marked merge. Restricting to prose-safe positions matters
+  # for the same reason the type is read only from the subject: a message that
+  # merely mentions the marker must not suppress a real release.
+  if [ "$index" -eq 0 ] && {
+    printf '%s' "$subject_line" | grep -qF '[skip release]' ||
+      printf '%s' "$record" | grep -qE '^[[:space:]]*\[skip release\][[:space:]]*$'
+  }; then
     skip=1
   fi
 
@@ -119,13 +129,22 @@ while IFS= read -r -d '' record; do
   # A BREAKING CHANGE: footer promotes the commit regardless of its type, but only
   # if the commit is conventional at all -- otherwise a quoted footer in a merge
   # blurb would escalate the whole range.
-  if [ "$this" != none ] && printf '%s' "$record" | grep -qE '^BREAKING[ -]CHANGE:'; then
-    this=major
+  #
+  # Per Conventional Commits this is a FOOTER, so only the last paragraph counts.
+  # Scanning every line let a fix: whose body quotes the policy (which AGENTS.md
+  # now spells out verbatim, so it invites pasting) silently cut a major release.
+  if [ "$this" != none ]; then
+    footer="$(printf '%s\n' "$record" | awk 'BEGIN { RS = "" } END { print }')"
+    if printf '%s' "$footer" | grep -qE '^BREAKING[ -]CHANGE:'; then
+      this=major
+    fi
   fi
 
   if [ "$(rank "$this")" -gt "$(rank "$bump")" ]; then
     bump="$this"
   fi
+
+  index=$((index + 1))
 done <"$records"
 
 emit() {

--- a/.github/scripts/next-version_test.sh
+++ b/.github/scripts/next-version_test.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Table-driven tests for next-version.sh. Release-critical math, so it is unit
+# tested rather than discovered in production.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+script="$here/next-version.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+failures=0
+
+# check <name> <latest-tag> <expected-tag-or-empty> <commit messages...>
+# Each trailing argument is ONE whole commit message, newlines and all.
+check() {
+  local name="$1" latest="$2" want="$3"
+  shift 3
+  local f="$tmp/records"
+  printf '%s\0' "$@" >"$f"
+
+  local got status
+  got="$(LATEST_TAG="$latest" COMMIT_MESSAGES_FILE="$f" bash "$script" 2>/dev/null)"
+  status=$?
+
+  if [ "$status" -ne 0 ]; then
+    printf 'FAIL %s: exited %d\n' "$name" "$status"
+    failures=$((failures + 1))
+    return
+  fi
+  if [ "$got" != "$want" ]; then
+    printf 'FAIL %s: want %s, got %s\n' "$name" "${want:-<none>}" "${got:-<none>}"
+    failures=$((failures + 1))
+    return
+  fi
+  printf 'ok   %s -> %s\n' "$name" "${got:-<none>}"
+}
+
+# check_fails <name> <latest-tag> <commit messages...>
+check_fails() {
+  local name="$1" latest="$2"
+  shift 2
+  local f="$tmp/records"
+  printf '%s\0' "$@" >"$f"
+  if LATEST_TAG="$latest" COMMIT_MESSAGES_FILE="$f" bash "$script" >/dev/null 2>&1; then
+    printf 'FAIL %s: expected a non-zero exit\n' "$name"
+    failures=$((failures + 1))
+    return
+  fi
+  printf 'ok   %s -> refused\n' "$name"
+}
+
+# --- prerelease base: the counter advances, the semver triple is frozen ---
+check 'rc2 + feat'                v2.0.0-rc2  v2.0.0-rc.3  'feat(cli): add a thing'
+check 'rc2 + fix'                 v2.0.0-rc2  v2.0.0-rc.3  'fix(cli): fix a thing'
+check 'legacy rc1 normalises'     v2.0.0-rc1  v2.0.0-rc.2  'feat: x'
+check 'dotted rc.9 -> rc.10'      v2.0.0-rc.9 v2.0.0-rc.10 'fix: x'
+check 'breaking stays on rc line' v2.0.0-rc2  v2.0.0-rc.3  'feat(cli)!: drop a flag'
+check 'BREAKING CHANGE body'      v2.0.0-rc2  v2.0.0-rc.3  "$(printf 'feat: x\n\nBREAKING CHANGE: nope')"
+
+# --- release base: standard semver ---
+check 'GA + feat'  v2.1.0 v2.2.0 'feat: x'
+check 'GA + fix'   v2.1.0 v2.1.1 'fix: x'
+check 'GA + perf'  v2.1.0 v2.1.1 'perf: x'
+check 'GA + build' v2.1.0 v2.1.1 'build: x'
+check 'GA + feat!' v2.1.0 v3.0.0 'feat!: x'
+check 'GA + BREAKING CHANGE body' v2.1.0 v3.0.0 "$(printf 'fix: x\n\nBREAKING CHANGE: nope')"
+check 'double-digit minor' v2.9.0  v2.10.0 'feat: x'
+check 'double-digit patch' v2.1.9  v2.1.10 'fix: x'
+
+# --- multi-commit ranges: every record must be classified, not just the newest ---
+# These inject records directly, so they cover the ranking loop, NOT the git output
+# format -- the real `git log` invocation is pinned by the fixture test at the end.
+check 'feat behind a chore'  v2.0.0-rc2 v2.0.0-rc.3 \
+  "$(printf 'chore: tidy\n\nbody\n')" "$(printf 'feat(cli): a real feature\n\nbody\n')"
+check 'feat behind two docs' v2.1.0 v2.2.0 \
+  "$(printf 'docs: a\n\nbody\n')" "$(printf 'docs: b\n\nbody\n')" "$(printf 'feat: c\n\nbody\n')"
+check 'breaking last'        v2.1.0 v3.0.0 \
+  "$(printf 'fix: a\n\nbody\n')" "$(printf 'feat!: b\n\nbody\n')"
+
+# --- highest bump in the range wins, regardless of order ---
+check 'feat then fix' v2.1.0 v2.2.0 'fix: a' 'feat: b'
+check 'fix then feat' v2.1.0 v2.2.0 'feat: b' 'fix: a'
+check 'feat then breaking' v2.1.0 v3.0.0 'feat: b' 'fix!: a'
+
+# --- no release ---
+check 'docs only'             v2.0.0-rc2 '' 'docs: readme'
+check 'chore/test/ci only'    v2.0.0-rc2 '' 'chore: tidy' 'test: more' 'ci: tweak'
+check 'style only'            v2.0.0-rc2 '' 'style: gofmt'
+check 'no conventional match' v2.0.0-rc2 '' 'Merge branch main' 'wip'
+check 'empty range'           v2.0.0-rc2 '' ''
+
+# --- only the SUBJECT carries the type; a body that discusses types must not ---
+# Regression: this project's own "chore(ci): ..." commit has a body reading
+# "computes v2.0.0 for both / feat: and fix:, which would ...". Classifying per
+# line rather than per commit read that as a feat and cut a spurious release.
+check 'body mentioning feat:' v2.0.0-rc2 '' "$(printf 'chore(ci): wire up the tagger\n\ncomputes v2.0.0 for both\nfeat: and fix:, which would silently release.\n')"
+check 'body quoting fix:'     v2.0.0-rc2 '' "$(printf 'docs: explain the mapping\n\nfix: maps to patch\nfeat: maps to minor\n')"
+# ...but a real feat subject with a chatty body still releases.
+check 'feat with chatty body' v2.0.0-rc2 v2.0.0-rc.3 "$(printf 'feat(cli): add a flag\n\ndocs: not a real subject\nchore: nor this\n')"
+
+# --- chore(deps) ships, bare chore does not ---
+check 'chore(deps)'      v2.1.0 v2.1.1 'chore(deps): bump go-sdk to v2.0.0-rc3'
+check 'chore(sdk)'       v2.1.0 ''     'chore(sdk): unrelated scope'
+check 'chore(ci)'        v2.1.0 ''     'chore(ci): a CI change does not release'
+
+# --- the [skip release] escape hatch beats every other commit ---
+check 'skip in subject'       v2.1.0 '' 'feat: big thing [skip release]'
+check 'skip on its own line'  v2.1.0 '' "$(printf 'feat: big thing\n\n[skip release]\n')"
+check 'skip indented line'    v2.1.0 '' "$(printf 'feat: big thing\n\n  [skip release]  \n')"
+check 'skip in another commit' v2.1.0 '' 'feat: shipped' 'chore: oops [skip release]'
+
+# Prose that merely MENTIONS the marker must not suppress a real release. The
+# commit introducing this feature documents "[skip release]" in its own body, which
+# is how the too-broad match was noticed.
+check 'marker mentioned in prose' v2.1.0 v2.2.0 \
+  "$(printf 'feat(cli): add a flag\n\nbodies are scanned for [skip release] only on\ntheir own line, not anywhere.\n')"
+check 'marker mid-sentence'       v2.1.0 v2.2.0 \
+  "$(printf 'feat: a thing\n\nnot using [skip release] here, we want this out.\n')"
+
+# --- refuse to guess rather than invent a version ---
+check_fails 'unknown prerelease suffix' v2.0.0-beta7 'feat: x'
+check_fails 'unparseable base tag'      not-a-tag    'feat: x'
+# ...but a no-op range is fine on any base, since no math is needed.
+check 'unknown suffix, no-op range' v2.0.0-beta7 '' 'docs: x'
+
+# --- the real `git log` path, against a throwaway repo ---
+# This is the only test that exercises how commits are read out of git, and the
+# reason it exists: `git log --format=%B%x00` joins entries with a newline, so every
+# record after the first began with "\n", its subject read as empty, and only the
+# newest commit in the range was ever classified. `git log -z` terminates records
+# with NUL and has no such seam. Record-injection tests cannot catch that.
+check_repo() {
+  local name="$1" want="$2"
+  shift 2
+  local repo="$tmp/repo"
+  rm -rf "$repo"
+  mkdir -p "$repo"
+
+  (
+    cd "$repo"
+    git init -q
+    git config user.email t@example.com
+    git config user.name test
+    git config commit.gpgsign false
+    git commit -q --allow-empty -m "chore: base"
+    git tag v2.0.0-rc2
+    for msg in "$@"; do
+      git commit -q --allow-empty -m "$msg"
+    done
+  )
+
+  local got
+  got="$(cd "$repo" && bash "$script" 2>/dev/null)"
+  if [ "$got" != "$want" ]; then
+    printf 'FAIL %s: want %s, got %s\n' "$name" "${want:-<none>}" "${got:-<none>}"
+    failures=$((failures + 1))
+    return
+  fi
+  printf 'ok   %s -> %s\n' "$name" "${got:-<none>}"
+}
+
+# A feat behind two non-releasing commits: only reachable if every record parses.
+check_repo 'git: feat behind chores' v2.0.0-rc.3 \
+  "feat(cli): the real feature" "chore: tidy up" "docs: explain it"
+# The base tag is found by git describe, and a no-op range stays a no-op.
+check_repo 'git: no-op range'       ''          "docs: only" "chore: only"
+# Multi-paragraph bodies must not shift the record boundaries.
+check_repo 'git: multiline bodies'  v2.0.0-rc.3 \
+  "$(printf 'fix(cli): a fix\n\nfirst para\n\nsecond para\n')" \
+  "$(printf 'chore: tidy\n\nfeat: a body line that must be ignored\n')"
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d test(s) failed\n' "$failures"
+  exit 1
+fi
+printf '\nall next-version.sh tests passed\n'

--- a/.github/scripts/next-version_test.sh
+++ b/.github/scripts/next-version_test.sh
@@ -18,7 +18,7 @@ check() {
   printf '%s\0' "$@" >"$f"
 
   local got status
-  got="$(LATEST_TAG="$latest" COMMIT_MESSAGES_FILE="$f" bash "$script" 2>/dev/null)"
+  got="$(env -u GITHUB_OUTPUT LATEST_TAG="$latest" COMMIT_MESSAGES_FILE="$f" bash "$script" 2>/dev/null)"
   status=$?
 
   if [ "$status" -ne 0 ]; then
@@ -40,7 +40,7 @@ check_fails() {
   shift 2
   local f="$tmp/records"
   printf '%s\0' "$@" >"$f"
-  if LATEST_TAG="$latest" COMMIT_MESSAGES_FILE="$f" bash "$script" >/dev/null 2>&1; then
+  if env -u GITHUB_OUTPUT LATEST_TAG="$latest" COMMIT_MESSAGES_FILE="$f" bash "$script" >/dev/null 2>&1; then
     printf 'FAIL %s: expected a non-zero exit\n' "$name"
     failures=$((failures + 1))
     return
@@ -97,6 +97,17 @@ check 'body quoting fix:'     v2.0.0-rc2 '' "$(printf 'docs: explain the mapping
 # ...but a real feat subject with a chatty body still releases.
 check 'feat with chatty body' v2.0.0-rc2 v2.0.0-rc.3 "$(printf 'feat(cli): add a flag\n\ndocs: not a real subject\nchore: nor this\n')"
 
+# --- BREAKING CHANGE is a FOOTER: only the last paragraph counts ---
+# Regression: matching any body line let a fix: whose body quotes the policy cut a
+# major release. AGENTS.md documents the footer verbatim, so it invites pasting.
+check 'BC quoted mid-body'    v2.1.0 v2.1.1 \
+  "$(printf 'fix(cli): a small fix\n\nBREAKING CHANGE: is a footer that maps to major, per the table.\n\nthe actual footer paragraph\n')"
+check 'BC in prose only'      v2.1.0 v2.2.0 \
+  "$(printf 'feat: a thing\n\nBREAKING CHANGE: would escalate this, so we do not write one.\n\nnothing to see here\n')"
+# ...and a real footer still escalates.
+check 'BC as the footer'      v2.1.0 v3.0.0 \
+  "$(printf 'fix(cli): a small fix\n\nsome explanation\n\nBREAKING CHANGE: the flag is gone\n')"
+
 # --- chore(deps) ships, bare chore does not ---
 check 'chore(deps)'      v2.1.0 v2.1.1 'chore(deps): bump go-sdk to v2.0.0-rc3'
 check 'chore(sdk)'       v2.1.0 ''     'chore(sdk): unrelated scope'
@@ -106,7 +117,13 @@ check 'chore(ci)'        v2.1.0 ''     'chore(ci): a CI change does not release'
 check 'skip in subject'       v2.1.0 '' 'feat: big thing [skip release]'
 check 'skip on its own line'  v2.1.0 '' "$(printf 'feat: big thing\n\n[skip release]\n')"
 check 'skip indented line'    v2.1.0 '' "$(printf 'feat: big thing\n\n  [skip release]  \n')"
-check 'skip in another commit' v2.1.0 '' 'feat: shipped' 'chore: oops [skip release]'
+# The marker is HEAD-ONLY. It used to match anywhere in the range, which latched the
+# release line off forever: skipping pushes no tag, so the base tag never advances
+# and the marked commit stays in `$latest..HEAD` on every subsequent run. Records are
+# newest-first, so arg 1 is HEAD.
+check 'skip on head'          v2.1.0 ''       'chore: oops [skip release]' 'feat: earlier'
+check 'skip behind a release' v2.1.0 v2.2.0   'feat: shipped' 'chore: oops [skip release]'
+check 'skip two commits back' v2.1.0 v2.1.1   'fix: a' 'docs: b' 'chore: c [skip release]'
 
 # Prose that merely MENTIONS the marker must not suppress a real release. The
 # commit introducing this feature documents "[skip release]" in its own body, which
@@ -149,7 +166,7 @@ check_repo() {
   )
 
   local got
-  got="$(cd "$repo" && bash "$script" 2>/dev/null)"
+  got="$(cd "$repo" && env -u GITHUB_OUTPUT bash "$script" 2>/dev/null)"
   if [ "$got" != "$want" ]; then
     printf 'FAIL %s: want %s, got %s\n' "$name" "${want:-<none>}" "${got:-<none>}"
     failures=$((failures + 1))

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,89 @@
+name: Auto Tag
+
+# Computes and pushes the next semver tag after a green Tests run on main, then
+# releases it. See AGENTS.md "Branching & Releases" for the version policy.
+#
+# Hanging off workflow_run rather than `push` reuses the Tests run that already
+# happened for that commit -- no duplicate e2e matrix -- and tags the exact SHA
+# that was tested.
+on:
+  workflow_run:
+    workflows: ["Tests"]
+    types: [completed]
+    branches: [main]
+  # Manual re-run, e.g. after fixing a transient failure. Idempotent: a tag that
+  # already exists is skipped rather than re-released.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  # Serialize: never cancel a run that may be mid tag-push.
+  group: auto-tag-main
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.next.outputs.tag }}
+    steps:
+      - name: Resolve the commit to tag
+        id: target
+        env:
+          # Empty on workflow_dispatch, where github.sha is the dispatched ref.
+          RUN_SHA: ${{ github.event.workflow_run.head_sha }}
+          RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          FALLBACK_SHA: ${{ github.sha }}
+          FALLBACK_BRANCH: ${{ github.ref_name }}
+        run: |
+          sha="${RUN_SHA:-$FALLBACK_SHA}"
+          branch="${RUN_BRANCH:-$FALLBACK_BRANCH}"
+          # workflow_run's `branches:` filter already excludes PR runs, and this
+          # backstops a workflow_dispatch aimed at the wrong branch.
+          if [ "$branch" != "main" ]; then
+            echo "Refusing to auto-tag branch '$branch'; only main is auto-released." >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.target.outputs.sha }}
+          # next-version.sh needs the tags and the full history to find the base
+          # tag and the commits since it.
+          fetch-depth: 0
+
+      - name: Check the Go SDK pin is a released tag
+        run: .github/scripts/check-sdk-pin.sh
+
+      - name: Compute the next version
+        id: next
+        run: .github/scripts/next-version.sh
+
+      - name: Push the tag
+        if: ${{ steps.next.outputs.tag != '' }}
+        env:
+          TAG: ${{ steps.next.outputs.tag }}
+          SHA: ${{ steps.target.outputs.sha }}
+        run: |
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists; nothing to push." >&2
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG" "$SHA"
+          git push origin "refs/tags/$TAG"
+          echo "Pushed $TAG at $SHA" >> "$GITHUB_STEP_SUMMARY"
+
+  release:
+    needs: tag
+    if: ${{ needs.tag.outputs.tag != '' }}
+    uses: ./.github/workflows/release.yml
+    with:
+      ref: ${{ needs.tag.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -28,6 +28,9 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     outputs:
+      # `pushed`, not `tag`, gates the release: `tag` is set whenever a version was
+      # computed, which includes the case where that tag already exists.
+      pushed: ${{ steps.push.outputs.pushed }}
       tag: ${{ steps.next.outputs.tag }}
     steps:
       - name: Resolve the commit to tag
@@ -65,24 +68,32 @@ jobs:
         run: .github/scripts/next-version.sh
 
       - name: Push the tag
+        id: push
         if: ${{ steps.next.outputs.tag != '' }}
         env:
           TAG: ${{ steps.next.outputs.tag }}
           SHA: ${{ steps.target.outputs.sha }}
         run: |
+          # Reachable when two merges land close together and their Tests runs finish
+          # out of order: the older SHA's `git describe` cannot see the newer tag, so
+          # it recomputes the same version. Releasing again would fail in GoReleaser
+          # and fire the failure webhook, so report it and let the release job skip.
           if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "Tag $TAG already exists; nothing to push." >&2
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            echo "Tag $TAG already exists; nothing to push, nothing to release." >&2
+            echo "Skipped: $TAG already exists." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG" "$SHA"
           git push origin "refs/tags/$TAG"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
           echo "Pushed $TAG at $SHA" >> "$GITHUB_STEP_SUMMARY"
 
   release:
     needs: tag
-    if: ${{ needs.tag.outputs.tag != '' }}
+    if: ${{ needs.tag.outputs.pushed == 'true' }}
     uses: ./.github/workflows/release.yml
     with:
       ref: ${{ needs.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,20 @@
 name: Release
 
 on:
+  # Hand-cut tags, including every release on releases/v1.
   push:
     tags:
       - "v*"
+  # Called by auto-tag.yml. A tag pushed with the default GITHUB_TOKEN does not
+  # fire the trigger above -- GitHub suppresses workflow events originating from
+  # GITHUB_TOKEN -- so the tagger invokes this workflow directly instead of
+  # relying on a PAT or GitHub App with write access to the repo.
+  workflow_call:
+    inputs:
+      ref:
+        description: Tag to build and release.
+        type: string
+        required: true
 
 permissions:
   contents: write
@@ -15,6 +26,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          # GoReleaser requires HEAD to sit exactly on the tag it is releasing,
+          # and fetch-depth 0 brings the tags and the changelog history with it.
+          ref: ${{ inputs.ref || github.ref_name }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -38,7 +52,7 @@ jobs:
           channel: 'C08KNSZGXQU'
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           users-map: ${{ vars.GITHUB_TO_SLACK_MAP }}
-          suffix: ${{ github.ref_name }}
+          suffix: ${{ inputs.ref || github.ref_name }}
 
       - name: Slack - Notify release failure
         if: failure()
@@ -47,4 +61,4 @@ jobs:
           channel: 'C09FE0QCN2E'
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           users-map: ${{ vars.GITHUB_TO_SLACK_MAP }}
-          suffix: ${{ github.ref_name }}
+          suffix: ${{ inputs.ref || github.ref_name }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Run tests
         run: go test ./src/...
 
+      - name: Test the release automation scripts
+        run: |
+          .github/scripts/next-version_test.sh
+          .github/scripts/check-sdk-pin_test.sh
+
       - name: Check installer defaults to the v2 line
         run: |
           cat ./install-scripts/install.sh | INSTALL_DIR=./ bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,31 @@ Two long-lived branches, two release lines:
 - **`main`** — kestractl v2, targeting Kestra 2.x (Go SDK `go-sdk/v2`). Tags: `v2.x.y`.
 - **`releases/v1`** — legacy v1 maintenance, targeting Kestra 1.x (Go SDK v1). Tags: `v1.x.y`. **v1 bugfixes branch from and PR into `releases/v1`, not `main`.**
 
-Releases are created by pushing a Git tag from the matching branch. See `.github/workflows/release.yml` for more details. When releasing, be sure that Go SDK version in `go.mod` is a fixed and short one. For example, `github.com/kestra-io/client-sdk/go-sdk v1.1.0` is valid for a release but `github.com/kestra-io/client-sdk/go-sdk v1.1.1-0.20260702143038-8c3851bea2e1` is not valid for a release.
+Releases are created by pushing a Git tag from the matching branch, which runs `.github/workflows/release.yml` (GoReleaser). When releasing, be sure that Go SDK version in `go.mod` is a fixed and short one. For example, `github.com/kestra-io/client-sdk/go-sdk v1.1.0` is valid for a release but `github.com/kestra-io/client-sdk/go-sdk v1.1.1-0.20260702143038-8c3851bea2e1` is not valid for a release. `.github/scripts/check-sdk-pin.sh` enforces this and blocks the automated release path.
+
+### `main` releases itself
+
+`main` is auto-released. `.github/workflows/auto-tag.yml` runs after a **green `Tests` run on `main`** (via `workflow_run`, so it reuses that run rather than re-running the e2e matrix), computes the next tag with `.github/scripts/next-version.sh`, pushes it, and calls `release.yml`. `releases/v1` is untouched by this: its tags stay hand-cut.
+
+Version policy, derived from the conventional-commit subjects since the last tag (highest bump wins):
+
+| commit                                                    | bump  |
+| --------------------------------------------------------- | ----- |
+| `<type>!:` or `BREAKING CHANGE:` in the body              | major |
+| `feat:`                                                   | minor |
+| `fix:` `perf:` `build:` `refactor:` `chore(deps):`        | patch |
+| `docs:` `test:` `ci:` `style:` bare `chore:`              | none  |
+
+`[skip release]` suppresses the release, but only in a commit subject or alone on its own line in the body — prose that merely mentions the marker (release notes, a commit documenting this policy) must not silently stop a release.
+
+**While `main` is pre-GA the semver triple is frozen and only the rc counter moves.** The base tag is `v2.0.0-rcN`, so any release-worthy merge yields `v2.0.0-rc.(N+1)` — a `feat:` does *not* jump to `v2.1.0`, and a breaking change does *not* jump to `v3.0.0`. Cutting `v2.0.0` GA is a deliberate manual tag push; after that the table above applies literally.
+
+Three traps are worth knowing before touching any of this:
+
+- **The rc counter must keep its dot.** `-rcN` is a single alphanumeric semver identifier compared as a string, so `rc10` sorts *below* `rc9`; `-rc.N` is a numeric identifier and increments without bound. The legacy `v2.0.0-rc1`/`rc2` tags use the undotted form, and `next-version.sh` normalises to dotted on the next bump. Note `v2.0.0-rc.3` therefore sorts *below* those two legacy tags under strict semver — harmless here, because nothing resolves these tags by semver (`install.sh` reads `/releases` in creation order, the update notifier reads `/releases/latest`, which excludes prereleases). Verify claims like this with a real semver implementation: GNU `sort -V` is not semver-compliant and gets this case backwards.
+- **Never find the base tag with `git tag --sort=-v:refname`.** Git's version sort mis-orders prerelease suffixes unless `versionsort.suffix` is configured. `next-version.sh` uses `git describe --tags --abbrev=0`, i.e. nearest by commit topology.
+- **A tag pushed with the default `GITHUB_TOKEN` does not fire `on: push: tags`.** GitHub suppresses workflow events originating from `GITHUB_TOKEN`. That is why `release.yml` also has a `workflow_call` trigger and `auto-tag.yml` invokes it directly, rather than the repo carrying a PAT or GitHub App token with write access.
+
+Each auto-tagged rc is what a default `curl … | bash` install resolves to, because `install.sh`'s `VERSION=2` default picks the newest release of the major line, **prereleases included**. That is why the release gate is the full `Tests` suite (unit, installer smoke, e2e matrix) and not a fast subset.
 
 **"Latest" is pinned per branch, not chronological.** GitHub has one repo-wide "latest" release and the public install script's default resolves it, so `.goreleaser.yml` pins `release.make_latest`: `"true"` on `releases/v1` (v1 stays the default install channel), `"false"` on `main` (v2 is opt-in via `VERSION=2`). Do not change these values as a side effect of another change — flipping main's to `"true"` is the deliberate switch that makes v2 the default install channel.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,12 +87,15 @@ Version policy, derived from the conventional-commit subjects since the last tag
 
 | commit                                                    | bump  |
 | --------------------------------------------------------- | ----- |
-| `<type>!:` or `BREAKING CHANGE:` in the body              | major |
+| `<type>!:`, or a `BREAKING CHANGE:` footer                 | major |
 | `feat:`                                                   | minor |
 | `fix:` `perf:` `build:` `refactor:` `chore(deps):`        | patch |
 | `docs:` `test:` `ci:` `style:` bare `chore:`              | none  |
 
-`[skip release]` suppresses the release, but only in a commit subject or alone on its own line in the body — prose that merely mentions the marker (release notes, a commit documenting this policy) must not silently stop a release.
+Two positional rules keep prose from moving the version, because AGENTS.md documents these markers verbatim and that invites pasting them into a commit body:
+
+- `BREAKING CHANGE:` counts only as a **footer** — the last paragraph of the message. Quoted mid-body it is ignored.
+- `[skip release]` counts only on the **head commit**, in its subject or alone on its own line. It suppresses that merge only: skipping pushes no tag, so the base tag does not advance, and a range-wide match would latch the release line off permanently after one marked merge.
 
 **While `main` is pre-GA the semver triple is frozen and only the rc counter moves.** The base tag is `v2.0.0-rcN`, so any release-worthy merge yields `v2.0.0-rc.(N+1)` — a `feat:` does *not* jump to `v2.1.0`, and a breaking change does *not* jump to `v3.0.0`. Cutting `v2.0.0` GA is a deliberate manual tag push; after that the table above applies literally.
 
@@ -104,4 +107,4 @@ Three traps are worth knowing before touching any of this:
 
 Each auto-tagged rc is what a default `curl … | bash` install resolves to, because `install.sh`'s `VERSION=2` default picks the newest release of the major line, **prereleases included**. That is why the release gate is the full `Tests` suite (unit, installer smoke, e2e matrix) and not a fast subset.
 
-**"Latest" is pinned per branch, not chronological.** GitHub has one repo-wide "latest" release and the public install script's default resolves it, so `.goreleaser.yml` pins `release.make_latest`: `"true"` on `releases/v1` (v1 stays the default install channel), `"false"` on `main` (v2 is opt-in via `VERSION=2`). Do not change these values as a side effect of another change — flipping main's to `"true"` is the deliberate switch that makes v2 the default install channel.
+**GitHub's "latest" is a badge, not the install default.** GitHub has one repo-wide "latest" release, and `.goreleaser.yml` pins `release.make_latest` per branch: `"true"` on `releases/v1`, `"false"` on `main` while 2.0 is pre-GA. Since `install.sh` resolves the newest release of a major line itself (`DEFAULT_MAJOR=2`, with `VERSION=1` for the legacy line), that pointer no longer decides what a default install gets — it drives the GitHub UI badge, and the in-CLI update notifier, which reads `/releases/latest`. Flip `main` to `"true"` (and `releases/v1` to `"false"`) when 2.0 goes GA, deliberately and not as a side effect of another change.


### PR DESCRIPTION
Automates the `main` release line: developers merge conventional-commit PRs, CI computes the next semver tag, pushes it, and GoReleaser cuts the release.

```
PR merged to main
  └─> Tests (already runs on push): unit + installer + e2e matrix
        └─> [workflow_run: success]  auto-tag.yml
              ├─ guard: go.mod SDK pin is a released tag
              ├─ next-version.sh -> "v2.0.0-rc.3" | "" (no release)
              ├─ push annotated tag at the tested SHA
              └─ uses: ./.github/workflows/release.yml -> GoReleaser + Slack
```

`releases/v1` is untouched — its tags stay hand-cut, and `release.yml` keeps its existing `push: tags` trigger.

## Two constraints that shaped this

**A tag pushed with the default `GITHUB_TOKEN` does not fire `on: push: tags`** — GitHub suppresses workflow events originating from `GITHUB_TOKEN`. So `release.yml` gains a `workflow_call` trigger and the tagger invokes it directly, rather than the repo carrying a PAT or GitHub App token with write access.

**While `main` is pre-GA the semver triple is frozen and only the rc counter moves.** Naive conventional-semver from `v2.0.0-rc2` computes `v2.0.0` for both a feature and a fix, so the first auto-tag would have silently declared 2.0.0 GA. Cutting `v2.0.0` stays a deliberate manual tag push.

The counter is dotted (`-rc.N`) because an undotted `rcN` is a single alphanumeric semver identifier compared as a string, so `rc10` sorts *below* `rc9` — a ceiling one tag per merge reaches in about a week. Verified with `golang.org/x/mod/semver`; note GNU `sort -V` is not semver-compliant and reports the opposite:

```
rc.3  vs rc2:  -1        rc10  vs rc9:  -1
rc3   vs rc2:  +1        rc.10 vs rc.9: +1
```

`v2.0.0-rc.3` therefore sorts below the two legacy `rc1`/`rc2` tags under strict semver. That is inert here: nothing resolves these tags by semver — `install.sh` reads `/releases` in creation order, and the update notifier reads `/releases/latest`, which excludes prereleases.

## Version policy

| commit | bump |
| --- | --- |
| `<type>!:` / `BREAKING CHANGE:` footer | major |
| `feat:` | minor |
| `fix:` `perf:` `build:` `refactor:` `chore(deps):` | patch |
| `docs:` `test:` `ci:` `style:` bare `chore:` | none |

Pre-GA, any non-none bump just advances the rc counter. A skip marker in a subject (or alone on its own line) suppresses the release.

## Accepted consequence

Each auto-tagged rc becomes what a default `curl … | bash` install resolves to, since `install.sh`'s `VERSION=2` default picks the newest release of the major line, **prereleases included**. That is why the gate is the full `Tests` suite rather than a fast subset. The in-CLI update notifier is unaffected.

## The tests caught three real bugs

1. The SDK-pin guard's pseudo-version regex missed Go's `-0.<ts>-<sha>` shape, so it **accepted the exact develop-tracking pin this repo once carried on `main`**. Caught by asserting on that real version string.
2. Classifying per line rather than per commit read a body discussing a feature or a fix as a subject — this PR's own commit message triggered it — which would cut a release from a docs-only PR. The type now comes from the subject only.
3. Reading commits needs `git log -z`, not `--format=%B%x00`: the latter joins entries with a newline, so every record after the first has an empty subject and **only the newest commit in a range was classified**. A git-fixture test pins this; record-injection tests bypass the format entirely (confirmed by reverting the fix — the fixture test fails, the injection tests don't).

The skip marker was also honoured anywhere in a message, so prose mentioning it suppressed releases. It now counts only in a subject or alone on its own line.

## Verification

- 43 `next-version.sh` tests + 9 `check-sdk-pin.sh` tests, both wired into `Tests`
- `go test ./src/...` passes; `actionlint` clean on `auto-tag.yml` (its 4 findings on `release.yml`/`tests.yml` are pre-existing)
- Real-history dry run: from `v2.0.0-rc1` across 17 commits → `v2.0.0-rc.2`. At current HEAD → no release, because `v2.0.0-rc2` already points at `main`'s tip, so the first auto-tag fires on the next merge.

## Needs a settings change before this fully works

- [ ] **Add `ci` and `perf` to the commit-convention ruleset regex.** Both are absent today, which is why this PR is typed `chore(ci)` — a `ci:` squash title would be rejected on `main`.

Also worth deciding separately: `main` has **no required status checks**, so the `workflow_run` gate stops a red `main` from being *released* but nothing stops a red commit from *landing*. And `release.yml`'s success Slack message now fires once per merge.

<sub>Plan: `~/.claude/plans/precious-gathering-pascal.md`</sub>