### PR TITLE
fix(cli): make the execution actions work on both Kestra 1.3 and 2.x

### DIFF
--- a/e2e_tests/executions_usecases_test.go
+++ b/e2e_tests/executions_usecases_test.go
@@ -1,0 +1,184 @@
+package e2e_tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Coverage for the single-execution action commands.
+//
+// Kestra 2.0 moved these under /executions/{executionId}/actions/ while 1.x
+// serves them bare, and the CLI normalises whichever shape its SDK emits into
+// the one the server in front of it routes (see #117 and
+// kestra-io/client-sdk#409). Because this suite runs against every version in
+// COMPATIBLE_KESTRA_VERSION.properties, these tests pin that routing on both
+// server lines at once — the gap that let #117 reach a release unnoticed.
+//
+// Assertions are on kestractl's own output rather than the server's error text,
+// which differs between 1.x and 2.0 for the same condition.
+
+const executionsTestNamespace = "e2e.executions"
+
+// executionIDPattern matches the line `executions run` prints on success.
+var executionIDPattern = regexp.MustCompile(`Execution ID: ([A-Za-z0-9]+)`)
+
+// wrongRouteSignatures are the errors a request gets when it reaches a path the
+// server does not route. None of them can be a legitimate answer to an action
+// on an execution that exists, so their absence is the routing assertion.
+//
+//   - On 2.0 a bare action path falls through to POST /executions/{namespace}/
+//     {flowId}, which reports a missing *flow* — the misleading symptom in #117.
+//   - "Access denied" / "Forbidden" is what a catch-all route answers when it
+//     matched but the action segment did not: 2.0 for a bare `kill`/`labels`,
+//     1.x for anything under /actions/.
+var wrongRouteSignatures = []string{
+	"Requested Flow is not found.",
+	"Access denied",
+	"Page Not Found",
+	"Forbidden",
+}
+
+func requireRoutedCorrectly(t *testing.T, action, stdout, stderr string) {
+	t.Helper()
+	for _, signature := range wrongRouteSignatures {
+		if strings.Contains(stderr, signature) || strings.Contains(stdout, signature) {
+			t.Errorf("executions %s did not reach a routed endpoint: %q\nstdout: %s\nstderr: %s",
+				action, signature, stdout, stderr)
+		}
+	}
+}
+
+// deployExecutionsTestFlow deploys the one-task flow these tests act on. It is
+// --override so a rerun against a persistent instance is not a hard failure,
+// and uses only io.kestra.plugin.core.log.Log, which the plugin-less image this
+// suite runs against still ships.
+func deployExecutionsTestFlow(t *testing.T, flowID string) {
+	t.Helper()
+
+	source := fmt.Sprintf(`id: %s
+namespace: %s
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: kestractl e2e
+`, flowID, executionsTestNamespace)
+
+	path := filepath.Join(t.TempDir(), flowID+".yml")
+	require.NoError(t, os.WriteFile(path, []byte(source), 0o600))
+
+	stdout, stderr, err := RunAuthenticatedCliCmd(t, "flows", "deploy", path, "--override")
+	require.NoError(t, err, "deploy failed\nstdout: %s\nstderr: %s", stdout, stderr)
+	require.Contains(t, stdout, "1 flow(s) deployed successfully")
+}
+
+// runTerminatedExecution runs the flow to completion and returns the execution
+// id. --wait is what makes the subject deterministic: the actions that require
+// a terminated execution behave identically on every run, with no sleeping.
+func runTerminatedExecution(t *testing.T, flowID string) string {
+	t.Helper()
+
+	stdout, stderr, err := RunAuthenticatedCliCmd(t, "executions", "run", executionsTestNamespace, flowID, "--wait")
+	require.NoError(t, err, "run failed\nstdout: %s\nstderr: %s", stdout, stderr)
+
+	match := executionIDPattern.FindStringSubmatch(stdout)
+	require.Len(t, match, 2, "could not read an execution id from:\n%s", stdout)
+	require.Contains(t, stdout, "State: SUCCESS", "expected a terminated execution:\n%s", stdout)
+	return match[1]
+}
+
+// TestExecutionActions_succeedOnTerminatedExecution covers the actions that a
+// terminated execution accepts, so each one asserts a real success rather than
+// merely the absence of a routing error. Every one of these failed on Kestra
+// 2.0 before #117, and eval-expression failed on 1.3.
+func TestExecutionActions_succeedOnTerminatedExecution(t *testing.T) {
+	flowID := "e2e-executions-actions"
+	deployExecutionsTestFlow(t, flowID)
+
+	tests := []struct {
+		action string
+		args   []string
+		expect string
+	}{
+		// Reached through the SDK's hand-written client, which emits the 2.0
+		// path: the one command that was broken on 1.3 rather than on 2.0.
+		{action: "eval-expression", args: []string{"{{ flow.id }}"}, expect: flowID},
+		{action: "set-labels", args: []string{"env=e2e"}, expect: "Set 1 label(s)"},
+		{action: "replay", expect: "replayed as"},
+		{action: "change-status", args: []string{"SUCCESS"}, expect: "status changed to"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.action, func(t *testing.T) {
+			// A fresh execution per action, so one action cannot move the
+			// subject's state out from under the next.
+			executionID := runTerminatedExecution(t, flowID)
+
+			args := append([]string{"executions", tt.action, executionID}, tt.args...)
+			stdout, stderr, err := RunAuthenticatedCliCmd(t, args...)
+
+			requireRoutedCorrectly(t, tt.action, stdout, stderr)
+			require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
+			require.Contains(t, stdout, tt.expect)
+		})
+	}
+}
+
+// TestExecutionActions_reachTheRoutedEndpoint is the broad net: every action,
+// asserting only that the request reached an endpoint the server routes.
+//
+// Several of these cannot succeed against a terminated execution — pause wants
+// a running one, restart a failed one — and the conflict they return differs by
+// version. That conflict is the point: it proves the path resolved. A wrong
+// path answers with one of wrongRouteSignatures instead.
+func TestExecutionActions_reachTheRoutedEndpoint(t *testing.T) {
+	flowID := "e2e-executions-routing"
+	deployExecutionsTestFlow(t, flowID)
+	executionID := runTerminatedExecution(t, flowID)
+
+	for _, tt := range []struct {
+		action string
+		args   []string
+	}{
+		{action: "kill"},
+		{action: "pause"},
+		{action: "resume"},
+		{action: "restart"},
+		{action: "force-run"},
+		{action: "replay"},
+		{action: "replay-with-inputs"},
+		{action: "unqueue", args: []string{"--state", "RUNNING"}},
+		{action: "change-status", args: []string{"SUCCESS"}},
+		{action: "set-labels", args: []string{"env=e2e"}},
+		{action: "eval-expression", args: []string{"{{ flow.id }}"}},
+	} {
+		t.Run(tt.action, func(t *testing.T) {
+			args := append([]string{"executions", tt.action, executionID}, tt.args...)
+			stdout, stderr, _ := RunAuthenticatedCliCmd(t, args...)
+			requireRoutedCorrectly(t, tt.action, stdout, stderr)
+		})
+	}
+}
+
+// TestExecutionsBulk_reportsTheAffectedCount guards the silent half of #117:
+// the bulk paths never moved, but 2.0 answers them with
+// {"operationId":..., "totalItems":N} where the SDK modelled only
+// {"count":N}, so the number was dropped at decode and every bulk command
+// reported 0 executions affected while having actually acted on them.
+func TestExecutionsBulk_reportsTheAffectedCount(t *testing.T) {
+	flowID := "e2e-executions-bulk"
+	deployExecutionsTestFlow(t, flowID)
+	executionID := runTerminatedExecution(t, flowID)
+
+	stdout, stderr, err := RunAuthenticatedCliCmd(t, "executions", "replay-bulk", executionID)
+
+	requireRoutedCorrectly(t, "replay-bulk", stdout, stderr)
+	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
+	require.Contains(t, stdout, "1 execution(s) affected",
+		"the affected count was dropped at decode\nstdout: %s", stdout)
+}

--- a/e2e_tests/executions_usecases_test.go
+++ b/e2e_tests/executions_usecases_test.go
@@ -101,13 +101,28 @@ func TestExecutionActions_succeedOnTerminatedExecution(t *testing.T) {
 	deployExecutionsTestFlow(t, flowID)
 
 	tests := []struct {
-		action string
-		args   []string
-		expect string
+		action    string
+		args      []string
+		expect    string
+		minKestra [2]int
+		minReason string
 	}{
 		// Reached through the SDK's hand-written client, which emits the 2.0
 		// path: the one command that was broken on 1.3 rather than on 2.0.
-		{action: "eval-expression", args: []string{"{{ flow.id }}"}, expect: flowID},
+		//
+		// Gated at 1.3 because the endpoint behind it does not answer a basic
+		// authenticated request before then — v1.0 through v1.2 reply
+		// "Unauthorized" for an execution that exists, and the pre-1.3 Go SDK
+		// exposed only an /eval/{taskRunId} variant, which this command has no
+		// argument for. Asserting it there would be asserting a feature those
+		// server lines do not offer.
+		{
+			action:    "eval-expression",
+			args:      []string{"{{ flow.id }}"},
+			expect:    flowID,
+			minKestra: [2]int{1, 3},
+			minReason: "the execution eval endpoint is not usable before 1.3",
+		},
 		{action: "set-labels", args: []string{"env=e2e"}, expect: "Set 1 label(s)"},
 		{action: "replay", expect: "replayed as"},
 		{action: "change-status", args: []string{"SUCCESS"}, expect: "status changed to"},
@@ -115,6 +130,10 @@ func TestExecutionActions_succeedOnTerminatedExecution(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.action, func(t *testing.T) {
+			if tt.minKestra != [2]int{} {
+				skipBelowKestra(t, tt.minKestra[0], tt.minKestra[1], tt.minReason)
+			}
+
 			// A fresh execution per action, so one action cannot move the
 			// subject's state out from under the next.
 			executionID := runTerminatedExecution(t, flowID)
@@ -142,8 +161,9 @@ func TestExecutionActions_reachTheRoutedEndpoint(t *testing.T) {
 	executionID := runTerminatedExecution(t, flowID)
 
 	for _, tt := range []struct {
-		action string
-		args   []string
+		action    string
+		args      []string
+		minKestra [2]int
 	}{
 		{action: "kill"},
 		{action: "pause"},
@@ -155,9 +175,16 @@ func TestExecutionActions_reachTheRoutedEndpoint(t *testing.T) {
 		{action: "unqueue", args: []string{"--state", "RUNNING"}},
 		{action: "change-status", args: []string{"SUCCESS"}},
 		{action: "set-labels", args: []string{"env=e2e"}},
-		{action: "eval-expression", args: []string{"{{ flow.id }}"}},
+		// See the gate in TestExecutionActions_succeedOnTerminatedExecution: on
+		// a pre-1.3 server this can only pass vacuously, so it is skipped there
+		// rather than left to look like coverage.
+		{action: "eval-expression", args: []string{"{{ flow.id }}"}, minKestra: [2]int{1, 3}},
 	} {
 		t.Run(tt.action, func(t *testing.T) {
+			if tt.minKestra != [2]int{} {
+				skipBelowKestra(t, tt.minKestra[0], tt.minKestra[1], "endpoint not available")
+			}
+
 			args := append([]string{"executions", tt.action, executionID}, tt.args...)
 			stdout, stderr, _ := RunAuthenticatedCliCmd(t, args...)
 			requireRoutedCorrectly(t, tt.action, stdout, stderr)

--- a/e2e_tests/utils_test.go
+++ b/e2e_tests/utils_test.go
@@ -3,14 +3,20 @@ package e2e_tests
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"math"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 const KESTRACTL_CLI_GENERATED_FOR_E2E = "KESTRACTL_CLI_GENERATED_FOR_E2E"
@@ -20,9 +26,69 @@ var (
 	builtCliErr error
 )
 
+// The instance this suite expects, per e2e_tests/README.md and
+// e2e_tests/docker-setup/application.yml.
+const (
+	e2eHost     = "http://localhost:9801"
+	e2eUsername = "root@root.com"
+	e2ePassword = "Root!1234"
+)
+
 func RunAuthenticatedCliCmd(t *testing.T, args ...string) (stdout string, stderr string, err error) {
-	args = append(args, "--host", "http://localhost:9801", "--username", "root@root.com", "--password", "Root!1234")
+	args = append(args, "--host", e2eHost, "--username", e2eUsername, "--password", e2ePassword)
 	return RunCliCmd(t, args...)
+}
+
+// serverKestraVersion returns the major and minor version of the Kestra the
+// suite is running against.
+//
+// It asks the server rather than reading KESTRA_VERSION, because the documented
+// way to run this suite is against an instance you started yourself, where that
+// variable is not set. Tests use it to skip assertions about endpoints a given
+// server line does not have, rather than hard-coding a version matrix here.
+func serverKestraVersion(t *testing.T) (major int, minor int) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, e2eHost+"/api/v1/configs", nil)
+	require.NoError(t, err)
+	req.SetBasicAuth(e2eUsername, e2ePassword)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "could not reach the Kestra under test")
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected status from /api/v1/configs")
+
+	var configs struct {
+		Version string `json:"version"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&configs))
+
+	// Versions look like "1.3.35", "2.0.0-rc13" or "SNAPSHOT" on a develop
+	// build. An unparseable version counts as current: this suite's develop job
+	// tracks the newest server, not an old one.
+	parts := strings.SplitN(configs.Version, ".", 3)
+	if len(parts) < 2 {
+		return math.MaxInt, 0
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return math.MaxInt, 0
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return major, 0
+	}
+	return major, minor
+}
+
+// skipBelowKestra skips the test when the server predates the given version.
+func skipBelowKestra(t *testing.T, major, minor int, reason string) {
+	t.Helper()
+
+	haveMajor, haveMinor := serverKestraVersion(t)
+	if haveMajor < major || (haveMajor == major && haveMinor < minor) {
+		t.Skipf("needs Kestra %d.%d or later (server is %d.%d): %s", major, minor, haveMajor, haveMinor, reason)
+	}
 }
 
 /*

--- a/e2e_tests/utils_test.go
+++ b/e2e_tests/utils_test.go
@@ -45,6 +45,7 @@ func RunCliCmd(t *testing.T, args ...string) (stdout string, stderr string, err 
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, cliPath, args...)
+	cmd.Env = isolatedEnv(t)
 
 	var outBuf, errBuf bytes.Buffer
 	cmd.Stdout = &outBuf
@@ -58,6 +59,44 @@ func RunCliCmd(t *testing.T, args ...string) (stdout string, stderr string, err 
 	}
 
 	return outBuf.String(), errBuf.String(), err
+}
+
+// isolatedEnv returns the environment for a CLI run with the developer's own
+// kestractl config kept out of it.
+//
+// The CLI resolves credentials as flags > env > ~/.kestractl/config.yaml, and
+// prefers a token over username/password. So a developer who has ever run
+// `kestractl config` has a token on disk that outranks the --username/--password
+// these tests pass, and the whole suite fails with "Authentication required"
+// against a perfectly good server. TestSimpleCmd_Unauthenticated has the same
+// dependency from the other side: it can only pass when no config is readable.
+// CI never notices because its HOME is empty.
+//
+// Pointing HOME at a per-test temp dir makes the suite hermetic. The KESTRACTL_*
+// credential variables are dropped for the same reason, minus the harness's own.
+func isolatedEnv(t *testing.T) []string {
+	t.Helper()
+
+	home := t.TempDir()
+	env := []string{"HOME=" + home, "USERPROFILE=" + home}
+	for _, kv := range os.Environ() {
+		key, _, found := strings.Cut(kv, "=")
+		if !found {
+			continue
+		}
+		switch key {
+		case "HOME", "USERPROFILE":
+			continue
+		case KESTRACTL_CLI_GENERATED_FOR_E2E:
+			// The harness's own handle on the built binary, not CLI config.
+		default:
+			if strings.HasPrefix(key, "KESTRACTL_") {
+				continue
+			}
+		}
+		env = append(env, kv)
+	}
+	return env
 }
 
 func cliExeName() string {

--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -115,7 +115,7 @@ func newClientDefault() (*Client, error) {
 		Ctx:    ctx,
 		Tenant: tenant,
 	}
-	compat.legacyServer = c.isLegacyServer
+	compat.era = c.serverEra
 	return c, nil
 }
 

--- a/src/cli/compat.go
+++ b/src/cli/compat.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -13,7 +14,7 @@ import (
 // Kestra 1.x compatibility.
 //
 // kestractl v2 targets Kestra 2.x, and stays usable against a 1.3 server on a
-// best-effort basis. Two things make that work:
+// best-effort basis. Four things make that work:
 //
 //   - compatTransport fills in response fields the 2.0 SDK marks as required
 //     but a 1.x server never emits (a 1.x flow has no `draft`, a 1.x execution
@@ -23,21 +24,73 @@ import (
 //     instead of letting the server silently ignore the field (a 1.x server
 //     drops an unknown `instanceOwner` or `quotas` from the request body and
 //     returns 200).
+//   - compatTransport mirrors a bulk response's item count across the two
+//     spellings the servers use — `count` on 1.x, `totalItems` on 2.0 — so
+//     whichever one the SDK models, the other server's number is not dropped at
+//     decode, leaving every bulk command reporting 0.
+//   - compatTransport also normalises the single-execution action paths, which
+//     Kestra 2.0 moved under /executions/{id}/actions/... The v2 SDK is split
+//     on this: its generated endpoints still emit the 1.x paths (kill, replay,
+//     restart, force-run, pause, resume, unqueue, change-status, labels,
+//     replay-with-inputs, state) while its hand-written ones already emit the
+//     2.0 paths (eval, and the same actions again). Neither shape works on both
+//     servers, so the transport rewrites whichever the SDK produced into the one
+//     the server actually routes. When the version is unknown it sends the 2.0
+//     shape and falls back to the 1.x one on a route miss, rather than picking
+//     one and failing every action if the guess was wrong.
+
+// serverEra is what the transport knows about the server it is talking to.
+//
+// The distinction between eraCurrent and eraUnknown matters only for the action
+// path rewrite: adding a response field is harmless when the version is a guess,
+// but sending a request to the wrong path is not, so an unknown server gets the
+// 2.0 shape with the 1.x shape as a fallback rather than a single guess.
+type serverEra int
+
+const (
+	eraUnknown serverEra = iota // unreachable or unparseable version (develop builds)
+	eraLegacy                   // Kestra 1.x
+	eraCurrent                  // Kestra 2.0 or later
+)
+
+// noRewriteKey marks a context whose request must keep the path the SDK built.
+//
+// It exists for POST /executions/{namespace}/{flowId}, which creates an
+// execution and is indistinguishable from a 1.x action call by path shape
+// alone: a flow named `pause` in a namespace named `productionanalytics` reads
+// exactly like `pause` on execution `productionanalytics`. Rather than tighten
+// the id heuristic — which only moves the collision to a longer namespace — the
+// one call site that builds that path opts out explicitly.
+type noRewriteKey struct{}
+
+// withoutExecutionActionRewrite returns a context whose requests keep the path
+// the SDK built, exempt from the action rewrite.
+func withoutExecutionActionRewrite(ctx context.Context) context.Context {
+	return context.WithValue(ctx, noRewriteKey{}, true)
+}
+
+func rewriteExempt(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	exempt, _ := ctx.Value(noRewriteKey{}).(bool)
+	return exempt
+}
 
 // newCompatHTTPClient returns the HTTP client shared by both SDK clients, so the
 // response shim applies to generated and hand-written endpoints alike.
 //
-// legacyServer reports whether the server runs Kestra 1.x; it is wired to
-// Client.ServerVersion once the client exists, and the shim stays inert until
-// then and against 2.x servers.
+// era reports what is known about the server version; it is wired to
+// Client.ServerVersion once the client exists, and the shims stay inert until
+// then.
 func newCompatHTTPClient() (*http.Client, *compatTransport) {
-	transport := &compatTransport{base: http.DefaultTransport, legacyServer: func() bool { return false }}
+	transport := &compatTransport{base: http.DefaultTransport, era: func() serverEra { return eraUnknown }}
 	return &http.Client{Transport: transport}, transport
 }
 
 type compatTransport struct {
-	base         http.RoundTripper
-	legacyServer func() bool
+	base http.RoundTripper
+	era  func() serverEra
 }
 
 // compatMarkers are the keys a body must contain for fillCompatDefaults to have
@@ -46,12 +99,31 @@ type compatTransport struct {
 var compatMarkers = [][]byte{[]byte(`"tasks"`), []byte(`"flowRevision"`)}
 
 func (t *compatTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req, fallback := t.routeExecutionAction(req)
+
 	resp, err := t.base.RoundTrip(req)
+	if err == nil && fallback != "" && isRouteMiss(resp) {
+		// The version is unknown, so the shape was a guess. A 403/404 here means
+		// the route did not match and nothing happened server-side, which makes
+		// the other shape safe to try. If it misses too, the first response is
+		// kept: its error describes the 2.x server this binary targets.
+		if retry, ok := cloneRequestWithPath(req, fallback); ok {
+			if second, secondErr := t.base.RoundTrip(retry); secondErr == nil {
+				if isRouteMiss(second) {
+					drainAndClose(second)
+				} else {
+					drainAndClose(resp)
+					req, resp = retry, second
+				}
+			}
+		}
+	}
 	if err != nil || resp.StatusCode < 200 || resp.StatusCode >= 300 || !isJSONResponse(resp) {
 		return resp, err
 	}
 	tenant, shimmed := shimmedEndpoint(req.URL.Path)
-	if !shimmed {
+	bulk := isBulkEndpoint(req.URL.Path)
+	if !shimmed && !bulk {
 		return resp, nil
 	}
 
@@ -63,7 +135,7 @@ func (t *compatTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	// The version probe runs through this same transport, so check the cheap
 	// marker scan first and only then ask which server we are talking to.
-	if containsAny(body, compatMarkers) && t.legacyServer() {
+	if shimmed && containsAny(body, compatMarkers) && t.era() == eraLegacy {
 		// UseNumber keeps integers verbatim: decoding into float64 would round
 		// anything above 2^53 (epoch nanos, counters) on the way back out.
 		dec := json.NewDecoder(bytes.NewReader(body))
@@ -77,9 +149,64 @@ func (t *compatTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}
 	}
 
+	if bulk {
+		if patched, ok := mirrorBulkCount(body); ok {
+			body = patched
+			resp.Header.Del("Content-Length")
+		}
+	}
+
 	resp.Body = io.NopCloser(bytes.NewReader(body))
 	resp.ContentLength = int64(len(body))
 	return resp, nil
+}
+
+// isBulkEndpoint reports whether a path is one of the /by-ids or /by-query bulk
+// endpoints, on any resource.
+func isBulkEndpoint(path string) bool {
+	return strings.HasSuffix(path, "/by-ids") || strings.HasSuffix(path, "/by-query")
+}
+
+// mirrorBulkCount makes a bulk response carry both spellings of its item
+// count, and reports whether it changed anything.
+//
+// Kestra 2.0 answers a bulk request with the async-operation shape
+// {"operationId":..., "totalItems":N}; 1.x answers {"count":N}. Whichever of
+// the two the SDK models, the other server's spelling is dropped at decode and
+// the command reports 0 executions affected even though the operation was
+// accepted. Filling in the missing key covers both directions, so this keeps
+// working across an SDK bump that retypes these endpoints (see
+// kestra-io/client-sdk#409) without needing to know which shape the SDK is on.
+//
+// The decision is made on the decoded top-level object, not a substring scan of
+// the body: a nested `count` elsewhere in the payload would otherwise read as
+// "already present" and skip the mirroring this exists to do.
+func mirrorBulkCount(body []byte) ([]byte, bool) {
+	// UseNumber keeps the count verbatim rather than routing it through float64.
+	dec := json.NewDecoder(bytes.NewReader(body))
+	dec.UseNumber()
+	var payload map[string]json.RawMessage
+	if dec.Decode(&payload) != nil {
+		return body, false
+	}
+
+	_, hasCount := payload["count"]
+	_, hasTotal := payload["totalItems"]
+	if hasCount == hasTotal {
+		return body, false
+	}
+
+	if hasTotal {
+		payload["count"] = payload["totalItems"]
+	} else {
+		payload["totalItems"] = payload["count"]
+	}
+
+	patched, err := json.Marshal(payload)
+	if err != nil {
+		return body, false
+	}
+	return patched, true
 }
 
 func isJSONResponse(resp *http.Response) bool {
@@ -113,6 +240,162 @@ func shimmedEndpoint(path string) (tenant string, ok bool) {
 	tenant, rest, _ = strings.Cut(rest, "/")
 	resource, _, _ := strings.Cut(rest, "/")
 	return tenant, resource == "flows" || resource == "executions"
+}
+
+// executionActions are the single-execution endpoints Kestra 2.0 moved under
+// /executions/{executionId}/actions/. Everything else below an execution
+// (graph, flow, file, file/metas, follow, follow-dependencies) kept its path in
+// 2.0 and is deliberately absent, as are the bulk `<action>/by-ids` and
+// `<action>/by-query` variants, which never moved.
+var executionActions = map[string]bool{
+	"change-status":      true,
+	"eval":               true,
+	"force-run":          true,
+	"kill":               true,
+	"labels":             true,
+	"pause":              true,
+	"replay":             true,
+	"replay-with-inputs": true,
+	"restart":            true,
+	"resume":             true,
+	"state":              true,
+	"unqueue":            true,
+}
+
+// routeExecutionAction returns the request to send and, when the server version
+// is unknown, the alternate action path to fall back to on a route miss.
+//
+// A known server gets a single shape and no fallback: bare
+// /executions/{id}/{action} on 1.x, /executions/{id}/actions/{action} on 2.0 and
+// later. An unknown server gets the 2.0 shape — this binary targets 2.x — with
+// the 1.x shape as the fallback, so a 1.x develop build keeps working instead of
+// silently 404ing on every action.
+//
+// The version probe is only consulted once the path is known to be an action
+// call, so requests that cannot be rewritten never pay for it (and the probe
+// itself, on /api/v1/configs, cannot recurse into it).
+func (t *compatTransport) routeExecutionAction(req *http.Request) (*http.Request, string) {
+	if rewriteExempt(req.Context()) {
+		return req, ""
+	}
+	prefix, action, ok := splitExecutionAction(req.URL.Path)
+	if !ok {
+		return req, ""
+	}
+
+	modern := prefix + "/actions/" + action
+	legacy := prefix + "/" + action
+
+	target, fallback := modern, ""
+	switch t.era() {
+	case eraLegacy:
+		target = legacy
+	case eraUnknown:
+		fallback = legacy
+	}
+
+	if target != req.URL.Path {
+		if rewritten, ok := cloneRequestWithPath(req, target); ok {
+			req = rewritten
+		} else {
+			// The body cannot be replayed, so leave the path alone rather than
+			// send a rewritten request whose body may already be consumed.
+			return req, ""
+		}
+	}
+	return req, fallback
+}
+
+// cloneRequestWithPath copies a request with a new path, and reports whether it
+// could. RoundTrip must not mutate the request it is given; Clone deep-copies
+// the URL, so writing Path here cannot be observed by the caller.
+//
+// A request carrying a body needs GetBody to be replayable — Clone shares the
+// original reader, which the first attempt consumes.
+func cloneRequestWithPath(req *http.Request, path string) (*http.Request, bool) {
+	out := req.Clone(req.Context())
+	if req.Body != nil && req.Body != http.NoBody {
+		if req.GetBody == nil {
+			return nil, false
+		}
+		body, err := req.GetBody()
+		if err != nil {
+			return nil, false
+		}
+		out.Body = body
+	}
+	// RawPath is cleared because every segment assembled here is unescaped.
+	out.URL.Path = path
+	out.URL.RawPath = ""
+	return out, true
+}
+
+// isRouteMiss reports whether a response looks like the path did not match a
+// route. Kestra answers an unmatched path under /executions/{id}/ with 404, and
+// with 403 where a catch-all route matched but denied access.
+func isRouteMiss(resp *http.Response) bool {
+	return resp != nil && (resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden)
+}
+
+func drainAndClose(resp *http.Response) {
+	if resp == nil || resp.Body == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+}
+
+// splitExecutionAction parses /api/v1/{tenant}/executions/{executionId}/[actions/]{action}
+// into the path up to and including the execution id, plus the action name.
+//
+// The execution id is required to look like one (Kestra ids are 20+ character
+// alphanumeric FriendlyIds) because POST /executions/{namespace}/{flowId}
+// creates an execution and would otherwise collide: a flow named `kill` in a
+// namespace named `kill` reads as an action call on that shape alone.
+func splitExecutionAction(path string) (prefix, action string, ok bool) {
+	rest, found := strings.CutPrefix(path, "/api/v1/")
+	if !found {
+		return "", "", false
+	}
+
+	parts := strings.Split(rest, "/")
+	if len(parts) < 4 || parts[1] != "executions" || !looksLikeExecutionID(parts[2]) {
+		return "", "", false
+	}
+
+	switch {
+	case len(parts) == 4:
+		action = parts[3]
+	case len(parts) == 5 && parts[3] == "actions":
+		action = parts[4]
+	default:
+		return "", "", false
+	}
+	if !executionActions[action] {
+		return "", "", false
+	}
+
+	return "/api/v1/" + strings.Join(parts[:3], "/"), action, true
+}
+
+// looksLikeExecutionID reports whether a path segment has the shape of a Kestra
+// execution id: at least 16 alphanumeric characters and nothing else. A tenant
+// or namespace segment that long without a dot, hyphen or underscore does not
+// occur in practice.
+func looksLikeExecutionID(segment string) bool {
+	if len(segment) < 16 {
+		return false
+	}
+	for _, r := range segment {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // fillCompatDefaults walks a decoded JSON payload and adds the fields a 2.0
@@ -169,16 +452,30 @@ func (c *Client) ServerVersion() (string, error) {
 	return c.serverVersion, c.serverVersionErr
 }
 
-// isLegacyServer reports whether the server is known to run Kestra 1.x. An
-// unreachable or unparseable version (develop builds, snapshots) counts as
-// current: the shims exist for 1.x servers, not for unknown ones.
-func (c *Client) isLegacyServer() bool {
+// serverEra reports what is known about the server's major version. An
+// unreachable or unparseable version (develop builds, snapshots) is eraUnknown
+// rather than being assumed current, so the action path rewrite can fall back
+// instead of committing to a guess.
+func (c *Client) serverEra() serverEra {
 	version, err := c.ServerVersion()
 	if err != nil {
-		return false
+		return eraUnknown
 	}
 	core, _ := splitVersion(version)
-	return core != [3]int{} && core[0] < 2
+	if core == [3]int{} {
+		return eraUnknown
+	}
+	if core[0] < 2 {
+		return eraLegacy
+	}
+	return eraCurrent
+}
+
+// isLegacyServer reports whether the server is known to run Kestra 1.x. An
+// unreachable or unparseable version counts as not-legacy: the response shims
+// and version guards exist for 1.x servers, not for unknown ones.
+func (c *Client) isLegacyServer() bool {
+	return c.serverEra() == eraLegacy
 }
 
 // requireKestra2 fails when the server is known to run Kestra 1.x, naming the

--- a/src/cli/compat_test.go
+++ b/src/cli/compat_test.go
@@ -348,3 +348,493 @@ func TestGuardedCommands_RefuseKestra2FeaturesOn13(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitExecutionAction(t *testing.T) {
+	const id = "2TLGqHrXC9k8BczKJe5djX"
+
+	tests := []struct {
+		name   string
+		path   string
+		prefix string
+		action string
+		ok     bool
+	}{
+		{
+			name:   "1.x action path",
+			path:   "/api/v1/main/executions/" + id + "/kill",
+			prefix: "/api/v1/main/executions/" + id,
+			action: "kill",
+			ok:     true,
+		},
+		{
+			name:   "2.0 action path",
+			path:   "/api/v1/main/executions/" + id + "/actions/replay",
+			prefix: "/api/v1/main/executions/" + id,
+			action: "replay",
+			ok:     true,
+		},
+		{
+			name:   "hyphenated action",
+			path:   "/api/v1/acme/executions/" + id + "/replay-with-inputs",
+			prefix: "/api/v1/acme/executions/" + id,
+			action: "replay-with-inputs",
+			ok:     true,
+		},
+		// Subresources that did not move in 2.0 must not be rewritten.
+		{name: "graph", path: "/api/v1/main/executions/" + id + "/graph"},
+		{name: "flow", path: "/api/v1/main/executions/" + id + "/flow"},
+		{name: "follow", path: "/api/v1/main/executions/" + id + "/follow"},
+		{name: "file metas", path: "/api/v1/main/executions/" + id + "/file/metas"},
+		{name: "the execution itself", path: "/api/v1/main/executions/" + id},
+		// Bulk variants keep their 1.x shape on both servers.
+		{name: "bulk by-ids", path: "/api/v1/main/executions/kill/by-ids"},
+		{name: "bulk by-query", path: "/api/v1/main/executions/replay/by-query"},
+		// POST /executions/{namespace}/{flowId} creates an execution: a flow
+		// named after an action must not be mistaken for one.
+		{name: "create execution for a flow named kill", path: "/api/v1/main/executions/qa.compat/kill"},
+		{name: "create execution in a short namespace", path: "/api/v1/main/executions/qa/kill"},
+		{name: "other resource", path: "/api/v1/main/flows/" + id + "/kill"},
+		{name: "not an api path", path: "/executions/" + id + "/kill"},
+		{name: "unknown action", path: "/api/v1/main/executions/" + id + "/teleport"},
+		{name: "too deep", path: "/api/v1/main/executions/" + id + "/actions/kill/extra"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefix, action, ok := splitExecutionAction(tt.path)
+			if ok != tt.ok || prefix != tt.prefix || action != tt.action {
+				t.Fatalf("got (%q, %q, %v), want (%q, %q, %v)", prefix, action, ok, tt.prefix, tt.action, tt.ok)
+			}
+		})
+	}
+}
+
+// TestCompatTransport_RoutesExecutionActionsPerServerVersion pins the wire path
+// for both the SDK's generated executions endpoints (which emit 1.x paths) and
+// its hand-written ones (which emit 2.0 /actions/ paths): each must come out as
+// the shape the server in front of it actually routes.
+func TestCompatTransport_RoutesExecutionActionsPerServerVersion(t *testing.T) {
+	const id = "2TLGqHrXC9k8BczKJe5djX"
+
+	tests := []struct {
+		name    string
+		version string
+		call    func(*Client) error
+		want    string
+	}{
+		{
+			name:    "generated kill on 1.x keeps the bare path",
+			version: "1.3.35",
+			call: func(c *Client) error {
+				_, _, err := c.API.ExecutionsAPI.KillExecution(c.Ctx, id, "main").Execute()
+				return err
+			},
+			want: "/api/v1/main/executions/" + id + "/kill",
+		},
+		{
+			name:    "generated kill on 2.0 moves under actions",
+			version: "2.0.0-rc13",
+			call: func(c *Client) error {
+				_, _, err := c.API.ExecutionsAPI.KillExecution(c.Ctx, id, "main").Execute()
+				return err
+			},
+			want: "/api/v1/main/executions/" + id + "/actions/kill",
+		},
+		{
+			name:    "generated replay on 2.0 moves under actions",
+			version: "2.0.0-rc13",
+			call: func(c *Client) error {
+				_, _, err := c.API.ExecutionsAPI.ReplayExecution(c.Ctx, id, "main").Execute()
+				return err
+			},
+			want: "/api/v1/main/executions/" + id + "/actions/replay",
+		},
+		{
+			name:    "hand-written eval on 1.x drops actions",
+			version: "1.3.35",
+			call: func(c *Client) error {
+				_, err := c.Kestra.Executions().EvalExpression(c.Ctx, id, "main", "{{ flow.id }}")
+				return err
+			},
+			want: "/api/v1/main/executions/" + id + "/eval",
+		},
+		{
+			name:    "hand-written eval on 2.0 keeps actions",
+			version: "2.0.0-rc13",
+			call: func(c *Client) error {
+				_, err := c.Kestra.Executions().EvalExpression(c.Ctx, id, "main", "{{ flow.id }}")
+				return err
+			},
+			want: "/api/v1/main/executions/" + id + "/actions/eval",
+		},
+		{
+			name:    "graph is not an action on 2.0",
+			version: "2.0.0-rc13",
+			call: func(c *Client) error {
+				_, _, err := c.API.ExecutionsAPI.ExecutionFlowGraph(c.Ctx, id, "main").Execute()
+				return err
+			},
+			want: "/api/v1/main/executions/" + id + "/graph",
+		},
+		{
+			name:    "bulk kill keeps its path on 2.0",
+			version: "2.0.0-rc13",
+			call: func(c *Client) error {
+				_, _, err := c.API.ExecutionsAPI.KillExecutionsByIds(c.Ctx, "main").RequestBody([]string{id}).Execute()
+				return err
+			},
+			want: "/api/v1/main/executions/kill/by-ids",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got string
+			server := httptest.NewServer(versionHandler(tt.version, func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			t.Cleanup(server.Close)
+
+			// The response is deliberately empty, so a decode error is fine:
+			// the assertion is on the path the server was asked for.
+			_ = tt.call(newTestClient(t, server.URL))
+			if got != tt.want {
+				t.Fatalf("requested %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCompatTransport_DoesNotMutateCallerRequest guards the net/http contract:
+// RoundTrip must leave the request it was handed untouched.
+func TestCompatTransport_DoesNotMutateCallerRequest(t *testing.T) {
+	const path = "/api/v1/main/executions/2TLGqHrXC9k8BczKJe5djX/kill"
+
+	server := httptest.NewServer(versionHandler("2.0.0-rc13", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClient(t, server.URL)
+	req, err := http.NewRequest(http.MethodDelete, server.URL+path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.API.GetConfig().HTTPClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if req.URL.Path != path {
+		t.Fatalf("caller request was mutated: %q", req.URL.Path)
+	}
+}
+
+func TestMirrorBulkCount(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{
+			name: "2.0 async operation response gains count",
+			in:   `{"operationId":"2gtoTYnQy1KHopwSQAXE3y","totalItems":3}`,
+			want: `{"count":3,"operationId":"2gtoTYnQy1KHopwSQAXE3y","totalItems":3}`,
+			ok:   true,
+		},
+		{
+			name: "1.x response gains totalItems",
+			in:   `{"count":3}`,
+			want: `{"count":3,"totalItems":3}`,
+			ok:   true,
+		},
+		{
+			name: "a response carrying both is untouched",
+			in:   `{"count":1,"totalItems":3}`,
+			want: `{"count":1,"totalItems":3}`,
+		},
+		{
+			name: "neither key is untouched",
+			in:   `{"operationId":"x"}`,
+			want: `{"operationId":"x"}`,
+		},
+		{
+			name: "a large count round-trips verbatim",
+			in:   `{"totalItems":9007199254740993}`,
+			want: `{"count":9007199254740993,"totalItems":9007199254740993}`,
+			ok:   true,
+		},
+		{
+			// A substring scan of the body would read the nested `count` as
+			// "already present" and skip the mirroring.
+			name: "a nested count does not mask a missing top-level one",
+			in:   `{"operationId":"x","totalItems":3,"failures":[{"count":1}]}`,
+			want: `{"count":3,"failures":[{"count":1}],"operationId":"x","totalItems":3}`,
+			ok:   true,
+		},
+		{
+			name: "non-object body is untouched",
+			in:   `["totalItems"]`,
+			want: `["totalItems"]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := mirrorBulkCount([]byte(tt.in))
+			if ok != tt.ok {
+				t.Fatalf("ok = %v, want %v", ok, tt.ok)
+			}
+			if string(got) != tt.want {
+				t.Fatalf("got  %s\nwant %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestRunExecutionsBulkOp_CountsKestra20AsyncResponse covers the whole path: a
+// 2.0 bulk endpoint answers {"operationId":..., "totalItems":N} and the command
+// must report N, not the 0 the SDK's count-only model would decode.
+func TestRunExecutionsBulkOp_CountsKestra20AsyncResponse(t *testing.T) {
+	for _, tt := range []struct {
+		version, body string
+	}{
+		{"2.0.0-rc13", `{"operationId":"2gtoTYnQy1KHopwSQAXE3y","totalItems":2}`},
+		{"1.3.35", `{"count":2}`},
+	} {
+		t.Run(tt.version, func(t *testing.T) {
+			server := httptest.NewServer(versionHandler(tt.version, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			var out strings.Builder
+			renderer, err := NewRenderer("table", &out)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = runExecutionsBulkOp(newTestClient(t, server.URL), []string{"a", "b"}, "kill", renderer)
+			if err != nil {
+				t.Fatalf("bulk kill: %v", err)
+			}
+			if !strings.Contains(out.String(), "2 execution(s) affected") {
+				t.Fatalf("unexpected output: %q", out.String())
+			}
+		})
+	}
+}
+
+// TestCompatTransport_UnknownVersionFallsBackToLegacyPath covers the server
+// whose version cannot be determined (a develop build, or a /configs the user
+// cannot read): the 2.0 shape is tried first because that is what this binary
+// targets, and a route miss falls back to the 1.x shape rather than failing.
+func TestCompatTransport_UnknownVersionFallsBackToLegacyPath(t *testing.T) {
+	const id = "2TLGqHrXC9k8BczKJe5djX"
+
+	tests := []struct {
+		name        string
+		configs     func(http.ResponseWriter)
+		routes      map[string]int // path -> status
+		wantOrder   []string
+		wantSuccess bool
+	}{
+		{
+			name:    "develop build serving only the 1.x path",
+			configs: func(w http.ResponseWriter) { _, _ = w.Write([]byte(`{"version":"develop"}`)) },
+			routes: map[string]int{
+				"/api/v1/main/executions/" + id + "/actions/kill": http.StatusNotFound,
+				"/api/v1/main/executions/" + id + "/kill":         http.StatusOK,
+			},
+			wantOrder: []string{
+				"/api/v1/main/executions/" + id + "/actions/kill",
+				"/api/v1/main/executions/" + id + "/kill",
+			},
+			wantSuccess: true,
+		},
+		{
+			name: "unreadable configs, server serving only the 1.x path",
+			configs: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusForbidden)
+				_, _ = w.Write([]byte(`{"message":"Forbidden"}`))
+			},
+			routes: map[string]int{
+				"/api/v1/main/executions/" + id + "/actions/kill": http.StatusForbidden,
+				"/api/v1/main/executions/" + id + "/kill":         http.StatusOK,
+			},
+			wantOrder: []string{
+				"/api/v1/main/executions/" + id + "/actions/kill",
+				"/api/v1/main/executions/" + id + "/kill",
+			},
+			wantSuccess: true,
+		},
+		{
+			name:    "2.0 path wins on the first try, no fallback request",
+			configs: func(w http.ResponseWriter) { _, _ = w.Write([]byte(`{"version":"develop"}`)) },
+			routes: map[string]int{
+				"/api/v1/main/executions/" + id + "/actions/kill": http.StatusOK,
+			},
+			wantOrder:   []string{"/api/v1/main/executions/" + id + "/actions/kill"},
+			wantSuccess: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var seen []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path == "/api/v1/configs" {
+					tt.configs(w)
+					return
+				}
+				seen = append(seen, r.URL.Path)
+				status, ok := tt.routes[r.URL.Path]
+				if !ok {
+					status = http.StatusNotFound
+				}
+				w.WriteHeader(status)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			t.Cleanup(server.Close)
+
+			client := newTestClient(t, server.URL)
+			_, resp, _ := client.API.ExecutionsAPI.KillExecution(client.Ctx, id, "main").Execute()
+
+			if strings.Join(seen, " -> ") != strings.Join(tt.wantOrder, " -> ") {
+				t.Fatalf("requests\ngot  %v\nwant %v", seen, tt.wantOrder)
+			}
+			if tt.wantSuccess && (resp == nil || resp.StatusCode != http.StatusOK) {
+				t.Fatalf("expected the fallback to succeed, got %+v", resp)
+			}
+		})
+	}
+}
+
+// TestCompatTransport_UnknownVersionKeepsFirstErrorWhenBothMiss pins which
+// error survives when neither shape routes: the 2.0 one, since that is the
+// server this binary targets.
+func TestCompatTransport_UnknownVersionKeepsFirstErrorWhenBothMiss(t *testing.T) {
+	const id = "2TLGqHrXC9k8BczKJe5djX"
+
+	var seen []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/configs" {
+			_, _ = w.Write([]byte(`{"version":"develop"}`))
+			return
+		}
+		seen = append(seen, r.URL.Path)
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"detail":"` + r.URL.Path + `"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClient(t, server.URL)
+	_, resp, _ := client.API.ExecutionsAPI.KillExecution(client.Ctx, id, "main").Execute()
+
+	if len(seen) != 2 {
+		t.Fatalf("expected both shapes to be tried, got %v", seen)
+	}
+	if resp == nil || !strings.HasSuffix(resp.Request.URL.Path, "/actions/kill") {
+		t.Fatalf("expected the 2.0 response to be kept, got %+v", resp)
+	}
+}
+
+// TestCompatTransport_KnownVersionDoesNotRetry keeps the fallback off the path
+// for a server whose version is known: a 404 there is a real missing execution,
+// not a route miss, and a second request would only muddy the error.
+func TestCompatTransport_KnownVersionDoesNotRetry(t *testing.T) {
+	const id = "2TLGqHrXC9k8BczKJe5djX"
+
+	for _, version := range []string{"2.0.0-rc13", "1.3.35"} {
+		t.Run(version, func(t *testing.T) {
+			var seen []string
+			server := httptest.NewServer(versionHandler(version, func(w http.ResponseWriter, r *http.Request) {
+				seen = append(seen, r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"detail":"Execution not found"}`))
+			}))
+			t.Cleanup(server.Close)
+
+			client := newTestClient(t, server.URL)
+			_, _, _ = client.API.ExecutionsAPI.KillExecution(client.Ctx, id, "main").Execute()
+
+			if len(seen) != 1 {
+				t.Fatalf("expected exactly one request, got %v", seen)
+			}
+		})
+	}
+}
+
+// TestCompatTransport_CreateExecutionIsNotRewritten guards the collision
+// between POST /executions/{namespace}/{flowId} and a 1.x action call: a flow
+// named after an action, in a namespace long enough to look like an execution
+// id, must still be triggered rather than rewritten to an actions path.
+func TestCompatTransport_CreateExecutionIsNotRewritten(t *testing.T) {
+	var seen string
+	server := httptest.NewServer(versionHandler("2.0.0-rc13", func(w http.ResponseWriter, r *http.Request) {
+		seen = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClient(t, server.URL)
+	// "productionanalytics" is 19 dot-free alphanumerics, so it passes
+	// looksLikeExecutionID; "pause" is in the action set.
+	ctx := withoutExecutionActionRewrite(client.Ctx)
+	_, _, _ = client.API.ExecutionsAPI.CreateExecution(ctx, "productionanalytics", "pause", "main").Execute()
+
+	if seen != "/api/v1/main/executions/productionanalytics/pause" {
+		t.Fatalf("create-execution path was rewritten to %q", seen)
+	}
+}
+
+// TestRunExecutionsByQueryOp_NormalizesOutputAcrossVersions pins the rendered
+// output for the by-query commands: the same shape on both servers, and no
+// field the server did not send (the compat transport mirrors a count key into
+// the body, which must not reach the user's JSON).
+func TestRunExecutionsByQueryOp_NormalizesOutputAcrossVersions(t *testing.T) {
+	for _, tt := range []struct {
+		version, body string
+	}{
+		{"2.0.0-rc13", `{"operationId":"2gtoTYnQy1KHopwSQAXE3y","totalItems":4}`},
+		{"1.3.35", `{"count":4}`},
+	} {
+		t.Run(tt.version, func(t *testing.T) {
+			server := httptest.NewServer(versionHandler(tt.version, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			var out strings.Builder
+			renderer, err := NewRenderer("json", &out)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := runExecutionsByQueryOp(newTestClient(t, server.URL), "kill", nil, renderer); err != nil {
+				t.Fatalf("by-query kill: %v", err)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal([]byte(out.String()), &got); err != nil {
+				t.Fatalf("output is not JSON: %q", out.String())
+			}
+			if got["operation"] != "kill" || got["count"] != float64(4) {
+				t.Fatalf("unexpected payload: %v", got)
+			}
+			// Neither the server's own spelling nor the mirrored one leaks.
+			for _, leaked := range []string{"totalItems", "operationId"} {
+				if _, ok := got[leaked]; ok {
+					t.Errorf("%q leaked into rendered output: %v", leaked, got)
+				}
+			}
+		})
+	}
+}

--- a/src/cli/executions.go
+++ b/src/cli/executions.go
@@ -974,7 +974,11 @@ func runExecutionsRun(client *Client, namespace, flowID string, wait bool, rende
 		fmt.Fprintln(renderer.Writer(), "Waiting for execution to complete...")
 	}
 
-	resp, _, err := client.API.ExecutionsAPI.CreateExecution(client.Ctx, namespace, flowID, client.Tenant).
+	// POST /executions/{namespace}/{flowId} is shaped exactly like a 1.x action
+	// call, so the compat rewrite is opted out of here rather than guessed at in
+	// the transport (see withoutExecutionActionRewrite).
+	ctx := withoutExecutionActionRewrite(client.Ctx)
+	resp, _, err := client.API.ExecutionsAPI.CreateExecution(ctx, namespace, flowID, client.Tenant).
 		Wait(wait).
 		Execute()
 
@@ -2084,8 +2088,14 @@ func runExecutionsByQueryOp(client *Client, op string, filters []kestra.QueryFil
 		return formatSDKError(err)
 	}
 
+	// The server's own body is not rendered: its shape differs by version
+	// (`count` on 1.x, `operationId`/`totalItems` on 2.0) and the compat
+	// transport mirrors a key into it, which would surface as a field the server
+	// never sent. Rendering fields this command owns keeps the output stable
+	// across versions and confines the shim to the wire.
 	count := extractCount(result)
-	return renderer.Render(result, func(w *tabwriter.Writer) error {
+	row := map[string]any{"operation": op, "count": count}
+	return renderer.Render(row, func(w *tabwriter.Writer) error {
 		if count >= 0 {
 			fmt.Fprintf(w, "By-query %s: %d execution(s) affected.\n", op, count)
 		} else {
@@ -2095,12 +2105,23 @@ func runExecutionsByQueryOp(client *Client, op string, filters []kestra.QueryFil
 	})
 }
 
+// extractCount reads a bulk response's item count from an untyped body, under
+// either of the two names the servers use: `count` on 1.x, `totalItems` on 2.0.
+// It returns -1 when the body carries neither.
 func extractCount(m map[string]interface{}) int64 {
 	if m == nil {
 		return -1
 	}
-	if v, ok := m["count"]; ok {
+	for _, key := range []string{"count", "totalItems"} {
+		v, ok := m[key]
+		if !ok {
+			continue
+		}
 		switch n := v.(type) {
+		case json.Number:
+			if parsed, err := n.Int64(); err == nil {
+				return parsed
+			}
 		case float64:
 			return int64(n)
 		case int64:

--- a/src/cli/nsfiles_test.go
+++ b/src/cli/nsfiles_test.go
@@ -25,7 +25,7 @@ func newTestClient(t *testing.T, serverURL string) *Client {
 		Ctx:    context.Background(),
 		Tenant: "main",
 	}
-	compat.legacyServer = c.isLegacyServer
+	compat.era = c.serverEra
 	return c
 }
 


### PR DESCRIPTION
Closes #117.

## What was wrong

Kestra 2.0 moved the single-execution actions under `/executions/{id}/actions/`, and the v2 Go SDK was **split on it**: its generated endpoints still emitted the 1.x paths, its hand-written ones already emitted the 2.0 paths. So neither half worked on both servers:

| | Kestra 1.3.35 | Kestra 2.0.0-rc13 |
|---|---|---|
| `kill`, `replay`, `restart`, `force-run`, `pause`, `resume`, `unqueue`, `change-status`, `set-labels`, `replay-with-inputs` (generated) | ✅ | ❌ |
| `eval-expression` (hand-written) | ❌ | ✅ |

The 404 in the issue is misleading, and it's worth knowing why: on 2.0 the bare POST actions fall through to `POST /executions/{namespace}/{flowId}`, so `replay` reported *"Requested Flow is not found."* — the server was looking for a **flow** named `replay`. That reads like a missing execution, which is what sent the original report looking in the wrong place.

The issue also asked whether the bulk variants were affected. Their **paths** never moved — but 2.0 answers them with `{"operationId":…,"totalItems":N}` where the SDK models only `{"count":N}`, so the number was dropped at decode and **every bulk command reported `0 execution(s) affected` while having actually killed them.** A silent wrong answer rather than an error.

## The upstream fix, and why this PR is still needed

The SDK is fixed in **kestra-io/client-sdk#409** (merged). But one kestractl binary still has to serve both server lines, so `compat.go` normalises on the wire — and it is written to keep working *either side* of the SDK bump, in both directions.

- **`routeExecutionAction`** rewrites whichever shape the SDK produced into the one the server routes, for the 12 actions that moved. Endpoints that did **not** move (`graph`, `flow`, `file`, `file/metas`, `follow`, `follow-dependencies`) and the bulk `<action>/by-ids` / `by-query` variants are excluded — each confirmed against a live 2.0, not inferred.
- **`mirrorBulkCount`** fills in whichever spelling of the count the body lacks. Bidirectional on purpose: with the old SDK the 2.0 body needs `count`, with the fixed SDK the 1.x body needs `totalItems`.

### Unknown server versions

Where the version can't be determined — a `develop` build, or a `/configs` the user can't read — the shape would be a pure guess, and guessing wrong breaks *every* action. So the 2.0 path is tried first (this binary targets 2.x) and a 403/404 route miss falls back to the 1.x path; if both miss, the **2.0** error is surfaced. A *known* version sends one request and never retries, so a genuine "execution not found" 404 isn't muddied by a second attempt.

### The namespace/flow-name collision

`POST /executions/{namespace}/{flowId}` is indistinguishable from a 1.x action call by path shape alone — a flow named `pause` in a namespace named `productionanalytics` reads exactly like `pause` on execution `productionanalytics`.

**Kestra 1.3 refused reserved-keyword flow ids** (`pause, resume, force-run, change-status, kill, …`), so this was impossible. **2.0 accepts them** — I confirmed it deploys with a 200 — so the collision is now reachable, and it silently failed to trigger the flow behind an `Access denied`:

```
executions run productionanalytics pause
  broken -> Error: API error: Access denied      (flow never ran)
  fixed  -> Execution triggered successfully!
```

The single call site that builds that path opts out explicitly (`withoutExecutionActionRewrite`) rather than leaning on the id heuristic, which would only move the collision to a longer namespace.

## ⚠️ Output change

`executions *-by-query` no longer renders the raw server body. That body differed by version (`count` on 1.x vs `operationId`/`totalItems` on 2.0) and would additionally have exposed the key the transport mirrors in — a field the server never sent, which a script would read as authoritative.

```
before   1.x -> {"count":1}          2.0 -> {"operationId":"..","totalItems":1}
after    both -> {"operation":"kill","count":1}
```

This matches what the `*-bulk` commands already emit. Flagging it per AGENTS.md; the table output is unchanged.

## Verification

Live against **EE 2.0.0-rc13 and EE 1.3.35**, and against **both** the pinned SDK (`v2.0.0-rc3`) and the fixed SDK from client-sdk#409 — so forward-compatibility is tested, not assumed. Every action was driven against a *correctly-stated* execution (a FAILED one for `restart`, a genuinely paused one for `resume`) so a state conflict couldn't be mistaken for a pass.

Covered: `kill`, `pause`, `force-run`, `replay`, `restart`, `resume`, `eval-expression`, `replay-with-inputs`, `set-labels`, `change-status`, `unqueue`, plus the `-bulk` and `-by-query` families. All pass on both, with correct counts.

`go vet`, `gofmt`, and `go test -race ./src/...` clean. New tests pin the wire path per server version for both SDK surfaces, the fallback ordering and the no-retry-when-known case, the create-execution exemption, the nested-`count` edge case, and the normalized by-query output.

## Note on `go.mod`

Deliberately still on `go-sdk/v2 v2.0.0-rc3`. client-sdk#409 is merged but **not yet tagged** (latest is `go-sdk/v2.0.0-rc3`), and AGENTS.md makes a pseudo-version pin a review blocker for `main`. This PR needs no bump — it's verified on rc3 and forward-compatible. Once a `go-sdk/v2.0.0-rc4` tag exists the bump is a small follow-up: 9 call sites moving `GetCount()` → `GetTotalItems()`, which I've already written and validated against the merged SDK.
