### PR TITLE
chore(deps): bump the Go SDK to v2.0.0-rc4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1
-	github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3
+	github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -19,8 +19,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3 h1:wWymwgqpnDlwpWurxmSUFbpMOh8wVhK9qQx+fU7xqSM=
-github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3/go.mod h1:ckpZC/7pTYvb7B2iLxY90UGKu374oBvDsGXJ8bWtlwk=
+github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc4 h1:3GOqNZOsx27RWh8F0AIjjL4sdd8C7Kb5oTois50OsyE=
+github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc4/go.mod h1:ckpZC/7pTYvb7B2iLxY90UGKu374oBvDsGXJ8bWtlwk=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=

--- a/src/cli/executions.go
+++ b/src/cli/executions.go
@@ -1353,7 +1353,10 @@ func newExecutionsBulkForceRunCommand() *cobra.Command {
 }
 
 func runExecutionsBulkOp(client *Client, ids []string, op string, renderer *Renderer) error {
-	var resp *kestra.BulkResponse
+	// The action bulk endpoints answer with the 2.0 async-operation shape; only
+	// the delete ones still return a BulkResponse (kestra-io/client-sdk#409).
+	var resp *kestra.ApiAsyncOperationResponse
+	var deleteResp *kestra.BulkResponse
 	var err error
 
 	switch op {
@@ -1362,7 +1365,7 @@ func runExecutionsBulkOp(client *Client, ids []string, op string, renderer *Rend
 			KillExecutionsByIds(client.Ctx, client.Tenant).
 			RequestBody(ids).Execute()
 	case "delete":
-		resp, _, err = client.API.ExecutionsAPI.
+		deleteResp, _, err = client.API.ExecutionsAPI.
 			DeleteExecutionsByIds(client.Ctx, client.Tenant).
 			RequestBody(ids).Execute()
 	case "restart":
@@ -1392,8 +1395,11 @@ func runExecutionsBulkOp(client *Client, ids []string, op string, renderer *Rend
 	}
 
 	count := int32(0)
-	if resp != nil {
-		count = resp.GetCount()
+	switch {
+	case resp != nil:
+		count = resp.GetTotalItems()
+	case deleteResp != nil:
+		count = deleteResp.GetCount()
 	}
 
 	result := map[string]any{
@@ -1450,7 +1456,7 @@ func runExecutionsBulkSetLabels(client *Client, ids []string, labels []kestra.La
 
 	count := int32(0)
 	if resp != nil {
-		count = resp.GetCount()
+		count = resp.GetTotalItems()
 	}
 
 	result := map[string]any{"count": count, "ids": ids, "labels": len(labels)}
@@ -1501,7 +1507,7 @@ func runExecutionsBulkUnqueue(client *Client, ids []string, state string, render
 
 	count := int32(0)
 	if resp != nil {
-		count = resp.GetCount()
+		count = resp.GetTotalItems()
 	}
 
 	result := map[string]any{"count": count, "ids": ids}
@@ -1791,7 +1797,7 @@ func runExecutionsUpdateStatusByQuery(client *Client, newStatus string, filters 
 
 	count := int32(0)
 	if resp != nil {
-		count = resp.GetCount()
+		count = resp.GetTotalItems()
 	}
 
 	result := map[string]any{"count": count, "new_status": newStatus}


### PR DESCRIPTION
Rebased onto `main` now that #125 has landed. Single commit; base is `main`.

## What

Picks up kestra-io/client-sdk#409, released as `go-sdk/v2.0.0-rc4`. That PR moved the generated executions endpoints onto the 2.0 `/actions/` paths and typed the action bulk endpoints as `ApiAsyncOperationResponse`.

This had to merge **after** #125: the rc4 SDK emits the 2.0 paths, so without #125's compat shim every execution action breaks on Kestra 1.x. Measured, not assumed —

```
rc4 SDK with the shim disabled, vs Kestra 1.3.35
  kill / pause / replay / restart / resume / eval  ->  API error: Forbidden
  kill-bulk / pause-bulk                           ->  0 execution(s) affected
```

## ⚠️ Breaking SDK change, absorbed here

The retype is a compile-time break, and that is the point: the `GetCount()` these call sites read was **always 0** against a 2.0 server, because the server sends `totalItems` and `BulkResponse` has no field for it. Nine call sites move to `GetTotalItems()`.

`DeleteExecutionsByIds` deliberately stays on `GetCount()` — the spec still types the *delete* bulk endpoints as `BulkResponse`, so `count` is correct there. That split is not mine; it is the one the SDK's own hand-written client already draws.

## compat.go is untouched, by design

Worth calling out, because it could have been a second migration:

- The action path rewrite keys off **what the server routes**, not what the SDK emits. It now no-ops on 2.x (the SDK already emits the right path) and rewrites to the bare paths on 1.x — the reverse of what it did on rc3.
- `mirrorBulkCount` is bidirectional for the same reason: with this SDK the **1.x** body is the one missing a key, where previously it was the 2.0 body.

Both were written for this bump in #125 and needed no edit here.

## Verification

Against live **EE 2.0.0-rc13** and **EE 1.3.35**: unit and e2e suites green on both. The unit suite passes **unchanged** — no test needed adjusting for the new SDK. The 1.3 e2e run is the meaningful one: it only passes because the rewrite and the count mirror both operate in the opposite direction now. Had either been one-directional, that run would be red.

`.github/scripts/check-sdk-pin.sh` passes — `v2.0.0-rc4` is a clean release tag, not a pseudo-version:

```
check-sdk-pin: github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc4 ok
```

## Release note

`chore(deps):` is a patch bump, so merging this auto-tags **`v2.0.0-rc.4`** off `main` (current base tag `v2.0.0-rc.3`). Note that number coincidentally matches the Go SDK's own `go-sdk/v2.0.0-rc4` — they are unrelated artifacts that happen to share a counter.
