### PR TITLE
fix: resolve the five open bug reports (#118–#122)

### DIFF
--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -43,7 +43,6 @@ func NewClient() (*Client, error) {
 // newClientDefault is the default client creation logic.
 func newClientDefault() (*Client, error) {
 	host, tenant, auth, err := resolveConfig()
-	isVerbose := viper.GetBool("verbose")
 
 	if err != nil {
 		return nil, err
@@ -72,7 +71,10 @@ func newClientDefault() (*Client, error) {
 	cfg.Servers = kestra.ServerConfigurations{
 		{URL: host},
 	}
-	cfg.Debug = isVerbose
+	// The generated SDK debug logger prints the Authorization header verbatim,
+	// so both SDK loggers stay off and compatTransport does the dumping with
+	// uniform masking instead (issue #119).
+	cfg.Debug = false
 
 	// One HTTP client for both SDK clients, so the Kestra 1.x response shim
 	// (see compat.go) applies to generated and hand-written endpoints alike.
@@ -91,7 +93,7 @@ func newClientDefault() (*Client, error) {
 
 	// The hand-written client shares the same resolved host, headers, and debug
 	// setting; auth is appended per-branch below.
-	opts := []kestra.ClientOption{kestra.WithDebug(isVerbose), kestra.WithHTTPClient(httpClient)}
+	opts := []kestra.ClientOption{kestra.WithDebug(false), kestra.WithHTTPClient(httpClient)}
 	if len(parsed) > 0 {
 		opts = append(opts, kestra.WithHeaders(parsed))
 	}

--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 
@@ -41,7 +42,7 @@ func NewClient() (*Client, error) {
 
 // newClientDefault is the default client creation logic.
 func newClientDefault() (*Client, error) {
-	host, tenant, token, username, password, err := resolveConfig()
+	host, tenant, auth, err := resolveConfig()
 	isVerbose := viper.GetBool("verbose")
 
 	if err != nil {
@@ -96,15 +97,15 @@ func newClientDefault() (*Client, error) {
 	}
 
 	ctx := context.Background()
-	if token != "" {
-		ctx = context.WithValue(ctx, kestra.ContextAccessToken, token)
-		opts = append(opts, kestra.WithTokenAuth(token))
-	} else if username != "" && password != "" {
+	if auth.Token != "" {
+		ctx = context.WithValue(ctx, kestra.ContextAccessToken, auth.Token)
+		opts = append(opts, kestra.WithTokenAuth(auth.Token))
+	} else if auth.Username != "" && auth.Password != "" {
 		ctx = context.WithValue(ctx, kestra.ContextBasicAuth, kestra.BasicAuth{
-			UserName: username,
-			Password: password,
+			UserName: auth.Username,
+			Password: auth.Password,
 		})
-		opts = append(opts, kestra.WithBasicAuth(username, password))
+		opts = append(opts, kestra.WithBasicAuth(auth.Username, auth.Password))
 	} else {
 		return nil, fmt.Errorf("could not init client without any auth, at least token or username+password is required")
 	}
@@ -119,14 +120,27 @@ func newClientDefault() (*Client, error) {
 	return c, nil
 }
 
-// resolveConfig returns (host, tenant, token, error) using Viper for precedence: flags > env > config file.
-func resolveConfig() (string, string, string, string, string, error) {
+// Auth methods reported by resolvedAuth.
+const (
+	authMethodToken = "token"
+	authMethodBasic = "basic"
+)
+
+// resolvedAuth is the authentication kestractl will use for this invocation.
+// Only the fields belonging to Method are populated; Method is empty when no
+// source configured any authentication at all.
+type resolvedAuth struct {
+	Method   string
+	Token    string
+	Username string
+	Password string
+}
+
+// resolveConfig returns (host, tenant, auth, error) using Viper for precedence: flags > env > config file.
+func resolveConfig() (string, string, resolvedAuth, error) {
 	// Viper handles precedence automatically: flags > env > config > defaults
 	host := strings.TrimSpace(viper.GetString(FlagHost))
 	tenant := viper.GetString(FlagTenant)
-	token := viper.GetString(FlagToken)
-	username := viper.GetString(FlagUsername)
-	password := viper.GetString(FlagPassword)
 
 	// Set defaults if not provided
 	if host == "" {
@@ -138,7 +152,90 @@ func resolveConfig() (string, string, string, string, string, error) {
 
 	host = normalizeHost(host)
 
-	return host, tenant, token, username, password, nil
+	auth, err := resolveAuth()
+	if err != nil {
+		return host, tenant, resolvedAuth{}, err
+	}
+
+	return host, tenant, auth, nil
+}
+
+// explicitAuthFlags records which auth flags the user set on the command line
+// with a non-empty value. It is populated by initializeConfig and stays empty
+// for callers that never parse flags.
+var explicitAuthFlags map[string]bool
+
+// authFieldFromFlag reports whether the named auth field was set by a flag.
+func authFieldFromFlag(name string) bool { return explicitAuthFlags[name] }
+
+// authFieldFromEnv reports whether the named auth field was set by a
+// KESTRACTL_* environment variable.
+func authFieldFromEnv(name string) bool {
+	v, ok := os.LookupEnv(envPrefix + "_" + strings.ToUpper(name))
+	return ok && strings.TrimSpace(v) != ""
+}
+
+// authFieldResolved reports whether the named auth field has any value at all.
+// Used as the last source in the precedence chain, where a value can only come
+// from the config file's default context.
+func authFieldResolved(name string) bool { return viper.GetString(name) != "" }
+
+// resolveAuth picks the authentication method and its values.
+//
+// The method is decided by the highest-precedence source (flags > env > config
+// file) that sets any of token/username/password; a token wins over basic auth
+// within the same source. Once the method is chosen, its individual values
+// still resolve through the normal per-field Viper precedence, so a config-file
+// username can pair with a --password flag. Fields belonging to the losing
+// method are dropped rather than silently taking over the request (issue #120).
+func resolveAuth() (resolvedAuth, error) {
+	method := ""
+	for _, sets := range []func(string) bool{authFieldFromFlag, authFieldFromEnv, authFieldResolved} {
+		switch {
+		case sets(FlagToken):
+			method = authMethodToken
+		case sets(FlagUsername) || sets(FlagPassword):
+			method = authMethodBasic
+		}
+		if method != "" {
+			break
+		}
+	}
+
+	switch method {
+	case authMethodToken:
+		token := viper.GetString(FlagToken)
+		if token == "" {
+			return resolvedAuth{}, missingAuthFieldsError([]string{FlagToken})
+		}
+		return resolvedAuth{Method: authMethodToken, Token: token}, nil
+	case authMethodBasic:
+		username := viper.GetString(FlagUsername)
+		password := viper.GetString(FlagPassword)
+		var missing []string
+		if username == "" {
+			missing = append(missing, FlagUsername)
+		}
+		if password == "" {
+			missing = append(missing, FlagPassword)
+		}
+		if len(missing) > 0 {
+			return resolvedAuth{}, missingAuthFieldsError(missing)
+		}
+		return resolvedAuth{Method: authMethodBasic, Username: username, Password: password}, nil
+	}
+
+	return resolvedAuth{}, nil
+}
+
+// missingAuthFieldsError explains which auth fields are missing and where they
+// can be set.
+func missingAuthFieldsError(missing []string) error {
+	hints := make([]string, 0, len(missing))
+	for _, name := range missing {
+		hints = append(hints, fmt.Sprintf("--%s, %s_%s, or %q in the config file's default context", name, envPrefix, strings.ToUpper(name), name))
+	}
+	return fmt.Errorf("incomplete authentication: missing %s (set %s)", strings.Join(missing, " and "), strings.Join(hints, "; "))
 }
 
 // parseHeaders parses a slice of "Key:Value" strings into a map.

--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -344,7 +344,12 @@ func formatErrorBody(body []byte, errMsg string) error {
 // problem document carries a "type" key, which those helpers would
 // otherwise read as the resource's own type and report success on a 404.
 func isProblemDocument(m map[string]any) bool {
-	if _, ok := m["status"].(float64); !ok {
+	// "status" is a float64 after a plain json.Unmarshal and a json.Number when
+	// the body was decoded with json.Decoder.UseNumber (as the KV paths do to
+	// keep integers above 2^53 exact), so accept either.
+	switch m["status"].(type) {
+	case float64, json.Number:
+	default:
 		return false
 	}
 	if _, ok := m["title"].(string); ok {

--- a/src/cli/client_test.go
+++ b/src/cli/client_test.go
@@ -3,12 +3,15 @@ package cli
 import (
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 	"unsafe"
 
 	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+	"github.com/spf13/viper"
 )
 
 func setGenericOpenAPIErrorBody(err *kestra.GenericOpenAPIError, body []byte) {
@@ -234,4 +237,180 @@ func TestTryParseActionsFromError(t *testing.T) {
 			t.Fatalf("expected nil, got: %v", actions)
 		}
 	})
+}
+
+// --- auth-method precedence (issue #120) ---
+
+// writeAuthConfig writes a config.yaml with a single default context and
+// returns its path.
+func writeAuthConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// initConfigForTest parses args on a fresh root command and runs the real
+// initializeConfig, so tests exercise the whole flags > env > config chain.
+func initConfigForTest(t *testing.T, args ...string) {
+	t.Helper()
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	root := NewRootCommand()
+	if err := root.ParseFlags(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := initializeConfig(root); err != nil {
+		t.Fatalf("initializeConfig: %v", err)
+	}
+}
+
+const tokenContextConfig = `default_context: tokenctx
+contexts:
+  tokenctx:
+    host: http://example.invalid
+    tenant: othertenant
+    auth_method: token
+    token: config-token
+`
+
+const basicContextConfig = `default_context: basicctx
+contexts:
+  basicctx:
+    host: http://example.invalid
+    tenant: othertenant
+    auth_method: basic
+    username: config-user
+    password: config-pass
+`
+
+func TestResolveConfigAuthPrecedence(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   string
+		env      map[string]string
+		args     []string
+		want     resolvedAuth
+		errorHas string
+	}{
+		{
+			name:   "flag basic auth beats config file token",
+			config: tokenContextConfig,
+			args:   []string{"--host", "http://localhost:9801", "--username", "u", "--password", "p"},
+			want:   resolvedAuth{Method: authMethodBasic, Username: "u", Password: "p"},
+		},
+		{
+			name: "flag basic auth with no config file",
+			args: []string{"--host", "http://localhost:9801", "--username", "u", "--password", "p"},
+			want: resolvedAuth{Method: authMethodBasic, Username: "u", Password: "p"},
+		},
+		{
+			name: "flag basic auth beats env token",
+			env:  map[string]string{"KESTRACTL_TOKEN": "env-token"},
+			args: []string{"--username", "u", "--password", "p"},
+			want: resolvedAuth{Method: authMethodBasic, Username: "u", Password: "p"},
+		},
+		{
+			name:   "env basic auth beats config file token",
+			config: tokenContextConfig,
+			env:    map[string]string{"KESTRACTL_USERNAME": "envuser", "KESTRACTL_PASSWORD": "envpass"},
+			want:   resolvedAuth{Method: authMethodBasic, Username: "envuser", Password: "envpass"},
+		},
+		{
+			name:   "flag token beats config file basic auth",
+			config: basicContextConfig,
+			args:   []string{"--token", "flag-token"},
+			want:   resolvedAuth{Method: authMethodToken, Token: "flag-token"},
+		},
+		{
+			name:   "flag basic auth overrides config file basic auth values",
+			config: basicContextConfig,
+			args:   []string{"--username", "u", "--password", "p"},
+			want:   resolvedAuth{Method: authMethodBasic, Username: "u", Password: "p"},
+		},
+		{
+			name:   "config file token used when nothing else is set",
+			config: tokenContextConfig,
+			want:   resolvedAuth{Method: authMethodToken, Token: "config-token"},
+		},
+		{
+			name:   "config file basic auth used when nothing else is set",
+			config: basicContextConfig,
+			want:   resolvedAuth{Method: authMethodBasic, Username: "config-user", Password: "config-pass"},
+		},
+		{
+			name: "token wins over basic auth within the same source",
+			args: []string{"--token", "flag-token", "--username", "u", "--password", "p"},
+			want: resolvedAuth{Method: authMethodToken, Token: "flag-token"},
+		},
+		{
+			name:   "values for the chosen method still merge across sources",
+			config: basicContextConfig,
+			args:   []string{"--password", "flagpass"},
+			want:   resolvedAuth{Method: authMethodBasic, Username: "config-user", Password: "flagpass"},
+		},
+		{
+			name:     "incomplete basic auth from flags is a hard error, not a token fallback",
+			config:   tokenContextConfig,
+			args:     []string{"--username", "u"},
+			errorHas: "password",
+		},
+		{
+			name:     "incomplete basic auth from the config file is a hard error",
+			config:   "default_context: c\ncontexts:\n  c:\n    username: only-user\n",
+			errorHas: "password",
+		},
+		{
+			name:     "basic auth with only a password names the missing username",
+			args:     []string{"--password", "p"},
+			errorHas: "username",
+		},
+		{
+			// Documents the behaviour of an explicitly empty --token: it carries
+			// no auth information, so lower-precedence sources still apply.
+			name:   "empty token flag does not select the token method",
+			config: basicContextConfig,
+			args:   []string{"--token", ""},
+			want:   resolvedAuth{Method: authMethodBasic, Username: "config-user", Password: "config-pass"},
+		},
+		{
+			name: "no auth configured anywhere",
+			want: resolvedAuth{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			args := tt.args
+			if tt.config != "" {
+				args = append([]string{"--config", writeAuthConfig(t, tt.config)}, args...)
+			} else {
+				// Never let the developer's real ~/.kestractl/config.yaml leak in.
+				args = append([]string{"--config", writeAuthConfig(t, "")}, args...)
+			}
+			initConfigForTest(t, args...)
+
+			_, _, auth, err := resolveConfig()
+			if tt.errorHas != "" {
+				if err == nil {
+					t.Fatalf("expected an error mentioning %q, got auth %+v", tt.errorHas, auth)
+				}
+				if !strings.Contains(err.Error(), tt.errorHas) {
+					t.Fatalf("error %q does not mention %q", err.Error(), tt.errorHas)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if auth != tt.want {
+				t.Fatalf("auth = %+v, want %+v", auth, tt.want)
+			}
+		})
+	}
 }

--- a/src/cli/client_test.go
+++ b/src/cli/client_test.go
@@ -414,3 +414,33 @@ func TestResolveConfigAuthPrecedence(t *testing.T) {
 		})
 	}
 }
+
+// TestIsProblemDocument_StatusNumberForms covers both decoders: a plain
+// json.Unmarshal yields float64, while UseNumber (used by the KV paths to keep
+// integers above 2^53 exact) yields json.Number. Either must still be
+// recognised, or a 404 would render as a record with a zero exit code.
+func TestIsProblemDocument_StatusNumberForms(t *testing.T) {
+	tests := []struct {
+		name string
+		doc  map[string]any
+		want bool
+	}{
+		{name: "float64 status", doc: map[string]any{"status": float64(404), "title": "Resource not found"}, want: true},
+		{name: "json.Number status", doc: map[string]any{"status": json.Number("404"), "title": "Resource not found"}, want: true},
+		{name: "json.Number status with detail only", doc: map[string]any{"status": json.Number("404"), "detail": "No value found"}, want: true},
+		{name: "json.Number status without title or detail", doc: map[string]any{"status": json.Number("404")}, want: false},
+		{name: "string status", doc: map[string]any{"status": "404", "title": "Resource not found"}, want: false},
+		{name: "no status", doc: map[string]any{"title": "Resource not found"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isProblemDocument(tt.doc); got != tt.want {
+				t.Fatalf("isProblemDocument = %v, want %v", got, tt.want)
+			}
+			if tt.want && problemMessage(tt.doc) == "" {
+				t.Fatal("expected a rendered problem message")
+			}
+		})
+	}
+}

--- a/src/cli/compat.go
+++ b/src/cli/compat.go
@@ -8,7 +8,11 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"os"
+	"sort"
 	"strings"
+
+	"github.com/spf13/viper"
 )
 
 // Kestra 1.x compatibility.
@@ -84,13 +88,26 @@ func rewriteExempt(ctx context.Context) bool {
 // Client.ServerVersion once the client exists, and the shims stay inert until
 // then.
 func newCompatHTTPClient() (*http.Client, *compatTransport) {
-	transport := &compatTransport{base: http.DefaultTransport, era: func() serverEra { return eraUnknown }}
+	transport := &compatTransport{
+		base:    http.DefaultTransport,
+		era:     func() serverEra { return eraUnknown },
+		verbose: viper.GetBool(FlagVerbose),
+	}
 	return &http.Client{Transport: transport}, transport
 }
 
 type compatTransport struct {
 	base http.RoundTripper
 	era  func() serverEra
+
+	// verbose enables the --verbose HTTP dump. Both SDK clients share this
+	// transport, so this is the one and only dump path: the SDKs' own debug
+	// loggers stay off (see newClientDefault), because the generated one prints
+	// the Authorization header verbatim (issue #119).
+	verbose bool
+	// logger is where the dump goes; nil means os.Stderr. It must never be
+	// stdout: `-o json` output has to stay parsable.
+	logger io.Writer
 }
 
 // compatMarkers are the keys a body must contain for fillCompatDefaults to have
@@ -99,7 +116,18 @@ type compatTransport struct {
 var compatMarkers = [][]byte{[]byte(`"tasks"`), []byte(`"flowRevision"`)}
 
 func (t *compatTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.roundTrip(req)
+	if err != nil {
+		t.dumpTransportError(err)
+	} else {
+		t.dumpResponse(resp)
+	}
+	return resp, err
+}
+
+func (t *compatTransport) roundTrip(req *http.Request) (*http.Response, error) {
 	req, fallback := t.routeExecutionAction(req)
+	t.dumpRequest(req)
 
 	resp, err := t.base.RoundTrip(req)
 	if err == nil && fallback != "" && isRouteMiss(resp) {
@@ -108,6 +136,7 @@ func (t *compatTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// the other shape safe to try. If it misses too, the first response is
 		// kept: its error describes the 2.x server this binary targets.
 		if retry, ok := cloneRequestWithPath(req, fallback); ok {
+			t.dumpRequest(retry)
 			if second, secondErr := t.base.RoundTrip(retry); secondErr == nil {
 				if isRouteMiss(second) {
 					drainAndClose(second)
@@ -488,4 +517,213 @@ func requireKestra2(client *Client, feature string) error {
 	}
 	version, _ := client.ServerVersion()
 	return fmt.Errorf("%s is only available on Kestra 2.0 or later (the server runs %s)", feature, version)
+}
+
+// --- verbose HTTP dump ---
+//
+// Both SDK clients ship their own debug logger, and they disagree: the
+// hand-written one masks sensitive headers, the generated one calls
+// httputil.DumpRequestOut and prints `Authorization: Basic <base64>` verbatim,
+// which is a credential in plain text (issue #119). Rather than depend on each
+// SDK client getting this right, kestractl turns both off and dumps here, on the
+// transport they share, so every request — generated, hand-written, or
+// hand-rolled (see runWebhookTrigger) — gets the same masking.
+
+// redactedHeaderValue is what a sensitive header's value is replaced with.
+const redactedHeaderValue = "REDACTED"
+
+// alwaysSensitiveHeaders are header names (lower-cased) that always carry a
+// credential.
+var alwaysSensitiveHeaders = map[string]bool{
+	"authorization":       true,
+	"proxy-authorization": true,
+	"cookie":              true,
+	"set-cookie":          true,
+}
+
+// sensitiveHeaderSubstrings catch credential-bearing headers this code does not
+// know by name, including anything a user passes with --header.
+var sensitiveHeaderSubstrings = []string{"token", "secret", "password", "api-key", "apikey"}
+
+// isSensitiveHeader reports whether a header's value must be masked in the
+// verbose dump. Matching is case-insensitive.
+func isSensitiveHeader(name string) bool {
+	lower := strings.ToLower(name)
+	if alwaysSensitiveHeaders[lower] {
+		return true
+	}
+	for _, needle := range sensitiveHeaderSubstrings {
+		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+// dumpWriter is where the verbose dump goes. Never stdout: the rendered command
+// output (notably `-o json`) has to stay parsable.
+func (t *compatTransport) dumpWriter() io.Writer {
+	if t.logger != nil {
+		return t.logger
+	}
+	return os.Stderr
+}
+
+// writeMaskedHeaders prints headers in sorted order, masking the sensitive
+// ones. It reads the header map without mutating it.
+func writeMaskedHeaders(w io.Writer, prefix string, h http.Header) {
+	names := make([]string, 0, len(h))
+	for name := range h {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		value := strings.Join(h[name], ", ")
+		if isSensitiveHeader(name) {
+			value = redactedHeaderValue
+		}
+		fmt.Fprintf(w, "%s %s: %s\n", prefix, name, value)
+	}
+}
+
+// dumpRequest prints the outgoing request. The request itself is left untouched:
+// the body is re-read through GetBody, and the headers are only read.
+func (t *compatTransport) dumpRequest(req *http.Request) {
+	if !t.verbose || req == nil {
+		return
+	}
+	var out bytes.Buffer
+	fmt.Fprintf(&out, "> %s %s\n", req.Method, req.URL.String())
+	writeMaskedHeaders(&out, ">", req.Header)
+	if body, ok := requestBodyForDump(req); ok {
+		writeDumpBody(&out, ">", req.Header, body)
+	}
+	out.WriteString("\n")
+	_, _ = t.dumpWriter().Write(out.Bytes())
+}
+
+// requestBodyForDump returns a copy of the request body, or false when it
+// cannot be read without consuming what is about to be sent.
+func requestBodyForDump(req *http.Request) ([]byte, bool) {
+	if req.Body == nil || req.Body == http.NoBody || req.GetBody == nil {
+		return nil, false
+	}
+	rc, err := req.GetBody()
+	if err != nil || rc == nil {
+		return nil, false
+	}
+	defer func() { _ = rc.Close() }()
+	body, err := io.ReadAll(rc)
+	if err != nil {
+		return nil, false
+	}
+	return body, true
+}
+
+// dumpResponse prints the response, then re-wraps its body so the SDK can still
+// decode it.
+func (t *compatTransport) dumpResponse(resp *http.Response) {
+	if !t.verbose || resp == nil {
+		return
+	}
+	var out bytes.Buffer
+	fmt.Fprintf(&out, "< %s\n", resp.Status)
+	writeMaskedHeaders(&out, "<", resp.Header)
+	if body, ok := t.readResponseBodyForDump(resp); ok {
+		writeDumpBody(&out, "<", resp.Header, body)
+	}
+	out.WriteString("\n")
+	_, _ = t.dumpWriter().Write(out.Bytes())
+}
+
+// readResponseBodyForDump buffers the response body and puts it back, so
+// dumping is transparent to the caller. A streaming response is skipped: it has
+// no end to read to, and buffering it would hang the command.
+func (t *compatTransport) readResponseBodyForDump(resp *http.Response) ([]byte, bool) {
+	if resp.Body == nil || resp.Body == http.NoBody || isEventStream(resp) {
+		return nil, false
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		// Hand the read error back to the caller rather than swallowing it.
+		resp.Body = io.NopCloser(errReader{err})
+		return body, true
+	}
+	resp.Body = io.NopCloser(bytes.NewReader(body))
+	resp.ContentLength = int64(len(body))
+	return body, true
+}
+
+// isEventStream reports whether a response is a server-sent-event stream.
+func isEventStream(resp *http.Response) bool {
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		return false
+	}
+	return mediaType == "text/event-stream"
+}
+
+// errReader replays a read error, so a body that failed to buffer during the
+// dump still surfaces that failure to the SDK.
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+// maxDumpBodyBytes caps how much of a body the dump prints. Past this, only the
+// placeholder is written: -v is a debugging aid, not a way to fill a terminal
+// with a multi-megabyte export.
+const maxDumpBodyBytes = 64 << 10
+
+// textLikeMediaTypes are the exact media types whose bodies are safe to print.
+// Anything else — a plugin jar, a namespace-file download, a CSV/zip export —
+// is binary and gets the placeholder instead of raw bytes on the terminal.
+var textLikeMediaTypes = map[string]bool{
+	"application/json":                  true,
+	"application/x-yaml":                true,
+	"application/yaml":                  true,
+	"application/x-www-form-urlencoded": true,
+}
+
+// isTextLikeContentType reports whether a body of this content type can be
+// printed as text. An absent or unparseable type is treated as binary: a body
+// that does not say what it is does not get dumped.
+func isTextLikeContentType(contentType string) bool {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return false
+	}
+	if strings.HasPrefix(mediaType, "text/") || textLikeMediaTypes[mediaType] {
+		return true
+	}
+	// application/problem+json and friends.
+	return strings.HasPrefix(mediaType, "application/") && strings.HasSuffix(mediaType, "+json")
+}
+
+// writeDumpBody prints a body, or a one-line placeholder when it is binary or
+// too large to be worth printing. The bytes themselves are never altered: the
+// caller has already put the response body back for the SDK to read.
+func writeDumpBody(w io.Writer, prefix string, header http.Header, body []byte) {
+	if len(body) == 0 {
+		return
+	}
+	contentType := header.Get("Content-Type")
+	if !isTextLikeContentType(contentType) || len(body) > maxDumpBodyBytes {
+		label := contentType
+		if label == "" {
+			label = "unknown content type"
+		}
+		fmt.Fprintf(w, "%s [body: %s, %d bytes, not shown]\n", prefix, label, len(body))
+		return
+	}
+	fmt.Fprintf(w, "%s\n%s %s\n", prefix, prefix, body)
+}
+
+// dumpTransportError prints a failed round trip. The error text can carry the
+// request URL but never a header, so it needs no masking.
+func (t *compatTransport) dumpTransportError(err error) {
+	if !t.verbose {
+		return
+	}
+	fmt.Fprintf(t.dumpWriter(), "! %v\n\n", err)
 }

--- a/src/cli/compat_test.go
+++ b/src/cli/compat_test.go
@@ -1,7 +1,9 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -836,5 +838,340 @@ func TestRunExecutionsByQueryOp_NormalizesOutputAcrossVersions(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestCompatTransport_MasksCredentialsInVerboseDump covers issue #119: the
+// verbose HTTP dump must never carry a usable credential. The dump lives on the
+// shared transport, so both SDK clients get the same masking.
+func TestCompatTransport_MasksCredentialsInVerboseDump(t *testing.T) {
+	const (
+		basic  = "dXNlcjpzZWNyZXRwYXNz" // user:secretpass
+		bearer = "faketoken123"
+		custom = "custom-token-value"
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Set-Cookie", "JSESSIONID=sessionsecret; Path=/")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var out bytes.Buffer
+	client, transport := newCompatHTTPClient()
+	transport.verbose = true
+	transport.logger = &out
+
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/api/v1/main/flows", strings.NewReader(`{"source":"id: f"}`))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Authorization", "Basic "+basic)
+	req.Header.Set("X-My-Token", custom)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	_ = resp.Body.Close()
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("response body not readable after dump: %q", body)
+	}
+
+	// Same transport, Bearer auth, to prove tokens are masked too.
+	req2, err := http.NewRequest(http.MethodGet, server.URL+"/api/v1/configs", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req2.Header.Set("Authorization", "Bearer "+bearer)
+	resp2, err := client.Do(req2)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	drainAndClose(resp2)
+
+	dump := out.String()
+	for _, secret := range []string{basic, bearer, custom, "sessionsecret"} {
+		if strings.Contains(dump, secret) {
+			t.Errorf("verbose dump leaked %q:\n%s", secret, dump)
+		}
+	}
+	// The headers are still reported, just masked.
+	for _, want := range []string{"Authorization: REDACTED", "X-My-Token: REDACTED", "Set-Cookie: REDACTED"} {
+		if !strings.Contains(dump, want) {
+			t.Errorf("verbose dump missing %q:\n%s", want, dump)
+		}
+	}
+	// Bodies stay visible: that is the point of -v.
+	for _, want := range []string{`{"source":"id: f"}`, `{"ok":true}`} {
+		if !strings.Contains(dump, want) {
+			t.Errorf("verbose dump missing body %q:\n%s", want, dump)
+		}
+	}
+	// Non-sensitive headers keep their values.
+	if !strings.Contains(dump, "Content-Type: application/json") {
+		t.Errorf("verbose dump dropped Content-Type:\n%s", dump)
+	}
+}
+
+// TestCompatTransport_QuietWhenVerboseOff asserts the dump is opt-in, so normal
+// runs (and `-o json` stdout) stay clean.
+func TestCompatTransport_QuietWhenVerboseOff(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var out bytes.Buffer
+	client, transport := newCompatHTTPClient()
+	transport.logger = &out
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/api/v1/configs", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpzZWNyZXRwYXNz")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	drainAndClose(resp)
+
+	if out.Len() != 0 {
+		t.Fatalf("expected no output with verbose off, got:\n%s", out.String())
+	}
+}
+
+func TestIsSensitiveHeader(t *testing.T) {
+	sensitive := []string{
+		"Authorization", "authorization", "Proxy-Authorization", "Cookie", "Set-Cookie",
+		"X-Api-Key", "x-apikey", "X-My-Token", "My-Secret-Header", "X-User-Password",
+	}
+	for _, name := range sensitive {
+		if !isSensitiveHeader(name) {
+			t.Errorf("%q should be treated as sensitive", name)
+		}
+	}
+	for _, name := range []string{"Content-Type", "Accept", "User-Agent", "X-Frame-Options"} {
+		if isSensitiveHeader(name) {
+			t.Errorf("%q should not be treated as sensitive", name)
+		}
+	}
+}
+
+// TestCompatTransport_DoesNotMutateHeadersWhenDumping guards the clone: the
+// live request must still carry the real credential after being dumped.
+func TestCompatTransport_DoesNotMutateHeadersWhenDumping(t *testing.T) {
+	var got string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var out bytes.Buffer
+	client, transport := newCompatHTTPClient()
+	transport.verbose = true
+	transport.logger = &out
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/api/v1/configs", nil)
+	req.Header.Set("Authorization", "Basic dXNlcjpzZWNyZXRwYXNz")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	drainAndClose(resp)
+
+	if got != "Basic dXNlcjpzZWNyZXRwYXNz" {
+		t.Fatalf("server saw a mangled Authorization header: %q", got)
+	}
+	if req.Header.Get("Authorization") != "Basic dXNlcjpzZWNyZXRwYXNz" {
+		t.Fatalf("caller request was mutated: %q", req.Header.Get("Authorization"))
+	}
+}
+
+func TestMaskHeaderFlagValues(t *testing.T) {
+	got := maskHeaderFlagValues([]string{"X-My-Token:supersecret", "X-Request-Id:abc", "Authorization:Basic zzz", "malformed"})
+	want := "[X-My-Token:REDACTED,X-Request-Id:abc,Authorization:REDACTED,malformed]"
+	if got != want {
+		t.Fatalf("maskHeaderFlagValues = %q, want %q", got, want)
+	}
+}
+
+// TestCompatTransport_DumpsTextBodiesOnly covers the body guard: JSON prints,
+// binary and oversize bodies get a placeholder, and the response the SDK reads
+// is complete either way.
+func TestCompatTransport_DumpsTextBodiesOnly(t *testing.T) {
+	big := strings.Repeat("a", maxDumpBodyBytes+1)
+
+	tests := []struct {
+		name        string
+		contentType string
+		body        string
+		wantDumped  bool
+		wantLine    string
+	}{
+		{
+			name:        "json is printed",
+			contentType: "application/json",
+			body:        `{"ok":true}`,
+			wantDumped:  true,
+		},
+		{
+			name:        "problem+json is printed",
+			contentType: "application/problem+json",
+			body:        `{"title":"nope"}`,
+			wantDumped:  true,
+		},
+		{
+			name:        "yaml is printed",
+			contentType: "application/x-yaml",
+			body:        "id: f",
+			wantDumped:  true,
+		},
+		{
+			name:        "binary gets a placeholder",
+			contentType: "application/octet-stream",
+			body:        "PK\x03\x04binary-payload",
+			wantLine:    "< [body: application/octet-stream, 18 bytes, not shown]",
+		},
+		{
+			name:        "zip gets a placeholder",
+			contentType: "application/zip",
+			body:        "PK\x03\x04",
+			wantLine:    "< [body: application/zip, 4 bytes, not shown]",
+		},
+		{
+			name:        "missing content type gets a placeholder",
+			contentType: "",
+			body:        "who knows",
+			wantLine:    "< [body: unknown content type, 9 bytes, not shown]",
+		},
+		{
+			name:        "oversize text gets a placeholder",
+			contentType: "application/json",
+			body:        big,
+			wantLine:    fmt.Sprintf("< [body: application/json, %d bytes, not shown]", len(big)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tt.contentType != "" {
+					w.Header().Set("Content-Type", tt.contentType)
+				} else {
+					// Suppress net/http's content sniffing, so the "server sent
+					// no Content-Type" case really has none.
+					w.Header()["Content-Type"] = nil
+				}
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			var out bytes.Buffer
+			client, transport := newCompatHTTPClient()
+			transport.verbose = true
+			transport.logger = &out
+
+			req, _ := http.NewRequest(http.MethodGet, server.URL+"/api/v1/main/files/download", nil)
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Fatalf("do: %v", err)
+			}
+			// Whatever the dump did, the SDK still sees the whole body.
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			_ = resp.Body.Close()
+			if string(body) != tt.body {
+				t.Fatalf("response body altered: got %d bytes, want %d", len(body), len(tt.body))
+			}
+
+			dump := out.String()
+			if tt.wantDumped {
+				if !strings.Contains(dump, tt.body) {
+					t.Errorf("expected body in dump:\n%s", dump)
+				}
+				if strings.Contains(dump, "not shown") {
+					t.Errorf("text body should not be replaced by a placeholder:\n%s", dump)
+				}
+				return
+			}
+			if !strings.Contains(dump, tt.wantLine) {
+				t.Errorf("dump missing %q:\n%s", tt.wantLine, truncateForMsg(dump))
+			}
+			if strings.Contains(dump, tt.body) {
+				t.Errorf("body bytes leaked into dump:\n%s", truncateForMsg(dump))
+			}
+		})
+	}
+}
+
+// truncateForMsg keeps a failure message readable when the dump is large.
+func truncateForMsg(s string) string {
+	if len(s) <= 512 {
+		return s
+	}
+	return s[:512] + "...(truncated)"
+}
+
+// TestCompatTransport_DumpsBinaryRequestBodyAsPlaceholder covers the upload
+// direction: a plugin or namespace-file upload must not spray bytes on stderr.
+func TestCompatTransport_DumpsBinaryRequestBodyAsPlaceholder(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var out bytes.Buffer
+	client, transport := newCompatHTTPClient()
+	transport.verbose = true
+	transport.logger = &out
+
+	payload := "PK\x03\x04a-jar-file"
+	req, _ := http.NewRequest(http.MethodPost, server.URL+"/api/v1/main/files", strings.NewReader(payload))
+	req.Header.Set("Content-Type", "application/octet-stream")
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	drainAndClose(resp)
+
+	dump := out.String()
+	want := fmt.Sprintf("> [body: application/octet-stream, %d bytes, not shown]", len(payload))
+	if !strings.Contains(dump, want) {
+		t.Errorf("dump missing %q:\n%s", want, dump)
+	}
+	if strings.Contains(dump, "a-jar-file") {
+		t.Errorf("request body leaked into dump:\n%s", dump)
+	}
+}
+
+func TestIsTextLikeContentType(t *testing.T) {
+	for _, ct := range []string{
+		"text/plain", "text/plain; charset=utf-8", "application/json",
+		"application/problem+json", "application/json; charset=utf-8",
+		"application/x-yaml", "application/yaml", "application/x-www-form-urlencoded",
+	} {
+		if !isTextLikeContentType(ct) {
+			t.Errorf("%q should be text-like", ct)
+		}
+	}
+	for _, ct := range []string{
+		"", "application/octet-stream", "application/zip", "application/java-archive",
+		"image/png", "not a media type",
+	} {
+		if isTextLikeContentType(ct) {
+			t.Errorf("%q should not be text-like", ct)
+		}
 	}
 }

--- a/src/cli/compat_triggers.go
+++ b/src/cli/compat_triggers.go
@@ -1,0 +1,412 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+)
+
+// Trigger responses across Kestra versions (issue #118).
+//
+// The two servers answer the trigger endpoints with different shapes, and the
+// SDK models both — in different clients:
+//
+//	                    Kestra 1.x                        Kestra 2.0
+//	/triggers/search    {abstractTrigger, triggerContext} {trigger, state}
+//	                    generated TriggersAPI             hand-written Triggers()
+//	single trigger      Trigger (date, nextExecutionDate) ApiTriggerState
+//	                                                      (updatedAt,
+//	                                                       nextEvaluationDate)
+//
+// The generated surface — which kestractl used for every trigger command — is
+// still on the 1.x models, so a 2.0 body decodes into empty fields (`triggers
+// list` rendered blank rows) or is rejected outright over a required field the
+// 2.0 server never sends ("no value given for required property date", on
+// search-for-flow, unlock and the single backfill ops).
+//
+// The fix is to read each shape with the client that models it, and to funnel
+// both into the era-agnostic values below so the commands themselves stay free
+// of version branching. An unknown era (a develop build, or an unreadable
+// /configs) takes the 2.0 path: that is the server this binary targets.
+//
+// Reshaping the 1.x body in compatTransport instead would put the mapping in
+// one place, but it cannot express this: `updatedAt` is required by the 2.0
+// decoder and a 1.x server omits it entirely from some responses (POST
+// .../restart returns a state with no date at all), so the transport would have
+// to invent a timestamp. Dispatching on the era keeps every field a server
+// actually sent.
+
+// triggerListRow is one `triggers list` row, read from whichever shape the
+// server sent.
+type triggerListRow struct {
+	Namespace         string
+	FlowID            string
+	TriggerID         string
+	Type              string
+	Disabled          bool
+	NextExecutionDate *time.Time
+}
+
+// triggerRef identifies a single trigger and its disabled flag: what the
+// per-flow search, unlock, and the single backfill ops render.
+type triggerRef struct {
+	Namespace string
+	FlowID    string
+	TriggerID string
+	Disabled  bool
+}
+
+// fetchTriggerRows lists triggers, reading the 2.0 {trigger, state} shape or the
+// 1.x {abstractTrigger, triggerContext} one, and returns the rows plus the total.
+func fetchTriggerRows(client *Client, page, size int32) ([]triggerListRow, int64, error) {
+	if client.isLegacyServer() {
+		body, err := legacyTriggerRequest(client, http.MethodGet,
+			legacyTriggerPath(client, "search"),
+			url.Values{"page": {strconv.Itoa(int(page))}, "size": {strconv.Itoa(int(size))}}, nil)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		results, total := jsonResults(body)
+		rows := make([]triggerListRow, 0, len(results))
+		for _, item := range results {
+			ctx := jsonObject(item, "triggerContext")
+			rows = append(rows, triggerListRow{
+				Namespace:         jsonString(ctx, "namespace"),
+				FlowID:            jsonString(ctx, "flowId"),
+				TriggerID:         jsonString(ctx, "triggerId"),
+				Type:              jsonString(jsonObject(item, "abstractTrigger"), "type"),
+				Disabled:          jsonBool(ctx, "disabled"),
+				NextExecutionDate: jsonTime(ctx, "nextExecutionDate"),
+			})
+		}
+		return rows, total, nil
+	}
+
+	p, s := int(page), int(size)
+	resp, err := client.Kestra.Triggers().SearchTriggers(client.Ctx, client.Tenant, &p, &s, nil, nil, nil)
+	if err != nil {
+		return nil, 0, formatSDKError(err)
+	}
+	if resp == nil {
+		return nil, 0, nil
+	}
+
+	rows := make([]triggerListRow, 0, len(resp.GetResults()))
+	for _, t := range resp.GetResults() {
+		state := t.GetState()
+		trigger := t.GetTrigger()
+		row := triggerListRow{
+			Namespace: state.GetNamespace(),
+			FlowID:    state.GetFlowId(),
+			TriggerID: state.GetTriggerId(),
+			Type:      trigger.GetType(),
+			Disabled:  state.GetDisabled(),
+		}
+		// 2.0 renamed nextExecutionDate to nextEvaluationDate.
+		if next, ok := state.GetNextEvaluationDateOk(); ok && next != nil && !next.IsZero() {
+			row.NextExecutionDate = next
+		}
+		rows = append(rows, row)
+	}
+	return rows, resp.GetTotal(), nil
+}
+
+// fetchFlowTriggerRefs lists the triggers of one flow, on either era.
+func fetchFlowTriggerRefs(client *Client, namespace, flowID string, page, size int32, query string) ([]triggerRef, int64, error) {
+	if client.isLegacyServer() {
+		params := url.Values{"page": {strconv.Itoa(int(page))}, "size": {strconv.Itoa(int(size))}}
+		if query != "" {
+			params.Set("q", query)
+		}
+		body, err := legacyTriggerRequest(client, http.MethodGet,
+			legacyTriggerPath(client, namespace, flowID), params, nil)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		results, total := jsonResults(body)
+		refs := make([]triggerRef, 0, len(results))
+		for _, item := range results {
+			refs = append(refs, jsonTriggerRef(item))
+		}
+		return refs, total, nil
+	}
+
+	p, s := int(page), int(size)
+	var q *string
+	if query != "" {
+		q = &query
+	}
+	resp, err := client.Kestra.Triggers().SearchTriggersForFlow(client.Ctx, client.Tenant, namespace, flowID, &p, &s, q, nil)
+	if err != nil {
+		return nil, 0, formatSDKError(err)
+	}
+	if resp == nil {
+		return nil, 0, nil
+	}
+
+	refs := make([]triggerRef, 0, len(resp.GetResults()))
+	for _, state := range resp.GetResults() {
+		refs = append(refs, triggerRef{
+			Namespace: state.GetNamespace(),
+			FlowID:    state.GetFlowId(),
+			TriggerID: state.GetTriggerId(),
+			Disabled:  state.GetDisabled(),
+		})
+	}
+	return refs, resp.GetTotal(), nil
+}
+
+// unlockTriggerRef unlocks a trigger and returns what the server reported back,
+// or nil when the response carried no body.
+func unlockTriggerRef(client *Client, namespace, flowID, triggerID string) (*triggerRef, error) {
+	if client.isLegacyServer() {
+		body, err := legacyTriggerRequest(client, http.MethodPost,
+			legacyTriggerPath(client, namespace, flowID, triggerID, "unlock"), nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		if body == nil {
+			return nil, nil
+		}
+		ref := jsonTriggerRef(body)
+		return &ref, nil
+	}
+
+	state, err := client.Kestra.Triggers().UnlockTrigger(client.Ctx, client.Tenant, namespace, flowID, triggerID)
+	if err != nil {
+		return nil, formatSDKError(err)
+	}
+	return triggerStateRef(state), nil
+}
+
+// backfillTriggerRef runs one of the single-trigger backfill operations —
+// "pause", "unpause" or "delete" — and returns what the server reported back.
+func backfillTriggerRef(client *Client, namespace, flowID, triggerID, op string) (*triggerRef, error) {
+	if client.isLegacyServer() {
+		// A 1.x server takes the whole Trigger as the request body, `date`
+		// included — that is what the generated client used to send.
+		payload := map[string]any{
+			"namespace": namespace,
+			"flowId":    flowID,
+			"triggerId": triggerID,
+			"date":      time.Now().UTC().Format(time.RFC3339),
+		}
+
+		method, action := http.MethodPut, op
+		if op != "pause" && op != "unpause" {
+			method, action = http.MethodPost, "delete"
+		}
+		body, err := legacyTriggerRequest(client, method,
+			legacyTriggerPath(client, "backfill", action), nil, payload)
+		if err != nil {
+			return nil, err
+		}
+		if body == nil {
+			return nil, nil
+		}
+		ref := jsonTriggerRef(body)
+		return &ref, nil
+	}
+
+	// 2.0 takes just the identifying triple.
+	id := kestra.NewTriggerControllerApiTriggerId()
+	id.SetNamespace(namespace)
+	id.SetFlowId(flowID)
+	id.SetTriggerId(triggerID)
+
+	var state *kestra.ApiTriggerState
+	var err error
+	switch op {
+	case "pause":
+		state, err = client.Kestra.Triggers().PauseBackfill(client.Ctx, client.Tenant, *id)
+	case "unpause":
+		state, err = client.Kestra.Triggers().UnpauseBackfill(client.Ctx, client.Tenant, *id)
+	default: // delete
+		state, err = client.Kestra.Triggers().DeleteBackfill(client.Ctx, client.Tenant, *id)
+	}
+	if err != nil {
+		return nil, formatSDKError(err)
+	}
+	return triggerStateRef(state), nil
+}
+
+// --- the Kestra 1.x path ---
+//
+// The generated models are not used on this side either, even though they are
+// the ones written for 1.x: they mark `date` required, and a 1.3 server omits it
+// from a trigger whose state was reset (POST .../restart, and any trigger that
+// has not been evaluated yet), which makes the decoder reject the whole body
+// with "no value given for required property date". These endpoints are read
+// from the raw response instead, taking only the fields the commands render, so
+// a missing optional field renders empty rather than failing the command.
+//
+// The request is built on the SDK's own configuration — host, default headers,
+// context auth, and the shared HTTP client — so it still goes through
+// compatTransport and the --verbose dump.
+
+// legacyTriggerPath assembles /api/v1/{tenant}/triggers/{segments...}.
+func legacyTriggerPath(client *Client, segments ...string) string {
+	path := "/api/v1/" + url.PathEscape(client.Tenant) + "/triggers"
+	for _, segment := range segments {
+		path += "/" + url.PathEscape(segment)
+	}
+	return path
+}
+
+// legacyTriggerRequest issues one request against a Kestra 1.x trigger endpoint
+// and returns its decoded JSON object, or nil when the response has no body.
+func legacyTriggerRequest(client *Client, method, path string, query url.Values, payload any) (map[string]any, error) {
+	cfg := client.API.GetConfig()
+
+	base := ""
+	if len(cfg.Servers) > 0 {
+		base = cfg.Servers[0].URL
+	}
+	if base == "" {
+		base = cfg.Scheme + "://" + cfg.Host
+	}
+	endpoint := strings.TrimRight(base, "/") + path
+	if len(query) > 0 {
+		endpoint += "?" + query.Encode()
+	}
+
+	var reader io.Reader
+	if payload != nil {
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequestWithContext(client.Ctx, method, endpoint, reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if payload != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	for header, value := range cfg.DefaultHeader {
+		req.Header.Set(header, value)
+	}
+	// Reuse the auth the SDK stored on the context.
+	if auth, ok := client.Ctx.Value(kestra.ContextBasicAuth).(kestra.BasicAuth); ok {
+		req.SetBasicAuth(auth.UserName, auth.Password)
+	}
+	if token, ok := client.Ctx.Value(kestra.ContextAccessToken).(string); ok {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// formatErrorBody renders the same message the SDK errors get.
+		return nil, formatErrorBody(raw, fmt.Sprintf("status %d", resp.StatusCode))
+	}
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, nil
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return nil, formatErrorBody(raw, "the trigger endpoint returned an unexpected body")
+	}
+	return decoded, nil
+}
+
+// jsonResults reads the {"results":[...],"total":N} envelope both servers use
+// for a paged response.
+func jsonResults(body map[string]any) ([]map[string]any, int64) {
+	raw, _ := body["results"].([]any)
+	results := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		if object, ok := item.(map[string]any); ok {
+			results = append(results, object)
+		}
+	}
+
+	var total int64
+	switch value := body["total"].(type) {
+	case float64:
+		total = int64(value)
+	case json.Number:
+		total, _ = value.Int64()
+	}
+	return results, total
+}
+
+func jsonObject(body map[string]any, key string) map[string]any {
+	object, _ := body[key].(map[string]any)
+	return object
+}
+
+func jsonString(body map[string]any, key string) string {
+	value, _ := body[key].(string)
+	return value
+}
+
+func jsonBool(body map[string]any, key string) bool {
+	value, _ := body[key].(bool)
+	return value
+}
+
+// jsonTime reads an RFC 3339 timestamp, and returns nil when the field is
+// absent, empty, unparseable or the zero instant.
+func jsonTime(body map[string]any, key string) *time.Time {
+	value, _ := body[key].(string)
+	if value == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil || parsed.IsZero() {
+		return nil
+	}
+	return &parsed
+}
+
+// jsonTriggerRef reads the identifying triple out of either server's
+// single-trigger body: 1.x Trigger and 2.0 ApiTriggerState agree on these
+// field names.
+func jsonTriggerRef(body map[string]any) triggerRef {
+	return triggerRef{
+		Namespace: jsonString(body, "namespace"),
+		FlowID:    jsonString(body, "flowId"),
+		TriggerID: jsonString(body, "triggerId"),
+		Disabled:  jsonBool(body, "disabled"),
+	}
+}
+
+func triggerStateRef(state *kestra.ApiTriggerState) *triggerRef {
+	if state == nil {
+		return nil
+	}
+	return &triggerRef{
+		Namespace: state.GetNamespace(),
+		FlowID:    state.GetFlowId(),
+		TriggerID: state.GetTriggerId(),
+		Disabled:  state.GetDisabled(),
+	}
+}

--- a/src/cli/compat_triggers_test.go
+++ b/src/cli/compat_triggers_test.go
@@ -1,0 +1,279 @@
+package cli
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The two shapes GET /triggers/search answers with, captured verbatim from a
+// live Kestra 2.0.0-rc13 and a live Kestra 1.3.35 (issue #118).
+const (
+	trigger20SearchBody = `{"results":[{"trigger":{"id":"every_min","type":"io.kestra.plugin.core.trigger.Schedule","cron":"*/5 * * * *"},` +
+		`"state":{"namespace":"bug118","flowId":"sched118","triggerId":"every_min","updatedAt":"2026-09-04T10:39:14Z",` +
+		`"nextEvaluationDate":"2026-09-04T10:40:00Z","disabled":false,"locked":false,"kind":"SCHEDULE"}}],"total":1}`
+
+	trigger13SearchBody = `{"results":[{"abstractTrigger":{"id":"every_min","type":"io.kestra.plugin.core.trigger.Schedule","cron":"*/5 * * * *"},` +
+		`"triggerContext":{"tenantId":"main","namespace":"bug118","flowId":"sched118","triggerId":"every_min",` +
+		`"date":"2026-09-04T10:39:15Z","nextExecutionDate":"2026-09-04T10:40:00Z","disabled":false}}],"total":1}`
+
+	// A single trigger, as unlock, the backfill ops and the per-flow search
+	// return it: ApiTriggerState on 2.0, Trigger on 1.x.
+	trigger20StateBody = `{"namespace":"bug118","flowId":"sched118","triggerId":"every_min",` +
+		`"updatedAt":"2026-09-04T10:39:14Z","nextEvaluationDate":"2026-09-04T10:40:00Z","disabled":false,"locked":false}`
+
+	trigger13StateBody = `{"tenantId":"main","namespace":"bug118","flowId":"sched118","triggerId":"every_min",` +
+		`"date":"2026-09-04T10:39:15Z","nextExecutionDate":"2026-09-04T10:40:00Z","disabled":false}`
+)
+
+// triggerVersionHandler serves a fixed Kestra version on /api/v1/configs — the
+// endpoint the era probe reads — and the given body for everything else. An
+// empty version makes /configs unreadable, which is the unknown era.
+func triggerVersionHandler(version, body string, seen *[]string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v1/configs" {
+			if version == "" {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"` + version + `"}`))
+			return
+		}
+		if seen != nil {
+			*seen = append(*seen, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}
+}
+
+func triggerTestServer(t *testing.T, version, body string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(triggerVersionHandler(version, body, nil))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// fetchTriggerRows must read both response shapes into the same row, so
+// `triggers list` renders the same thing on both servers (issue #118: the 2.0
+// body used to decode into empty fields).
+func TestFetchTriggerRows_BothEras(t *testing.T) {
+	for _, tt := range []struct {
+		name, version, body string
+	}{
+		{"kestra 2.0 trigger/state", "2.0.0-rc13", trigger20SearchBody},
+		{"kestra 1.3 abstractTrigger/triggerContext", "1.3.35", trigger13SearchBody},
+		{"unknown version takes the 2.0 shape", "", trigger20SearchBody},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := triggerTestServer(t, tt.version, tt.body)
+
+			rows, total, err := fetchTriggerRows(newTestClient(t, server.URL), 1, 50)
+			if err != nil {
+				t.Fatalf("fetchTriggerRows: %v", err)
+			}
+			if total != 1 || len(rows) != 1 {
+				t.Fatalf("expected 1 row and total 1, got %d rows, total %d", len(rows), total)
+			}
+
+			got := rows[0]
+			if got.Namespace != "bug118" || got.FlowID != "sched118" || got.TriggerID != "every_min" {
+				t.Errorf("unexpected identity: %+v", got)
+			}
+			if got.Type != "io.kestra.plugin.core.trigger.Schedule" {
+				t.Errorf("expected the trigger type, got %q", got.Type)
+			}
+			if got.Disabled {
+				t.Error("expected the trigger to be enabled")
+			}
+			if got.NextExecutionDate == nil || got.NextExecutionDate.UTC().Format("2006-01-02T15:04:05Z") != "2026-09-04T10:40:00Z" {
+				t.Errorf("expected the next evaluation date, got %v", got.NextExecutionDate)
+			}
+		})
+	}
+}
+
+// Both eras use the same path — only the response model differs — so a wrong
+// dispatch shows up as a decode error rather than a 404. This pins the path all
+// the same.
+func TestFetchTriggerRows_UsesSearchPath(t *testing.T) {
+	var seen []string
+	server := httptest.NewServer(triggerVersionHandler("2.0.0-rc13", trigger20SearchBody, &seen))
+	t.Cleanup(server.Close)
+
+	if _, _, err := fetchTriggerRows(newTestClient(t, server.URL), 1, 50); err != nil {
+		t.Fatalf("fetchTriggerRows: %v", err)
+	}
+	if len(seen) != 1 || seen[0] != "/api/v1/main/triggers/search" {
+		t.Fatalf("expected one call to /api/v1/main/triggers/search, got %v", seen)
+	}
+}
+
+func TestFetchFlowTriggerRefs_BothEras(t *testing.T) {
+	for _, tt := range []struct {
+		version, body string
+	}{
+		{"2.0.0-rc13", `{"results":[` + trigger20StateBody + `],"total":1}`},
+		{"1.3.35", `{"results":[` + trigger13StateBody + `],"total":1}`},
+	} {
+		t.Run(tt.version, func(t *testing.T) {
+			server := triggerTestServer(t, tt.version, tt.body)
+
+			refs, total, err := fetchFlowTriggerRefs(newTestClient(t, server.URL), "bug118", "sched118", 1, 50, "")
+			if err != nil {
+				t.Fatalf("fetchFlowTriggerRefs: %v", err)
+			}
+			if total != 1 || len(refs) != 1 {
+				t.Fatalf("expected 1 ref and total 1, got %d refs, total %d", len(refs), total)
+			}
+			if refs[0] != (triggerRef{Namespace: "bug118", FlowID: "sched118", TriggerID: "every_min"}) {
+				t.Fatalf("unexpected ref: %+v", refs[0])
+			}
+		})
+	}
+}
+
+func TestUnlockTriggerRef_BothEras(t *testing.T) {
+	for _, tt := range []struct {
+		version, body string
+	}{
+		{"2.0.0-rc13", trigger20StateBody},
+		{"1.3.35", trigger13StateBody},
+	} {
+		t.Run(tt.version, func(t *testing.T) {
+			server := triggerTestServer(t, tt.version, tt.body)
+
+			ref, err := unlockTriggerRef(newTestClient(t, server.URL), "bug118", "sched118", "every_min")
+			if err != nil {
+				t.Fatalf("unlockTriggerRef: %v", err)
+			}
+			if ref == nil || *ref != (triggerRef{Namespace: "bug118", FlowID: "sched118", TriggerID: "every_min"}) {
+				t.Fatalf("unexpected ref: %+v", ref)
+			}
+		})
+	}
+}
+
+func TestBackfillTriggerRef_BothEras(t *testing.T) {
+	for _, op := range []string{"pause", "unpause", "delete"} {
+		for _, tt := range []struct {
+			version, body string
+		}{
+			{"2.0.0-rc13", trigger20StateBody},
+			{"1.3.35", trigger13StateBody},
+		} {
+			t.Run(op+"/"+tt.version, func(t *testing.T) {
+				server := triggerTestServer(t, tt.version, tt.body)
+
+				ref, err := backfillTriggerRef(newTestClient(t, server.URL), "bug118", "sched118", "every_min", op)
+				if err != nil {
+					t.Fatalf("backfillTriggerRef(%s): %v", op, err)
+				}
+				if ref == nil || ref.TriggerID != "every_min" {
+					t.Fatalf("unexpected ref: %+v", ref)
+				}
+			})
+		}
+	}
+}
+
+// A 1.3 server legitimately omits `date` from a trigger context whose state was
+// reset or never evaluated. The generated 1.x models mark it required, so
+// reading these endpoints through them failed the whole command with "no value
+// given for required property date" — hence the raw decode on the legacy path.
+const (
+	trigger13DatelessSearchBody = `{"results":[{"abstractTrigger":{"id":"every_min","type":"io.kestra.plugin.core.trigger.Schedule","cron":"*/5 * * * *"},` +
+		`"triggerContext":{"tenantId":"main","namespace":"bug118","flowId":"sched118","triggerId":"every_min",` +
+		`"nextExecutionDate":"2026-09-04T10:40:00Z","disabled":false}}],"total":1}`
+
+	trigger13DatelessStateBody = `{"tenantId":"main","namespace":"bug118","flowId":"sched118","triggerId":"every_min",` +
+		`"nextExecutionDate":"2026-09-04T10:45:00Z","disabled":false}`
+)
+
+func TestFetchTriggerRows_DatelessLegacyBody(t *testing.T) {
+	server := triggerTestServer(t, "1.3.35", trigger13DatelessSearchBody)
+
+	rows, total, err := fetchTriggerRows(newTestClient(t, server.URL), 1, 50)
+	if err != nil {
+		t.Fatalf("fetchTriggerRows: %v", err)
+	}
+	if total != 1 || len(rows) != 1 {
+		t.Fatalf("expected 1 row and total 1, got %d rows, total %d", len(rows), total)
+	}
+	got := rows[0]
+	if got.Namespace != "bug118" || got.FlowID != "sched118" || got.TriggerID != "every_min" {
+		t.Errorf("unexpected identity: %+v", got)
+	}
+	if got.Type != "io.kestra.plugin.core.trigger.Schedule" {
+		t.Errorf("expected the trigger type, got %q", got.Type)
+	}
+	if got.NextExecutionDate == nil {
+		t.Error("expected the next execution date to survive")
+	}
+}
+
+func TestFetchFlowTriggerRefs_DatelessLegacyBody(t *testing.T) {
+	server := triggerTestServer(t, "1.3.35", `{"results":[`+trigger13DatelessStateBody+`],"total":1}`)
+
+	refs, total, err := fetchFlowTriggerRefs(newTestClient(t, server.URL), "bug118", "sched118", 1, 50, "")
+	if err != nil {
+		t.Fatalf("fetchFlowTriggerRefs: %v", err)
+	}
+	if total != 1 || len(refs) != 1 {
+		t.Fatalf("expected 1 ref and total 1, got %d refs, total %d", len(refs), total)
+	}
+	if refs[0] != (triggerRef{Namespace: "bug118", FlowID: "sched118", TriggerID: "every_min"}) {
+		t.Fatalf("unexpected ref: %+v", refs[0])
+	}
+}
+
+func TestUnlockAndBackfill_DatelessLegacyBody(t *testing.T) {
+	want := triggerRef{Namespace: "bug118", FlowID: "sched118", TriggerID: "every_min"}
+
+	t.Run("unlock", func(t *testing.T) {
+		server := triggerTestServer(t, "1.3.35", trigger13DatelessStateBody)
+		ref, err := unlockTriggerRef(newTestClient(t, server.URL), "bug118", "sched118", "every_min")
+		if err != nil {
+			t.Fatalf("unlockTriggerRef: %v", err)
+		}
+		if ref == nil || *ref != want {
+			t.Fatalf("unexpected ref: %+v", ref)
+		}
+	})
+
+	for _, op := range []string{"pause", "unpause", "delete"} {
+		t.Run("backfill-"+op, func(t *testing.T) {
+			server := triggerTestServer(t, "1.3.35", trigger13DatelessStateBody)
+			ref, err := backfillTriggerRef(newTestClient(t, server.URL), "bug118", "sched118", "every_min", op)
+			if err != nil {
+				t.Fatalf("backfillTriggerRef(%s): %v", op, err)
+			}
+			if ref == nil || *ref != want {
+				t.Fatalf("unexpected ref: %+v", ref)
+			}
+		})
+	}
+}
+
+// The legacy path must still surface a server error rather than an empty row.
+func TestLegacyTriggerRequest_SurfacesServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/api/v1/configs" {
+			_, _ = w.Write([]byte(`{"version":"1.3.35"}`))
+			return
+		}
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"message":"Illegal state: Trigger is not locked"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := unlockTriggerRef(newTestClient(t, server.URL), "bug118", "sched118", "every_min")
+	if err == nil {
+		t.Fatal("expected the server error to be surfaced")
+	}
+	if err.Error() != "API error: Illegal state: Trigger is not locked" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/src/cli/kv.go
+++ b/src/cli/kv.go
@@ -1,8 +1,12 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -282,16 +286,9 @@ func newKVGetCommand() *cobra.Command {
 }
 
 func runKVGet(client *Client, namespace, key string, renderer *Renderer) error {
-	resp, _, err := client.API.KVAPI.KeyValue(client.Ctx, namespace, key, client.Tenant).Execute()
-
-	var typedValue *kvTypedValue
+	typedValue, err := fetchKVTypedValue(client, namespace, key)
 	if err != nil {
-		typedValue = tryParseKVTypedValueFromError(err)
-		if typedValue == nil {
-			return formatSDKError(err)
-		}
-	} else {
-		typedValue = extractKVTypedValue(resp)
+		return err
 	}
 
 	if typedValue == nil {
@@ -385,10 +382,10 @@ func formatKVRequestBody(kvType kestra.KVType, rawValue string) (string, error) 
 		return string(encoded), nil
 	case kestra.KVTYPE_NUMBER:
 		var parsed any
-		if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		if err := decodeJSONPreservingNumbers([]byte(trimmed), &parsed); err != nil {
 			return "", fmt.Errorf("invalid NUMBER value %q: %w", rawValue, err)
 		}
-		if _, ok := parsed.(float64); !ok {
+		if _, ok := parsed.(json.Number); !ok {
 			return "", fmt.Errorf("invalid NUMBER value %q", rawValue)
 		}
 		return trimmed, nil
@@ -399,15 +396,18 @@ func formatKVRequestBody(kvType kestra.KVType, rawValue string) (string, error) 
 		}
 		return lower, nil
 	case kestra.KVTYPE_JSON:
+		// Validate without re-encoding: a decode into any followed by
+		// json.Marshal turns every integer above 2^53 into a lossy float64 and
+		// would store corrupted digits server-side (#121).
 		var parsed any
-		if err := json.Unmarshal([]byte(trimmed), &parsed); err != nil {
+		if err := decodeJSONPreservingNumbers([]byte(trimmed), &parsed); err != nil {
 			return "", fmt.Errorf("invalid JSON value %q: %w", rawValue, err)
 		}
-		encoded, err := json.Marshal(parsed)
-		if err != nil {
-			return "", err
+		var compacted bytes.Buffer
+		if err := json.Compact(&compacted, []byte(trimmed)); err != nil {
+			return "", fmt.Errorf("invalid JSON value %q: %w", rawValue, err)
 		}
-		return string(encoded), nil
+		return compacted.String(), nil
 	case kestra.KVTYPE_DATE:
 		if _, err := time.Parse("2006-01-02", trimmed); err != nil {
 			return "", fmt.Errorf("invalid DATE value %q, expected format YYYY-MM-DD", rawValue)
@@ -434,13 +434,32 @@ func parseKVDisplayValue(kvType kestra.KVType, rawValue string) any {
 	switch kvType {
 	case kestra.KVTYPE_NUMBER, kestra.KVTYPE_BOOLEAN, kestra.KVTYPE_JSON:
 		var parsed any
-		if err := json.Unmarshal([]byte(trimmed), &parsed); err == nil {
+		if err := decodeJSONPreservingNumbers([]byte(trimmed), &parsed); err == nil {
 			return parsed
 		}
 		return rawValue
 	default:
 		return rawValue
 	}
+}
+
+// decodeJSONPreservingNumbers decodes JSON into out with json.Decoder.UseNumber,
+// so numbers land as json.Number (their original digits) instead of float64.
+// Anything above 2^53 — a large ID, epoch nanos — otherwise loses precision the
+// moment it is decoded, and re-renders wrong (#121). json.Number re-encodes as a
+// bare JSON number, so both the table and the --output json paths stay exact.
+// Trailing content after the first value is rejected, which plain
+// json.Unmarshal does for free.
+func decodeJSONPreservingNumbers(data []byte, out any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(out); err != nil {
+		return err
+	}
+	if decoder.More() {
+		return fmt.Errorf("unexpected trailing data after JSON value")
+	}
+	return nil
 }
 
 func isLikelyISO8601Duration(value string) bool {
@@ -458,39 +477,96 @@ func isLikelyISO8601Duration(value string) bool {
 	return true
 }
 
-func extractKVTypedValue(resp *kestra.KVControllerKvDetail) *kvTypedValue {
-	if resp == nil {
+// fetchKVTypedValue reads a KV entry with a direct HTTP request instead of the
+// SDK. The SDK types KVControllerKvDetail.Value as map[string]interface{} and
+// decodes with plain json.Unmarshal, so a JSON value's integers are already
+// float64 (and above 2^53 already wrong) by the time kestractl sees them, and a
+// scalar value does not fit the map at all. Reading the body here lets it be
+// decoded with UseNumber, keeping every digit (#121). The URL mirrors the SDK's
+// KeyValue endpoint, and the request reuses the SDK's configured host, HTTP
+// client, default headers and context-based auth.
+func fetchKVTypedValue(client *Client, namespace, key string) (*kvTypedValue, error) {
+	cfg := client.API.GetConfig()
+
+	base := ""
+	if len(cfg.Servers) > 0 {
+		base = cfg.Servers[0].URL
+	}
+	if base == "" {
+		base = cfg.Scheme + "://" + cfg.Host
+	}
+	base = strings.TrimRight(base, "/")
+
+	endpoint := fmt.Sprintf("%s/api/v1/%s/namespaces/%s/kv/%s",
+		base,
+		url.PathEscape(client.Tenant),
+		url.PathEscape(namespace),
+		url.PathEscape(key),
+	)
+
+	req, err := http.NewRequestWithContext(client.Ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	if auth, ok := client.Ctx.Value(kestra.ContextBasicAuth).(kestra.BasicAuth); ok {
+		req.SetBasicAuth(auth.UserName, auth.Password)
+	}
+	if token, ok := client.Ctx.Value(kestra.ContextAccessToken).(string); ok {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	for h, v := range cfg.DefaultHeader {
+		req.Header.Set(h, v)
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key-value response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, formatErrorBody(body, resp.Status)
+	}
+
+	return parseKVTypedValueBody(body), nil
+}
+
+// parseKVTypedValueBody reads a KV detail payload, preserving number literals.
+func parseKVTypedValueBody(body []byte) *kvTypedValue {
+	if len(body) == 0 {
+		return nil
+	}
+
+	var rawResp map[string]any
+	if decodeJSONPreservingNumbers(body, &rawResp) != nil {
+		return nil
+	}
+
+	// A problem document also carries a "type"; reading that as a value type
+	// would turn an error response into a rendered record.
+	if isProblemDocument(rawResp) {
 		return nil
 	}
 
 	result := &kvTypedValue{}
-	if typ, ok := resp.GetTypeOk(); ok && typ != nil {
-		result.Type = string(*typ)
+	if typ, ok := rawResp["type"].(string); ok {
+		result.Type = typ
 	}
-
-	if resp.Value != nil {
-		if value, ok := resp.Value["value"]; ok {
-			result.Value = value
-		} else if value, ok := resp.Value["Value"]; ok {
-			result.Value = value
-		} else {
-			result.Value = resp.Value
-		}
-	}
-
-	if resp.AdditionalProperties != nil {
-		if result.Type == "" {
-			if typ, ok := resp.AdditionalProperties["type"].(string); ok {
-				result.Type = typ
-			}
-		}
-		if result.Value == nil {
-			if value, ok := resp.AdditionalProperties["value"]; ok {
-				result.Value = value
-			} else if value, ok := resp.AdditionalProperties["Value"]; ok {
-				result.Value = value
-			}
-		}
+	if value, ok := rawResp["value"]; ok {
+		result.Value = value
+	} else if value, ok := rawResp["Value"]; ok {
+		result.Value = value
 	}
 
 	if result.Type == "" && result.Value == nil {
@@ -512,7 +588,7 @@ func tryParseKVTypedValueFromError(err error) *kvTypedValue {
 	}
 
 	var rawResp map[string]any
-	if json.Unmarshal(body, &rawResp) != nil {
+	if decodeJSONPreservingNumbers(body, &rawResp) != nil {
 		return nil
 	}
 

--- a/src/cli/kv_test.go
+++ b/src/cli/kv_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -166,12 +167,8 @@ func TestFormatKVRequestBody(t *testing.T) {
 	}
 }
 
-func TestExtractKVTypedValue(t *testing.T) {
-	resp := kestra.NewKVControllerKvDetail()
-	resp.SetType(kestra.KVTYPE_STRING)
-	resp.SetValue(map[string]any{"value": "hello"})
-
-	typed := extractKVTypedValue(resp)
+func TestParseKVTypedValueBody(t *testing.T) {
+	typed := parseKVTypedValueBody([]byte(`{"type":"STRING","value":"hello","revision":1}`))
 	if typed == nil {
 		t.Fatal("expected typed value, got nil")
 	}
@@ -183,12 +180,8 @@ func TestExtractKVTypedValue(t *testing.T) {
 	}
 }
 
-func TestExtractKVTypedValue_JSONObject(t *testing.T) {
-	resp := kestra.NewKVControllerKvDetail()
-	resp.SetType(kestra.KVTYPE_JSON)
-	resp.SetValue(map[string]any{"feature": true, "count": 2})
-
-	typed := extractKVTypedValue(resp)
+func TestParseKVTypedValueBody_JSONObject(t *testing.T) {
+	typed := parseKVTypedValueBody([]byte(`{"type":"JSON","value":{"feature":true,"count":2}}`))
 	if typed == nil {
 		t.Fatal("expected typed value, got nil")
 	}
@@ -203,8 +196,18 @@ func TestExtractKVTypedValue_JSONObject(t *testing.T) {
 	if valueMap["feature"] != true {
 		t.Fatalf("expected feature=true, got %v", valueMap["feature"])
 	}
-	if valueMap["count"] != 2 {
-		t.Fatalf("expected count=2, got %v", valueMap["count"])
+	if got := toPrettyString(valueMap["count"]); got != "2" {
+		t.Fatalf("expected count=2, got %s", got)
+	}
+}
+
+func TestParseKVTypedValueBody_RejectsProblemDocumentAndEmptyBody(t *testing.T) {
+	if got := parseKVTypedValueBody(nil); got != nil {
+		t.Fatalf("expected nil for an empty body, got %#v", got)
+	}
+	problem := []byte(`{"type":"https://kestra.io/docs/api-reference/problems/not-found","title":"Resource not found","status":404,"detail":"No value found"}`)
+	if got := parseKVTypedValueBody(problem); got != nil {
+		t.Fatalf("expected a problem document to be rejected, got %#v", got)
 	}
 }
 
@@ -230,8 +233,8 @@ func TestTryParseKVTypedValueFromError(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected map value, got %T", typed.Value)
 	}
-	if valueMap["a"] != 1.0 {
-		t.Fatalf("expected parsed value 1.0, got %v", valueMap["a"])
+	if got := toPrettyString(valueMap["a"]); got != "1" {
+		t.Fatalf("expected parsed value 1, got %s", got)
 	}
 }
 
@@ -378,5 +381,248 @@ func TestTryParseKVTypedValueFromError_StillRecoversRealValue(t *testing.T) {
 	got := tryParseKVTypedValueFromError(err)
 	if got == nil || got.Type != "STRING" || got.Value != "hello" {
 		t.Fatalf("expected the KV payload to still be recovered, got %#v", got)
+	}
+}
+
+// --- #121: integer precision above 2^53 ---------------------------------
+
+const (
+	bigNumber   = "9007199254740993"
+	bigNanosObj = `{"nanos":1725450000123456789}`
+)
+
+// TestFormatKVRequestBody_PreservesLargeIntegers pins the write path: the body
+// PUT to Kestra must carry the digits the user typed, not a float64 round-trip.
+func TestFormatKVRequestBody_PreservesLargeIntegers(t *testing.T) {
+	tests := []struct {
+		name     string
+		kvType   kestra.KVType
+		rawValue string
+		wantBody string
+	}{
+		{name: "number above 2^53", kvType: kestra.KVTYPE_NUMBER, rawValue: bigNumber, wantBody: bigNumber},
+		{name: "number with surrounding space", kvType: kestra.KVTYPE_NUMBER, rawValue: " " + bigNumber + " ", wantBody: bigNumber},
+		{name: "json with epoch nanos", kvType: kestra.KVTYPE_JSON, rawValue: bigNanosObj, wantBody: bigNanosObj},
+		{name: "json array of big ints", kvType: kestra.KVTYPE_JSON, rawValue: `[9007199254740993,9007199254740995]`, wantBody: `[9007199254740993,9007199254740995]`},
+		{name: "json nested big int", kvType: kestra.KVTYPE_JSON, rawValue: `{"a":{"b":[1725450000123456789]}}`, wantBody: `{"a":{"b":[1725450000123456789]}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, err := formatKVRequestBody(tt.kvType, tt.rawValue)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if body != tt.wantBody {
+				t.Fatalf("expected body %q, got %q", tt.wantBody, body)
+			}
+		})
+	}
+}
+
+// TestFormatKVRequestBody_JSONIsCompacted keeps the pre-#121 behaviour of
+// normalising whitespace, which the old Unmarshal/Marshal round-trip provided.
+func TestFormatKVRequestBody_JSONIsCompacted(t *testing.T) {
+	body, err := formatKVRequestBody(kestra.KVTYPE_JSON, "{ \"a\" : 1,\n\"b\": [ 2, 3 ] }")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if body != `{"a":1,"b":[2,3]}` {
+		t.Fatalf("expected compacted JSON, got %q", body)
+	}
+}
+
+func TestFormatKVRequestBody_RejectsNonNumericNumbers(t *testing.T) {
+	for _, raw := range []string{"abc", "true", `"5"`, "null", "[1]", "{}", "1 2", ""} {
+		if body, err := formatKVRequestBody(kestra.KVTYPE_NUMBER, raw); err == nil {
+			t.Fatalf("expected NUMBER %q to be rejected, got body %q", raw, body)
+		}
+	}
+}
+
+func TestFormatKVRequestBody_RejectsTrailingJSONGarbage(t *testing.T) {
+	if body, err := formatKVRequestBody(kestra.KVTYPE_JSON, `{"a":1} {"b":2}`); err == nil {
+		t.Fatalf("expected trailing garbage to be rejected, got body %q", body)
+	}
+}
+
+// TestParseKVDisplayValue_PreservesLargeIntegers covers the echo printed by
+// kv set / kv update, asserting on rendered digits rather than on Go types.
+func TestParseKVDisplayValue_PreservesLargeIntegers(t *testing.T) {
+	tests := []struct {
+		name     string
+		kvType   kestra.KVType
+		rawValue string
+		want     string
+	}{
+		{name: "number", kvType: kestra.KVTYPE_NUMBER, rawValue: bigNumber, want: bigNumber},
+		{name: "small number", kvType: kestra.KVTYPE_NUMBER, rawValue: "42", want: "42"},
+		{name: "float number", kvType: kestra.KVTYPE_NUMBER, rawValue: "1.5", want: "1.5"},
+		{name: "boolean", kvType: kestra.KVTYPE_BOOLEAN, rawValue: "true", want: "true"},
+		{name: "string", kvType: kestra.KVTYPE_STRING, rawValue: "hello", want: "hello"},
+		{name: "date", kvType: kestra.KVTYPE_DATE, rawValue: "2025-10-13", want: "2025-10-13"},
+		{name: "datetime", kvType: kestra.KVTYPE_DATETIME, rawValue: "2025-10-14T18:02:08Z", want: "2025-10-14T18:02:08Z"},
+		{name: "duration", kvType: kestra.KVTYPE_DURATION, rawValue: "PT15M", want: "PT15M"},
+		{name: "json nanos", kvType: kestra.KVTYPE_JSON, rawValue: bigNanosObj, want: "1725450000123456789"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toPrettyString(parseKVDisplayValue(tt.kvType, tt.rawValue))
+			if !strings.Contains(got, tt.want) {
+				t.Fatalf("expected rendered value to contain %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestTryParseKVTypedValueFromError_PreservesLargeIntegers(t *testing.T) {
+	err := &kestra.GenericOpenAPIError{}
+	setGenericOpenAPIErrorBody(err, []byte(`{"type":"NUMBER","value":`+bigNumber+`,"revision":1}`))
+
+	got := tryParseKVTypedValueFromError(err)
+	if got == nil {
+		t.Fatal("expected the KV payload to be recovered")
+	}
+	if rendered := toPrettyString(got.Value); rendered != bigNumber {
+		t.Fatalf("expected %s, got %s", bigNumber, rendered)
+	}
+}
+
+// kvGetServer answers the KV detail endpoint with a canned raw body.
+func kvGetServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/namespaces/ns/kv/k") {
+			http.Error(w, "unexpected path "+r.URL.Path, http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestKVGet_PreservesLargeIntegers(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "number", body: `{"type":"NUMBER","value":` + bigNumber + `,"revision":1}`, want: bigNumber},
+		{name: "json object", body: `{"type":"JSON","value":` + bigNanosObj + `,"revision":1}`, want: "1725450000123456789"},
+		{name: "json array", body: `{"type":"JSON","value":[9007199254740993],"revision":1}`, want: "9007199254740993"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := kvGetServer(t, tt.body)
+
+			var table bytes.Buffer
+			if err := runKVGet(newTestClient(t, server.URL), "ns", "k", newTableRenderer(&table)); err != nil {
+				t.Fatalf("runKVGet error: %v", err)
+			}
+			if !strings.Contains(table.String(), tt.want) {
+				t.Fatalf("table output lost precision, want %s in:\n%s", tt.want, table.String())
+			}
+
+			var asJSON bytes.Buffer
+			if err := runKVGet(newTestClient(t, server.URL), "ns", "k", newJSONRenderer(&asJSON)); err != nil {
+				t.Fatalf("runKVGet error: %v", err)
+			}
+			if !strings.Contains(asJSON.String(), tt.want) {
+				t.Fatalf("json output lost precision, want %s in:\n%s", tt.want, asJSON.String())
+			}
+			// The value must stay a bare JSON number, never a quoted string.
+			if strings.Contains(asJSON.String(), `"`+tt.want+`"`) {
+				t.Fatalf("expected a bare JSON number, got:\n%s", asJSON.String())
+			}
+		})
+	}
+}
+
+// TestKVGet_OtherTypes keeps the non-numeric types rendering as before.
+func TestKVGet_OtherTypes(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "string", body: `{"type":"STRING","value":"hello"}`, want: "Value: hello"},
+		{name: "boolean", body: `{"type":"BOOLEAN","value":true}`, want: "Value: true"},
+		{name: "datetime", body: `{"type":"DATETIME","value":"2025-10-14T18:02:08Z"}`, want: "Value: 2025-10-14T18:02:08Z"},
+		{name: "duration", body: `{"type":"DURATION","value":"PT15M"}`, want: "Value: PT15M"},
+		{name: "nested json", body: `{"type":"JSON","value":{"a":{"b":true}}}`, want: `"b": true`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := kvGetServer(t, tt.body)
+			var buf bytes.Buffer
+			if err := runKVGet(newTestClient(t, server.URL), "ns", "k", newTableRenderer(&buf)); err != nil {
+				t.Fatalf("runKVGet error: %v", err)
+			}
+			if !strings.Contains(buf.String(), tt.want) {
+				t.Fatalf("expected %q in:\n%s", tt.want, buf.String())
+			}
+		})
+	}
+}
+
+func TestKVGet_NotFoundStillErrors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"type":"https://kestra.io/docs/api-reference/problems/not-found","title":"Resource not found","status":404,"detail":"No value found for key 'k' in namespace 'ns'"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runKVGet(newTestClient(t, server.URL), "ns", "k", newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected a not-found error")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("expected a not-found message, got: %v", err)
+	}
+}
+
+// TestKVWrite_SendsExactDigits is the data-loss half of #121: the value stored
+// server-side must be the digits the user typed.
+func TestKVWrite_SendsExactDigits(t *testing.T) {
+	tests := []struct {
+		name     string
+		kvType   string
+		rawValue string
+		wantBody string
+	}{
+		{name: "number", kvType: "NUMBER", rawValue: bigNumber, wantBody: bigNumber},
+		{name: "json", kvType: "JSON", rawValue: bigNanosObj, wantBody: bigNanosObj},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotBody string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				raw, _ := io.ReadAll(r.Body)
+				gotBody = string(raw)
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			t.Cleanup(server.Close)
+
+			var buf bytes.Buffer
+			if err := runKVWrite(newTestClient(t, server.URL), "ns", "k", tt.rawValue, tt.kvType, "", false, newTableRenderer(&buf)); err != nil {
+				t.Fatalf("runKVWrite error: %v", err)
+			}
+			if gotBody != tt.wantBody {
+				t.Fatalf("expected request body %q, got %q", tt.wantBody, gotBody)
+			}
+			for _, digits := range strings.FieldsFunc(tt.wantBody, func(r rune) bool { return r < '0' || r > '9' }) {
+				if !strings.Contains(buf.String(), digits) {
+					t.Fatalf("expected the echo to show exact digits %s, got:\n%s", digits, buf.String())
+				}
+			}
+		})
 	}
 }

--- a/src/cli/logs.go
+++ b/src/cli/logs.go
@@ -306,7 +306,7 @@ func runLogsSearch(client *Client, filters []kestra.SearchFilter, page, size int
 	for i, entry := range logs {
 		result[i] = map[string]any{
 			"timestamp": entry.GetTimestamp().Format(time.RFC3339),
-			"level":     stringify(entry.GetLevel()),
+			"level":     string(entry.GetLevel()),
 			"namespace": entry.GetNamespace(),
 			"flowId":    entry.GetFlowId(),
 			"taskId":    entry.GetTaskId(),
@@ -424,7 +424,7 @@ func runLogsList(client *Client, executionID string, opts logFilter, renderer *R
 	for i, entry := range logs {
 		result[i] = map[string]any{
 			"timestamp": entry.GetTimestamp().Format(time.RFC3339),
-			"level":     stringify(entry.GetLevel()),
+			"level":     string(entry.GetLevel()),
 			"taskId":    entry.GetTaskId(),
 			"message":   entry.GetMessage(),
 		}

--- a/src/cli/logs_test.go
+++ b/src/cli/logs_test.go
@@ -1,7 +1,11 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -197,6 +201,48 @@ func TestLogFilterOptions(t *testing.T) {
 		f := logFilterOptions("", "", "", false, 0)
 		if f.attempt != nil {
 			t.Errorf("expected attempt nil when not changed, got %v", *f.attempt)
+		}
+	})
+}
+
+// Regression test for #122: the LEVEL column and the JSON "level" field must
+// not carry the JSON quotes of the SDK's Level enum.
+func TestRunLogsList_LevelHasNoQuotes(t *testing.T) {
+	body := `[{"timestamp":"2026-09-03T12:54:31.000Z","level":"INFO","namespace":"bug122","flowId":"hello122","taskId":"hello","message":"hello from bug122"}]`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+
+	t.Run("json", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := runLogsList(newTestClient(t, server.URL), "exec-1", logFilter{}, newJSONRenderer(&buf)); err != nil {
+			t.Fatalf("runLogsList error: %v", err)
+		}
+		var got []map[string]any
+		if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+			t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+		}
+		if len(got) != 1 {
+			t.Fatalf("expected 1 entry, got %d: %s", len(got), buf.String())
+		}
+		if got[0]["level"] != "INFO" {
+			t.Errorf(`json level = %#v, want "INFO"`, got[0]["level"])
+		}
+	})
+
+	t.Run("table", func(t *testing.T) {
+		var buf bytes.Buffer
+		if err := runLogsList(newTestClient(t, server.URL), "exec-1", logFilter{}, newTableRenderer(&buf)); err != nil {
+			t.Fatalf("runLogsList error: %v", err)
+		}
+		out := buf.String()
+		if strings.Contains(out, `"INFO"`) {
+			t.Errorf("table output contains quoted level:\n%s", out)
+		}
+		if !strings.Contains(out, "INFO") {
+			t.Errorf("table output missing level:\n%s", out)
 		}
 	})
 }

--- a/src/cli/render.go
+++ b/src/cli/render.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"reflect"
 	"strings"
 	"text/tabwriter"
 )
@@ -70,6 +71,28 @@ func (r *Renderer) RenderJSON(value any) error {
 	return err
 }
 
+// underlyingString reports the text of any value whose underlying kind is
+// string, dereferencing pointers along the way.
+//
+// The Kestra SDK generates its enums as named string types (Level, StateType,
+// Relation, ...) with no String() method, so a plain `case string` type switch
+// does not match them and they would otherwise fall through to json.Marshal
+// and be rendered with their JSON quotes — e.g. `"INFO"` instead of INFO.
+// See https://github.com/kestra-io/kestractl/issues/122.
+func underlyingString(value any) (string, bool) {
+	rv := reflect.ValueOf(value)
+	for rv.Kind() == reflect.Pointer {
+		if rv.IsNil() {
+			return "", false
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() == reflect.String {
+		return rv.String(), true
+	}
+	return "", false
+}
+
 func stringify(value any) string {
 	switch v := value.(type) {
 	case nil:
@@ -79,6 +102,9 @@ func stringify(value any) string {
 	case fmt.Stringer:
 		return v.String()
 	default:
+		if s, ok := underlyingString(v); ok {
+			return s
+		}
 		data, err := json.Marshal(v)
 		if err != nil {
 			return fmt.Sprintf("%v", v)
@@ -94,6 +120,9 @@ func toPrettyString(value any) string {
 	case string:
 		return v
 	default:
+		if s, ok := underlyingString(v); ok {
+			return s
+		}
 		data, err := json.MarshalIndent(v, "", "  ")
 		if err != nil {
 			return fmt.Sprintf("%v", v)

--- a/src/cli/render_test.go
+++ b/src/cli/render_test.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 	"text/tabwriter"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 )
 
 func TestNormalizeOutputFormat(t *testing.T) {
@@ -120,5 +123,52 @@ func TestRenderer_RenderTable(t *testing.T) {
 	}
 	if strings.Contains(output, "\"id\"") {
 		t.Fatalf("did not expect JSON output, got: %s", output)
+	}
+}
+
+// bugStringer is a named string type that also implements fmt.Stringer, to
+// prove the Stringer branch still wins over the plain-string-kind fallback.
+type bugStringer string
+
+func (b bugStringer) String() string { return "stringer:" + string(b) }
+
+func TestStringify(t *testing.T) {
+	tests := []struct {
+		name  string
+		input any
+		want  string
+	}{
+		{name: "nil", input: nil, want: ""},
+		{name: "plain string", input: "INFO", want: "INFO"},
+		{name: "sdk Level enum", input: kestra.LEVEL_INFO, want: "INFO"},
+		{name: "sdk Level enum error", input: kestra.LEVEL_ERROR, want: "ERROR"},
+		{name: "sdk StateType enum", input: kestra.STATETYPE_SUCCESS, want: "SUCCESS"},
+		{name: "sdk Relation enum", input: kestra.RELATION_USED_BY, want: "USED_BY"},
+		{name: "pointer to enum", input: kestra.LEVEL_WARN.Ptr(), want: "WARN"},
+		{name: "stringer wins over string kind", input: bugStringer("x"), want: "stringer:x"},
+		{name: "int stays json", input: 42, want: "42"},
+		{name: "bool stays json", input: true, want: "true"},
+		{name: "byte slice stays json", input: []byte("hi"), want: `"aGk="`},
+		{name: "json.RawMessage stays json", input: json.RawMessage(`{"a":1}`), want: `{"a":1}`},
+		{name: "map stays json", input: map[string]any{"a": 1}, want: `{"a":1}`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stringify(tc.input); got != tc.want {
+				t.Errorf("stringify(%#v) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestToPrettyString_EnumHasNoQuotes(t *testing.T) {
+	if got := toPrettyString(kestra.STATETYPE_FAILED); got != "FAILED" {
+		t.Errorf("toPrettyString(STATETYPE_FAILED) = %q, want %q", got, "FAILED")
+	}
+	// Non-string values keep their existing pretty-printed JSON form.
+	wantPretty := "{\n  \"a\": 1\n}"
+	if got := toPrettyString(json.RawMessage(`{"a":1}`)); got != wantPretty {
+		t.Errorf("toPrettyString(RawMessage) = %q, want %q", got, wantPretty)
 	}
 }

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -18,6 +18,9 @@ var (
 	buildDate = "unknown"
 )
 
+// envPrefix is the prefix for kestractl's environment variables.
+const envPrefix = "KESTRACTL"
+
 // Flag names
 const (
 	FlagHost     = "host"
@@ -139,7 +142,7 @@ with support for multiple authentication contexts and output formats.`,
 // initializeConfig sets up Viper to handle configuration from multiple sources.
 func initializeConfig(cmd *cobra.Command) error {
 	// 1. Set up Viper to use environment variables
-	viper.SetEnvPrefix("KESTRACTL")
+	viper.SetEnvPrefix(envPrefix)
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.AutomaticEnv()
 
@@ -175,6 +178,20 @@ func initializeConfig(cmd *cobra.Command) error {
 	// This ensures flags have the highest priority
 	if err := viper.BindPFlags(cmd.Flags()); err != nil {
 		return err
+	}
+
+	// 4b. Record which auth flags the user set explicitly. Viper flattens every
+	// auth field independently below, which loses track of the source; without
+	// this, a config-file token would outrank --username/--password (issue #120).
+	explicitAuthFlags = map[string]bool{}
+	for _, name := range []string{FlagToken, FlagUsername, FlagPassword} {
+		f := cmd.Flags().Lookup(name)
+		if f == nil {
+			f = cmd.Root().PersistentFlags().Lookup(name)
+		}
+		if f != nil && f.Changed && strings.TrimSpace(f.Value.String()) != "" {
+			explicitAuthFlags[name] = true
+		}
 	}
 
 	// 5. Read from the default context if config file was loaded

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -77,19 +77,29 @@ with support for multiple authentication contexts and output formats.`,
 			// collected by awaitNewVersionCheck once the command is done.
 			startNewVersionCheck(cmd.ErrOrStderr())
 			if verbose, _ := cmd.Flags().GetBool(FlagVerbose); verbose == true {
+				// Diagnostics go to stderr so rendered output — `-o json` above
+				// all — stays parsable when -v is on.
+				diag := cmd.ErrOrStderr()
 				if viper.ConfigFileUsed() != "" {
-					fmt.Printf("config location: %s\n", viper.ConfigFileUsed())
+					fmt.Fprintf(diag, "config location: %s\n", viper.ConfigFileUsed())
 				}
-				fmt.Printf("resolved params: \n")
+				fmt.Fprintf(diag, "resolved params: \n")
 				cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 					v := flag.Value.String()
 					// Mask any credential-bearing flag, not just the global
 					// token/password ones (e.g. users --user-password).
 					name := strings.ToLower(flag.Name)
-					if v != "" && (strings.Contains(name, "token") || strings.Contains(name, "password")) {
+					switch {
+					case flag.Name == FlagHeader:
+						// A user-supplied header can carry a credential too, so
+						// mask per entry by header name (issue #119).
+						if headers, err := cmd.Flags().GetStringArray(FlagHeader); err == nil {
+							v = maskHeaderFlagValues(headers)
+						}
+					case v != "" && (strings.Contains(name, "token") || strings.Contains(name, "password")):
 						v = "XXX"
 					}
-					fmt.Printf("\t%s: %s\n", flag.Name, v)
+					fmt.Fprintf(diag, "\t%s: %s\n", flag.Name, v)
 				})
 			}
 			return nil
@@ -107,7 +117,7 @@ with support for multiple authentication contexts and output formats.`,
 	root.PersistentFlags().StringVar(&globalFlags.Tenant, FlagTenant, "", "Tenant name")
 	root.PersistentFlags().StringVarP(&globalFlags.Output, FlagOutput, "o", "table", "Output format (table or json)")
 	root.PersistentFlags().String(FlagConfig, "", "config file (default is $HOME/.kestractl/config.yaml)")
-	root.PersistentFlags().BoolP(FlagVerbose, "v", false, "verbose output (warning: it will print credentials in http requests")
+	root.PersistentFlags().BoolP(FlagVerbose, "v", false, "print HTTP requests/responses to stderr; Authorization, cookie and other credential-bearing headers are masked, bodies are printed as-is")
 	root.PersistentFlags().StringArray(FlagHeader, nil, "Extra HTTP header to include in all requests (format: 'Key:Value', repeatable)")
 
 	root.AddCommand(newVersionCommand())
@@ -274,4 +284,23 @@ func newVersionCommand() *cobra.Command {
 			}
 		},
 	}
+}
+
+// maskHeaderFlagValues renders the --header flag for the verbose diagnostics,
+// masking the value of any entry whose header name looks credential-bearing.
+// The name is kept: knowing which header was sent is the point of -v.
+func maskHeaderFlagValues(headers []string) string {
+	masked := make([]string, 0, len(headers))
+	for _, h := range headers {
+		name, value, found := strings.Cut(h, ":")
+		if !found {
+			masked = append(masked, h)
+			continue
+		}
+		if isSensitiveHeader(strings.TrimSpace(name)) {
+			value = redactedHeaderValue
+		}
+		masked = append(masked, name+":"+value)
+	}
+	return "[" + strings.Join(masked, ",") + "]"
 }

--- a/src/cli/telemetry.go
+++ b/src/cli/telemetry.go
@@ -103,7 +103,7 @@ func newTelemetryReporter() telemetryReporter {
 		return noopTelemetry{}
 	}
 
-	host, tenant, _, _, _, _ := resolveConfig()
+	host, tenant, _, _ := resolveConfig()
 	instanceConfig := fetchInstanceConfig()
 
 	phClient, err := posthogFactory(posthogToken, posthog.Config{

--- a/src/cli/triggers.go
+++ b/src/cli/triggers.go
@@ -88,30 +88,28 @@ func runTriggersList(client *Client, page, size int32, renderer *Renderer) error
 		size = 50
 	}
 
-	resp, _, err := client.API.TriggersAPI.
-		SearchTriggers(client.Ctx, client.Tenant).
-		Page(page).
-		Size(size).
-		Execute()
+	// Both response shapes are read in compat_triggers.go; the 2.0 one is what a
+	// 2.x server sends and what the generated endpoint used here before could
+	// not decode (issue #118).
+	triggers, total, err := fetchTriggerRows(client, page, size)
 	if err != nil {
-		return formatSDKError(err)
+		return err
 	}
 
-	triggers := resp.GetResults()
 	result := make([]map[string]any, len(triggers))
 	for i, t := range triggers {
-		ctx := t.GetTriggerContext()
 		row := map[string]any{
-			"namespace": ctx.GetNamespace(),
-			"flowId":    ctx.GetFlowId(),
-			"triggerId": ctx.GetTriggerId(),
-			"disabled":  ctx.GetDisabled(),
+			"namespace": t.Namespace,
+			"flowId":    t.FlowID,
+			"triggerId": t.TriggerID,
+			"type":      t.Type,
+			"disabled":  t.Disabled,
 		}
-		if next, ok := ctx.GetNextExecutionDateOk(); ok && next != nil && !next.IsZero() {
-			row["nextExecutionDate"] = next.Format(time.RFC3339)
+		// The output key keeps the 1.x spelling kestractl has always rendered,
+		// whichever server the value came from.
+		if t.NextExecutionDate != nil {
+			row["nextExecutionDate"] = t.NextExecutionDate.Format(time.RFC3339)
 		}
-		ab := t.GetAbstractTrigger()
-		row["type"] = ab.GetType()
 		result[i] = row
 	}
 
@@ -131,7 +129,7 @@ func runTriggersList(client *Client, page, size int32, renderer *Renderer) error
 				nextRun,
 			)
 		}
-		fmt.Fprintf(w, "\nShowing %d trigger(s) (page %d, total %d)\n", len(result), page, resp.GetTotal())
+		fmt.Fprintf(w, "\nShowing %d trigger(s) (page %d, total %d)\n", len(result), page, total)
 		return nil
 	})
 }
@@ -201,11 +199,9 @@ func newTriggersUnlockCommand() *cobra.Command {
 }
 
 func runTriggersUnlock(client *Client, namespace, flowID, triggerID string, renderer *Renderer) error {
-	t, _, err := client.API.TriggersAPI.
-		UnlockTrigger(client.Ctx, namespace, flowID, triggerID, client.Tenant).
-		Execute()
+	t, err := unlockTriggerRef(client, namespace, flowID, triggerID)
 	if err != nil {
-		return formatSDKError(err)
+		return err
 	}
 	if t == nil {
 		result := map[string]any{"namespace": namespace, "flowId": flowID, "triggerId": triggerID}
@@ -216,16 +212,16 @@ func runTriggersUnlock(client *Client, namespace, flowID, triggerID string, rend
 	}
 
 	result := map[string]any{
-		"namespace": t.GetNamespace(),
-		"flowId":    t.GetFlowId(),
-		"triggerId": t.GetTriggerId(),
-		"disabled":  t.GetDisabled(),
+		"namespace": t.Namespace,
+		"flowId":    t.FlowID,
+		"triggerId": t.TriggerID,
+		"disabled":  t.Disabled,
 	}
 	return renderer.Render(result, func(w *tabwriter.Writer) error {
-		fmt.Fprintf(w, "NAMESPACE\t%s\n", t.GetNamespace())
-		fmt.Fprintf(w, "FLOW\t%s\n", t.GetFlowId())
-		fmt.Fprintf(w, "TRIGGER\t%s\n", t.GetTriggerId())
-		fmt.Fprintf(w, "DISABLED\t%v\n", t.GetDisabled())
+		fmt.Fprintf(w, "NAMESPACE\t%s\n", t.Namespace)
+		fmt.Fprintf(w, "FLOW\t%s\n", t.FlowID)
+		fmt.Fprintf(w, "TRIGGER\t%s\n", t.TriggerID)
+		fmt.Fprintf(w, "DISABLED\t%v\n", t.Disabled)
 		fmt.Fprintln(w, "\nTrigger unlocked.")
 		return nil
 	})
@@ -254,6 +250,12 @@ func newTriggersRestartCommand() *cobra.Command {
 }
 
 func runTriggersRestart(client *Client, namespace, flowID, triggerID string, renderer *Renderer) error {
+	// Deliberately still the generated endpoint: it decodes into
+	// map[string]interface{}, which accepts both the 2.0 and the 1.x response
+	// shapes, so restart is not affected by issue #118. The hand-written
+	// endpoint returns a typed ApiTriggerState, whose required `updatedAt` a 1.3
+	// server omits from this particular response — swapping it would trade a
+	// working command on both servers for a broken one on 1.3.
 	resp, _, err := client.API.TriggersAPI.
 		RestartTrigger(client.Ctx, namespace, flowID, triggerID, client.Tenant).
 		Execute()
@@ -334,41 +336,29 @@ func runTriggersSearchForFlow(client *Client, namespace, flowID string, page, si
 		size = 50
 	}
 
-	req := client.API.TriggersAPI.
-		SearchTriggersForFlow(client.Ctx, namespace, flowID, client.Tenant).
-		Page(page).
-		Size(size)
-	if query != "" {
-		req = req.Q(query)
-	}
-
-	resp, _, err := req.Execute()
+	// See compat_triggers.go: a 2.0 server's ApiTriggerState has no `date`, which
+	// the generated endpoint's model requires (issue #118).
+	triggers, total, err := fetchFlowTriggerRefs(client, namespace, flowID, page, size, query)
 	if err != nil {
-		return formatSDKError(err)
+		return err
 	}
 
-	triggers := resp.GetResults()
 	result := make([]map[string]any, len(triggers))
 	for i, t := range triggers {
 		result[i] = map[string]any{
-			"namespace": t.GetNamespace(),
-			"flowId":    t.GetFlowId(),
-			"triggerId": t.GetTriggerId(),
-			"disabled":  t.GetDisabled(),
+			"namespace": t.Namespace,
+			"flowId":    t.FlowID,
+			"triggerId": t.TriggerID,
+			"disabled":  t.Disabled,
 		}
 	}
 
 	return renderer.Render(result, func(w *tabwriter.Writer) error {
 		fmt.Fprintln(w, "NAMESPACE\tFLOW\tTRIGGER ID\tDISABLED")
 		for _, t := range triggers {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%v\n",
-				t.GetNamespace(),
-				t.GetFlowId(),
-				t.GetTriggerId(),
-				t.GetDisabled(),
-			)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%v\n", t.Namespace, t.FlowID, t.TriggerID, t.Disabled)
 		}
-		fmt.Fprintf(w, "\nShowing %d trigger(s) (page %d, total %d)\n", len(triggers), page, resp.GetTotal())
+		fmt.Fprintf(w, "\nShowing %d trigger(s) (page %d, total %d)\n", len(triggers), page, total)
 		return nil
 	})
 }
@@ -440,38 +430,16 @@ func newTriggersBackfillDeleteCommand() *cobra.Command {
 }
 
 func runTriggersBackfillOp(client *Client, namespace, flowID, triggerID, op string, renderer *Renderer) error {
-	t := kestra.NewTrigger(namespace, flowID, triggerID, time.Now())
-
-	var updated *kestra.Trigger
-	var err error
-
-	switch op {
-	case "pause":
-		updated, _, err = client.API.TriggersAPI.
-			PauseBackfill(client.Ctx, client.Tenant).
-			Trigger(*t).
-			Execute()
-	case "unpause":
-		updated, _, err = client.API.TriggersAPI.
-			UnpauseBackfill(client.Ctx, client.Tenant).
-			Trigger(*t).
-			Execute()
-	default: // delete
-		updated, _, err = client.API.TriggersAPI.
-			DeleteBackfill(client.Ctx, client.Tenant).
-			Trigger(*t).
-			Execute()
-	}
-
+	updated, err := backfillTriggerRef(client, namespace, flowID, triggerID, op)
 	if err != nil {
-		return formatSDKError(err)
+		return err
 	}
 
 	ns, fid, tid := namespace, flowID, triggerID
 	if updated != nil {
-		ns = updated.GetNamespace()
-		fid = updated.GetFlowId()
-		tid = updated.GetTriggerId()
+		ns = updated.Namespace
+		fid = updated.FlowID
+		tid = updated.TriggerID
 	}
 
 	result := map[string]any{

--- a/src/cli/triggers_test.go
+++ b/src/cli/triggers_test.go
@@ -2,10 +2,12 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -778,5 +780,166 @@ func TestTriggersExportCSVCommand_ClientError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "client error") {
 		t.Fatalf("expected client error, got: %v", err)
+	}
+}
+
+// --- issue #118: the 2.0 trigger/state response shape ---
+//
+// Kestra 2.0 answers GET /triggers/search with {"trigger":{...},"state":{...}}
+// while 1.3 answers {"abstractTrigger":{...},"triggerContext":{...}}. Both must
+// render the same row, on both servers.
+
+func TestRunTriggersList_RendersBothEras(t *testing.T) {
+	for _, tt := range []struct {
+		version, body string
+	}{
+		{"2.0.0-rc13", trigger20SearchBody},
+		{"1.3.35", trigger13SearchBody},
+	} {
+		t.Run(tt.version, func(t *testing.T) {
+			server := triggerTestServer(t, tt.version, tt.body)
+
+			var buf bytes.Buffer
+			if err := runTriggersList(newTestClient(t, server.URL), 1, 50, newTableRenderer(&buf)); err != nil {
+				t.Fatalf("runTriggersList: %v", err)
+			}
+			out := buf.String()
+			for _, want := range []string{
+				"bug118", "sched118", "every_min",
+				"io.kestra.plugin.core.trigger.Schedule",
+				"2026-09-04T10:40:00Z",
+			} {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected %q in output, got:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+// The JSON keys are part of the CLI's contract and must not move.
+func TestRunTriggersList_JSONKeys(t *testing.T) {
+	server := triggerTestServer(t, "2.0.0-rc13", trigger20SearchBody)
+
+	var buf bytes.Buffer
+	renderer, err := NewRenderer("json", &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runTriggersList(newTestClient(t, server.URL), 1, 50, renderer); err != nil {
+		t.Fatalf("runTriggersList: %v", err)
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rows); err != nil {
+		t.Fatalf("output is not JSON: %v (%s)", err, buf.String())
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	want := map[string]any{
+		"namespace":         "bug118",
+		"flowId":            "sched118",
+		"triggerId":         "every_min",
+		"type":              "io.kestra.plugin.core.trigger.Schedule",
+		"disabled":          false,
+		"nextExecutionDate": "2026-09-04T10:40:00Z",
+	}
+	if !reflect.DeepEqual(rows[0], want) {
+		t.Fatalf("row mismatch\n got: %v\nwant: %v", rows[0], want)
+	}
+}
+
+func TestRunTriggersSearchForFlow_BothEras(t *testing.T) {
+	for _, tt := range []struct {
+		version, body string
+	}{
+		{"2.0.0-rc13", `{"results":[` + trigger20StateBody + `],"total":1}`},
+		{"1.3.35", `{"results":[` + trigger13StateBody + `],"total":1}`},
+	} {
+		t.Run(tt.version, func(t *testing.T) {
+			server := triggerTestServer(t, tt.version, tt.body)
+
+			var buf bytes.Buffer
+			err := runTriggersSearchForFlow(newTestClient(t, server.URL), "bug118", "sched118", 1, 50, "", newTableRenderer(&buf))
+			if err != nil {
+				t.Fatalf("runTriggersSearchForFlow: %v", err)
+			}
+			for _, want := range []string{"bug118", "sched118", "every_min"} {
+				if !strings.Contains(buf.String(), want) {
+					t.Errorf("expected %q in output, got:\n%s", want, buf.String())
+				}
+			}
+		})
+	}
+}
+
+func TestRunTriggersUnlock_BothEras(t *testing.T) {
+	for _, tt := range []struct {
+		version, body string
+	}{
+		{"2.0.0-rc13", trigger20StateBody},
+		{"1.3.35", trigger13StateBody},
+	} {
+		t.Run(tt.version, func(t *testing.T) {
+			server := triggerTestServer(t, tt.version, tt.body)
+
+			var buf bytes.Buffer
+			err := runTriggersUnlock(newTestClient(t, server.URL), "bug118", "sched118", "every_min", newTableRenderer(&buf))
+			if err != nil {
+				t.Fatalf("runTriggersUnlock: %v", err)
+			}
+			for _, want := range []string{"bug118", "sched118", "every_min"} {
+				if !strings.Contains(buf.String(), want) {
+					t.Errorf("expected %q in output, got:\n%s", want, buf.String())
+				}
+			}
+		})
+	}
+}
+
+func TestRunTriggersBackfillOp_BothEras(t *testing.T) {
+	for _, op := range []string{"pause", "unpause", "delete"} {
+		for _, tt := range []struct {
+			version, body string
+		}{
+			{"2.0.0-rc13", trigger20StateBody},
+			{"1.3.35", trigger13StateBody},
+		} {
+			t.Run(op+"/"+tt.version, func(t *testing.T) {
+				server := triggerTestServer(t, tt.version, tt.body)
+
+				var buf bytes.Buffer
+				err := runTriggersBackfillOp(newTestClient(t, server.URL), "bug118", "sched118", "every_min", op, newTableRenderer(&buf))
+				if err != nil {
+					t.Fatalf("runTriggersBackfillOp(%s): %v", op, err)
+				}
+				if !strings.Contains(buf.String(), "every_min") {
+					t.Errorf("expected the trigger id in output, got:\n%s", buf.String())
+				}
+			})
+		}
+	}
+}
+
+func TestRunTriggersRestart_BothEras(t *testing.T) {
+	for _, tt := range []struct {
+		version, body string
+	}{
+		{"2.0.0-rc13", trigger20StateBody},
+		{"1.3.35", trigger13StateBody},
+	} {
+		t.Run(tt.version, func(t *testing.T) {
+			server := triggerTestServer(t, tt.version, tt.body)
+
+			var buf bytes.Buffer
+			err := runTriggersRestart(newTestClient(t, server.URL), "bug118", "sched118", "every_min", newTableRenderer(&buf))
+			if err != nil {
+				t.Fatalf("runTriggersRestart: %v", err)
+			}
+			if !strings.Contains(buf.String(), "restarted") {
+				t.Errorf("expected a restart confirmation, got:\n%s", buf.String())
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes the five open bug issues, one commit each. Every fix was reproduced first, then written test-first, then verified live on Kestra EE **2.0.0-rc13** and **1.3.35**. The full e2e suite passes against rc13.

| Issue | Commit | Change |
|---|---|---|
| #120 default context token overrides `--username/--password` | `fix(auth)` | The highest-precedence source (flags > env > config context) that sets any auth field picks the auth method. Values for that method still resolve per field, so a context `username` pairs with a `--password` flag. An incomplete method errors with a message naming the missing field instead of silently falling back to a stored token. |
| #119 `--verbose` prints the raw Authorization header | `fix(cli)` | Both SDK debug loggers are off; the shared `compatTransport` is the single dump path. Authorization, cookie, and credential-looking headers (including user `--header` values) print as `REDACTED`; binary or >64 KiB bodies get a one-line placeholder; the `resolved params` block moved from stdout to stderr so `-o json -v` stays parsable. Flag help updated. |
| #122 LEVEL / STATE rendered with literal quotes | `fix(render)` | `stringify`/`toPrettyString` now handle named string types (SDK enums have no `String()`), fixing LEVEL, STATE, and RELATION columns centrally. `logs list -o json` stores the raw level so it is no longer double-quoted. |
| #121 `kv get` loses precision above 2^53 | `fix(kv)` | Worse than reported: `kv set JSON` re-marshalled through `float64` and **wrote corrupted digits to the server**. All kv decode paths use `UseNumber`, JSON values are sent as the original text, and `kv get` reads the endpoint directly so the SDK cannot lose precision first. `isProblemDocument` accepts `json.Number`. |
| #118 `triggers list` blank rows on Kestra 2.0 | `fix(triggers)` | Trigger commands dispatch on server era in a new `compat_triggers.go`: the hand-written v2 client for 2.x, lenient raw decoding for 1.x (which can omit `date`). Also fixes `search-for-flow`, `unlock`, and the single backfill ops, which hard-failed on 2.0 with "no value given for required property date". Output keys and columns unchanged. |

### Behaviour changes worth noting
- `--username` without a password (anywhere) now errors instead of silently authenticating with a stored token.
- `-v` output format changed to the `>`/`<` style of the hand-written client; the flag help no longer warns about leaking credentials.
- `logs list -o json` emits `"level": "INFO"` instead of `"level": "\"INFO\""`.

### Out of scope / follow-ups
- Same precision loss as #121 in other `map[string]any` paths: namespace `variables`, execution outputs, the `tryParse*FromError` helpers in `client.go`/`flows.go`, and the webhook trigger response in `executions.go`.
- `triggers update` hits `PUT /triggers`, which returns 403 on Kestra 2.0 (endpoint removed); left untouched.
- The generated Go SDK still ships 1.x trigger models for `/triggers/**`; regenerating upstream would let `compat_triggers.go` shrink.
- Every command sends the `/api/v1/configs` version probe twice.

Closes #118, closes #119, closes #120, closes #121, closes #122.
