### PR TITLE
fix(cli): preserve large integers in namespace variables and execution outputs

### DIFF
--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -391,8 +391,11 @@ func tryParseExecutionFromError(err error) map[string]any {
 		return nil
 	}
 
+	// UseNumber: this body is rendered as-is, user data included (a JSON input
+	// with epoch nanos, a large ID), and plain json.Unmarshal would round every
+	// integer above 2^53 through float64 (follow-up to #121).
 	var rawResp map[string]any
-	if json.Unmarshal(body, &rawResp) != nil {
+	if decodeJSONPreservingNumbers(body, &rawResp) != nil {
 		return nil
 	}
 

--- a/src/cli/client_test.go
+++ b/src/cli/client_test.go
@@ -444,3 +444,23 @@ func TestIsProblemDocument_StatusNumberForms(t *testing.T) {
 		})
 	}
 }
+
+// TestTryParseExecutionFromError_PreservesLargeIntegers covers the raw-body
+// fallback used by executions get/run on Kestra 2.x: it renders whatever the
+// execution carries, including user data such as JSON inputs with epoch nanos.
+func TestTryParseExecutionFromError_PreservesLargeIntegers(t *testing.T) {
+	sdkErr := &kestra.GenericOpenAPIError{}
+	setGenericOpenAPIErrorBody(sdkErr, []byte(`{"id":"exec-1","inputs":{"payload":{"nanos":1725450000123456789}},"state":{"current":"SUCCESS","duration":"PT0.07S"}}`))
+
+	execution := tryParseExecutionFromError(sdkErr)
+	if execution == nil {
+		t.Fatal("expected the execution to be recovered")
+	}
+	rendered := toPrettyString(execution)
+	if !strings.Contains(rendered, "1725450000123456789") {
+		t.Fatalf("expected exact digits in:\n%s", rendered)
+	}
+	if strings.Contains(rendered, "1725450000123456800") {
+		t.Fatalf("precision was lost:\n%s", rendered)
+	}
+}

--- a/src/cli/executions.go
+++ b/src/cli/executions.go
@@ -1157,6 +1157,12 @@ func formatDuration(raw any) string {
 		return v
 	case float64:
 		return fmt.Sprintf("%.2fs", v/1000)
+	case json.Number:
+		// Bodies decoded with UseNumber carry json.Number rather than float64.
+		if ms, err := v.Float64(); err == nil {
+			return fmt.Sprintf("%.2fs", ms/1000)
+		}
+		return v.String()
 	default:
 		return fmt.Sprintf("%v", v)
 	}
@@ -2416,7 +2422,9 @@ func triggerWebhookDirect(client *Client, method, namespace, flowID, key string)
 
 	result := map[string]any{}
 	if len(body) > 0 {
-		if err := json.Unmarshal(body, &result); err != nil {
+		// UseNumber: the whole response is rendered as-is, so integers above
+		// 2^53 must not be rounded through float64 (follow-up to #121).
+		if err := decodeJSONPreservingNumbers(body, &result); err != nil {
 			return nil, fmt.Errorf("failed to parse webhook response: %w", err)
 		}
 	}

--- a/src/cli/executions_test.go
+++ b/src/cli/executions_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -392,6 +393,10 @@ func TestFormatDuration(t *testing.T) {
 		{input: "not-iso", expected: "not-iso"},
 		{input: "plain string", expected: "plain string"},
 		{input: 42, expected: "42"},
+		// Bodies decoded with UseNumber carry json.Number, not float64.
+		{input: json.Number("5000"), expected: "5.00s"},
+		{input: json.Number("1234"), expected: "1.23s"},
+		{input: json.Number("not-a-number"), expected: "not-a-number"},
 	}
 
 	for _, tt := range tests {
@@ -1565,5 +1570,24 @@ func TestExecutionsWatchCommand_ClientError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "client error") {
 		t.Fatalf("expected client error, got: %v", err)
+	}
+}
+
+// TestTriggerWebhookDirect_PreservesLargeIntegers covers the path-less
+// POST/PUT webhook, whose whole response body is rendered as-is.
+func TestTriggerWebhookDirect_PreservesLargeIntegers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"exec-1","namespace":"ns","flowId":"f","inputs":{"payload":{"nanos":1725450000123456789}}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	result, err := triggerWebhookDirect(newTestClient(t, server.URL), http.MethodPost, "ns", "f", "key")
+	if err != nil {
+		t.Fatalf("triggerWebhookDirect error: %v", err)
+	}
+	rendered := toPrettyString(result)
+	if !strings.Contains(rendered, "1725450000123456789") {
+		t.Fatalf("expected exact digits in:\n%s", rendered)
 	}
 }

--- a/src/cli/jsonutil.go
+++ b/src/cli/jsonutil.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+)
+
+// decodeJSONPreservingNumbers decodes JSON into out with json.Decoder.UseNumber,
+// so numbers land as json.Number (their original digits) instead of float64.
+// Anything above 2^53 — a large ID, epoch nanos — otherwise loses precision the
+// moment it is decoded, and re-renders wrong (#121). json.Number re-encodes as a
+// bare JSON number, so both the table and the --output json paths stay exact.
+// Trailing content after the first value is rejected, which plain
+// json.Unmarshal does for free.
+func decodeJSONPreservingNumbers(data []byte, out any) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := decoder.Decode(out); err != nil {
+		return err
+	}
+	if decoder.More() {
+		return fmt.Errorf("unexpected trailing data after JSON value")
+	}
+	return nil
+}
+
+// rawGet issues a GET against the Kestra API and returns the response body
+// unparsed, reusing the SDK's configured host, HTTP client, default headers and
+// context-based authentication. It exists because the generated client decodes
+// free-form values (KV values, namespace variables) into map[string]interface{}
+// with plain json.Unmarshal, which loses integer precision above 2^53 before
+// kestractl ever sees the payload; reading the bytes here lets the caller decode
+// them with decodeJSONPreservingNumbers instead (#121).
+//
+// path must be the full API path, starting with a slash and already escaped.
+func rawGet(client *Client, path string) ([]byte, error) {
+	cfg := client.API.GetConfig()
+
+	base := ""
+	if len(cfg.Servers) > 0 {
+		base = cfg.Servers[0].URL
+	}
+	if base == "" {
+		base = cfg.Scheme + "://" + cfg.Host
+	}
+	base = strings.TrimRight(base, "/")
+
+	req, err := http.NewRequestWithContext(client.Ctx, http.MethodGet, base+path, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	// Reuse the auth the SDK stored on the context.
+	if auth, ok := client.Ctx.Value(kestra.ContextBasicAuth).(kestra.BasicAuth); ok {
+		req.SetBasicAuth(auth.UserName, auth.Password)
+	}
+	if token, ok := client.Ctx.Value(kestra.ContextAccessToken).(string); ok {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	for h, v := range cfg.DefaultHeader {
+		req.Header.Set(h, v)
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response from %s: %w", path, err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, formatErrorBody(body, resp.Status)
+	}
+
+	return body, nil
+}

--- a/src/cli/jsonutil_test.go
+++ b/src/cli/jsonutil_test.go
@@ -1,0 +1,95 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+)
+
+func TestDecodeJSONPreservingNumbers(t *testing.T) {
+	var got map[string]any
+	if err := decodeJSONPreservingNumbers([]byte(`{"nanos":1725450000123456789,"nested":{"big":9007199254740993},"list":[9007199254740995]}`), &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := got["nanos"].(json.Number); !ok {
+		t.Fatalf("expected a json.Number, got %T", got["nanos"])
+	}
+	rendered := toPrettyString(got)
+	for _, digits := range []string{"1725450000123456789", "9007199254740993", "9007199254740995"} {
+		if !strings.Contains(rendered, digits) {
+			t.Fatalf("expected %s in:\n%s", digits, rendered)
+		}
+	}
+}
+
+func TestDecodeJSONPreservingNumbers_Errors(t *testing.T) {
+	var out any
+	if err := decodeJSONPreservingNumbers([]byte(`{"a":1} {"b":2}`), &out); err == nil {
+		t.Fatal("expected trailing data to be rejected")
+	}
+	if err := decodeJSONPreservingNumbers([]byte(`{`), &out); err == nil {
+		t.Fatal("expected malformed JSON to be rejected")
+	}
+	if err := decodeJSONPreservingNumbers(nil, &out); err == nil {
+		t.Fatal("expected an empty body to be rejected")
+	}
+}
+
+func TestRawGet(t *testing.T) {
+	var gotPath, gotAccept, gotAuth, gotExtra string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAccept = r.Header.Get("Accept")
+		gotAuth = r.Header.Get("Authorization")
+		gotExtra = r.Header.Get("X-Extra")
+		_, _ = w.Write([]byte(`{"value":9007199254740993}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newTestClient(t, server.URL)
+	client.API.GetConfig().DefaultHeader["X-Extra"] = "yes"
+	client.Ctx = context.WithValue(client.Ctx, kestra.ContextAccessToken, "tok")
+
+	body, err := rawGet(client, "/api/v1/main/namespaces/ns")
+	if err != nil {
+		t.Fatalf("rawGet error: %v", err)
+	}
+	if string(body) != `{"value":9007199254740993}` {
+		t.Fatalf("unexpected body: %s", body)
+	}
+	if gotPath != "/api/v1/main/namespaces/ns" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if gotAccept != "application/json" {
+		t.Fatalf("unexpected Accept: %s", gotAccept)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Fatalf("expected the context token to be reused, got %q", gotAuth)
+	}
+	if gotExtra != "yes" {
+		t.Fatalf("expected the SDK default headers to be reused, got %q", gotExtra)
+	}
+}
+
+func TestRawGet_ErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"type":"https://kestra.io/docs/api-reference/problems/not-found","title":"Resource not found","status":404,"detail":"No namespace found"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := rawGet(newTestClient(t, server.URL), "/api/v1/main/namespaces/ns")
+	if err == nil {
+		t.Fatal("expected an error for a 404")
+	}
+	if !strings.Contains(err.Error(), "No namespace found") {
+		t.Fatalf("expected the problem detail in the error, got: %v", err)
+	}
+}

--- a/src/cli/kv.go
+++ b/src/cli/kv.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 	"strings"
 	"text/tabwriter"
@@ -443,25 +441,6 @@ func parseKVDisplayValue(kvType kestra.KVType, rawValue string) any {
 	}
 }
 
-// decodeJSONPreservingNumbers decodes JSON into out with json.Decoder.UseNumber,
-// so numbers land as json.Number (their original digits) instead of float64.
-// Anything above 2^53 — a large ID, epoch nanos — otherwise loses precision the
-// moment it is decoded, and re-renders wrong (#121). json.Number re-encodes as a
-// bare JSON number, so both the table and the --output json paths stay exact.
-// Trailing content after the first value is rejected, which plain
-// json.Unmarshal does for free.
-func decodeJSONPreservingNumbers(data []byte, out any) error {
-	decoder := json.NewDecoder(bytes.NewReader(data))
-	decoder.UseNumber()
-	if err := decoder.Decode(out); err != nil {
-		return err
-	}
-	if decoder.More() {
-		return fmt.Errorf("unexpected trailing data after JSON value")
-	}
-	return nil
-}
-
 func isLikelyISO8601Duration(value string) bool {
 	if len(value) < 2 {
 		return false
@@ -486,57 +465,13 @@ func isLikelyISO8601Duration(value string) bool {
 // KeyValue endpoint, and the request reuses the SDK's configured host, HTTP
 // client, default headers and context-based auth.
 func fetchKVTypedValue(client *Client, namespace, key string) (*kvTypedValue, error) {
-	cfg := client.API.GetConfig()
-
-	base := ""
-	if len(cfg.Servers) > 0 {
-		base = cfg.Servers[0].URL
-	}
-	if base == "" {
-		base = cfg.Scheme + "://" + cfg.Host
-	}
-	base = strings.TrimRight(base, "/")
-
-	endpoint := fmt.Sprintf("%s/api/v1/%s/namespaces/%s/kv/%s",
-		base,
+	body, err := rawGet(client, fmt.Sprintf("/api/v1/%s/namespaces/%s/kv/%s",
 		url.PathEscape(client.Tenant),
 		url.PathEscape(namespace),
 		url.PathEscape(key),
-	)
-
-	req, err := http.NewRequestWithContext(client.Ctx, http.MethodGet, endpoint, nil)
+	))
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-
-	if auth, ok := client.Ctx.Value(kestra.ContextBasicAuth).(kestra.BasicAuth); ok {
-		req.SetBasicAuth(auth.UserName, auth.Password)
-	}
-	if token, ok := client.Ctx.Value(kestra.ContextAccessToken).(string); ok {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-	for h, v := range cfg.DefaultHeader {
-		req.Header.Set(h, v)
-	}
-
-	httpClient := cfg.HTTPClient
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read key-value response: %w", err)
-	}
-	if resp.StatusCode >= 400 {
-		return nil, formatErrorBody(body, resp.Status)
 	}
 
 	return parseKVTypedValueBody(body), nil

--- a/src/cli/namespaces.go
+++ b/src/cli/namespaces.go
@@ -2,7 +2,9 @@ package cli
 
 import (
 	"fmt"
+	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -151,11 +153,13 @@ func runNamespacesGet(client *Client, id string, renderer *Renderer) error {
 		ns = kestra.NewNamespaceWithDefaults()
 	}
 
+	variables := namespaceVariables(client, id, ns.GetVariables())
+
 	result := map[string]any{
 		"id":          ns.GetId(),
 		"description": ns.GetDescription(),
 		"deleted":     ns.GetDeleted(),
-		"variables":   ns.GetVariables(),
+		"variables":   variables,
 	}
 	if c, ok := ns.GetConcurrencyOk(); ok {
 		result["concurrency"] = c
@@ -171,10 +175,17 @@ func runNamespacesGet(client *Client, id string, renderer *Renderer) error {
 		}
 		fmt.Fprintf(w, "DELETED\t%v\n", ns.GetDeleted())
 		writeConcurrencyAndQuotas(w, ns.Concurrency, ns.GetQuotas())
-		if vars := ns.GetVariables(); len(vars) > 0 {
+		if len(variables) > 0 {
 			fmt.Fprintln(w, "\nVARIABLES:")
-			for k, v := range vars {
-				fmt.Fprintf(w, "  %s\t%v\n", k, v)
+			keys := make([]string, 0, len(variables))
+			for k := range variables {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				// stringify, not %v: a json.Number prints its digits and a
+				// nested object prints as JSON rather than Go's map[...] form.
+				fmt.Fprintf(w, "  %s\t%s\n", k, stringify(variables[k]))
 			}
 		}
 		return nil
@@ -210,6 +221,38 @@ func parseVariableFlags(pairs []string, filePath string) (map[string]interface{}
 	}
 
 	return variables, nil
+}
+
+// namespaceVariables re-reads a namespace straight from the API so its
+// variables keep every digit: the SDK types Namespace.Variables as
+// map[string]interface{} and decodes it with plain json.Unmarshal, which turns
+// any integer above 2^53 into a lossy float64 before kestractl sees it
+// (follow-up to #121). The SDK's own map is returned as a fallback, so a failed
+// extra read degrades to the old rendering instead of failing the command.
+func namespaceVariables(client *Client, id string, fallback map[string]any) map[string]any {
+	// No variables at all: the extra read cannot add anything, so the common
+	// case stays at a single request.
+	if len(fallback) == 0 {
+		return fallback
+	}
+
+	body, err := rawGet(client, fmt.Sprintf("/api/v1/%s/namespaces/%s",
+		url.PathEscape(client.Tenant),
+		url.PathEscape(id),
+	))
+	if err != nil {
+		return fallback
+	}
+
+	var raw map[string]any
+	if decodeJSONPreservingNumbers(body, &raw) != nil {
+		return fallback
+	}
+	variables, ok := raw["variables"].(map[string]any)
+	if !ok {
+		return fallback
+	}
+	return variables
 }
 
 func newNamespacesCreateCommand() *cobra.Command {
@@ -300,7 +343,7 @@ func runNamespacesCreate(client *Client, id, description string, variables map[s
 	result := map[string]any{
 		"id":          created.GetId(),
 		"description": created.GetDescription(),
-		"variables":   created.GetVariables(),
+		"variables":   namespaceVariables(client, id, created.GetVariables()),
 	}
 	if c, ok := created.GetConcurrencyOk(); ok {
 		result["concurrency"] = c
@@ -463,7 +506,7 @@ func runNamespacesUpdate(client *Client, id, description string, descriptionSet 
 	result := map[string]any{
 		"id":          updated.GetId(),
 		"description": updated.GetDescription(),
-		"variables":   updated.GetVariables(),
+		"variables":   namespaceVariables(client, id, updated.GetVariables()),
 	}
 	if c, ok := updated.GetConcurrencyOk(); ok {
 		result["concurrency"] = c

--- a/src/cli/namespaces_test.go
+++ b/src/cli/namespaces_test.go
@@ -568,3 +568,145 @@ func TestNamespacesCreateCommand_InvalidQuota(t *testing.T) {
 		t.Fatalf("expected missing-key error, got: %v", err)
 	}
 }
+
+// --- large integers in namespace variables (follow-up to #121) -----------
+
+const nsBigVariablesBody = `{"id":"ns","deleted":false,"variables":{"bigint":1725450000123456789,"nested":{"nanos":9007199254740993},"small":42}}`
+
+// namespaceServer answers both the SDK's namespace call and the raw read with
+// the same body, so a test exercises whichever path the code takes.
+func namespaceServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestNamespacesGet_PreservesLargeIntegers(t *testing.T) {
+	server := namespaceServer(t, nsBigVariablesBody)
+
+	var asJSON bytes.Buffer
+	if err := runNamespacesGet(newTestClient(t, server.URL), "ns", newJSONRenderer(&asJSON)); err != nil {
+		t.Fatalf("runNamespacesGet error: %v", err)
+	}
+	for _, digits := range []string{"1725450000123456789", "9007199254740993"} {
+		if !strings.Contains(asJSON.String(), digits) {
+			t.Fatalf("json output lost precision, want %s in:\n%s", digits, asJSON.String())
+		}
+		if strings.Contains(asJSON.String(), `"`+digits+`"`) {
+			t.Fatalf("expected a bare JSON number, got:\n%s", asJSON.String())
+		}
+	}
+
+	var table bytes.Buffer
+	if err := runNamespacesGet(newTestClient(t, server.URL), "ns", newTableRenderer(&table)); err != nil {
+		t.Fatalf("runNamespacesGet error: %v", err)
+	}
+	// The table used to print float64s through %v: "1.7254500001234568e+18"
+	// for a scalar and "map[nanos:9.007199254740992e+15]" for a nested object.
+	if !strings.Contains(table.String(), "1725450000123456789") {
+		t.Fatalf("table output lost precision:\n%s", table.String())
+	}
+	if strings.Contains(table.String(), "e+18") || strings.Contains(table.String(), "map[") {
+		t.Fatalf("expected JSON rendering rather than %%v, got:\n%s", table.String())
+	}
+	if !strings.Contains(table.String(), "9007199254740993") {
+		t.Fatalf("nested table value lost precision:\n%s", table.String())
+	}
+}
+
+func TestNamespacesCreate_EchoPreservesLargeIntegers(t *testing.T) {
+	server := namespaceServer(t, nsBigVariablesBody)
+
+	variables := map[string]any{"bigint": int64(1725450000123456789)}
+	var buf bytes.Buffer
+	if err := runNamespacesCreate(newTestClient(t, server.URL), "ns", "", variables, nil, nil, newJSONRenderer(&buf)); err != nil {
+		t.Fatalf("runNamespacesCreate error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "1725450000123456789") {
+		t.Fatalf("create echo lost precision:\n%s", buf.String())
+	}
+}
+
+func TestNamespacesUpdate_EchoPreservesLargeIntegers(t *testing.T) {
+	server := namespaceServer(t, nsBigVariablesBody)
+
+	variables := map[string]any{"bigint": int64(1725450000123456789)}
+	var buf bytes.Buffer
+	if err := runNamespacesUpdate(newTestClient(t, server.URL), "ns", "", false, variables, nil, nil, newJSONRenderer(&buf)); err != nil {
+		t.Fatalf("runNamespacesUpdate error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "1725450000123456789") {
+		t.Fatalf("update echo lost precision:\n%s", buf.String())
+	}
+}
+
+// TestNamespacesGet_RawReadFailureFallsBack keeps the command working when the
+// extra raw read fails: the SDK's (lossy) variables are better than an error.
+func TestNamespacesGet_RawReadFailureFallsBack(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls > 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"ns","deleted":false,"variables":{"env":"prod"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runNamespacesGet(newTestClient(t, server.URL), "ns", newJSONRenderer(&buf)); err != nil {
+		t.Fatalf("runNamespacesGet error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "prod") {
+		t.Fatalf("expected the SDK variables as a fallback, got:\n%s", buf.String())
+	}
+}
+
+// TestNamespacesGet_NoVariablesSkipsRawRead keeps the common case at a single
+// request: an empty variables map has no precision to preserve.
+func TestNamespacesGet_NoVariablesSkipsRawRead(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"ns","deleted":false}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runNamespacesGet(newTestClient(t, server.URL), "ns", newJSONRenderer(&buf)); err != nil {
+		t.Fatalf("runNamespacesGet error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected exactly one request, got %d", calls)
+	}
+}
+
+// TestNamespacesGet_VariablesTriggerRawRead is the counterpart: with variables
+// present, the raw read must happen so their digits survive.
+func TestNamespacesGet_VariablesTriggerRawRead(t *testing.T) {
+	var calls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(nsBigVariablesBody))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	if err := runNamespacesGet(newTestClient(t, server.URL), "ns", newJSONRenderer(&buf)); err != nil {
+		t.Fatalf("runNamespacesGet error: %v", err)
+	}
+	if calls != 2 {
+		t.Fatalf("expected the raw read to happen, got %d request(s)", calls)
+	}
+	if !strings.Contains(buf.String(), "1725450000123456789") {
+		t.Fatalf("expected exact digits:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
Follow-up to #121 (stacked on #127; retarget to `main` once #127 merges).

Integers above 2^53 were still rounded through `float64` in the remaining places where free-form JSON is decoded into `any` before rendering. Unlike #121 these are display-only (the server keeps exact digits), but `-o json` emitted wrong numbers and tables printed `1.7254500001234568e+18` or Go's `map[...]` form.

### Sites fixed
- **`namespaces get` and the `create`/`update` echoes** — the SDK types `Namespace.Variables` as `map[string]interface{}`, so precision is lost inside the SDK. Variables are re-read with a direct GET decoded with `UseNumber` (skipped when the SDK reports no variables, so the common case stays at one request; falls back to the SDK map if the read fails). Table values render via `stringify` with sorted keys.
- **`tryParseExecutionFromError`** (`client.go`) — the raw-body fallback `executions get`/`run` take on Kestra 2.x; it renders whole executions including JSON inputs. `formatDuration` accepts `json.Number`.
- **Path-less webhook response** (`executions.go`).

`decodeJSONPreservingNumbers` moved from `kv.go` to a shared `jsonutil.go`, with a `rawGet` helper that `kv.go` and `namespaces.go` now share.

### Deliberately untouched
`flows.go` tryParse helpers and `tryParseNamespaceListFromError` only extract typed scalars; `UseNumber` there would break existing `float64`/`int32` assertions without fixing any user-visible loss. `namespaces inherited-variables` is hard-broken on 2.0 for an unrelated reason, filed as #128.

### Verification
TDD (tests failed pre-fix for the right reasons). Live on 2.0.0-rc13 and 1.3.35: namespace variable and execution JSON input of `1725450000123456789` print verbatim in table and JSON; durations still render. e2e suite passes except the pre-existing env-dependent `TestSimpleCmd_WrongServer`.