### PR TITLE
fix(nsfiles): delete a directory in one request so --recursive keeps siblings

### DIFF
--- a/e2e_tests/nsfiles_usecases_test.go
+++ b/e2e_tests/nsfiles_usecases_test.go
@@ -50,6 +50,38 @@ func TestNsfilesUpload_e2e(t *testing.T) {
 	require.Error(t, err, "file should have been deleted")
 }
 
+// Regression test for #130: deleting a subdirectory recursively used to wipe
+// every sibling file in the parent directory.
+func TestNsfilesDeleteRecursive_keepsSiblings(t *testing.T) {
+	dir := "e2e-nsfiles-tests/" + randomId()
+	keep := dir + "/keep.txt"
+	nested := dir + "/sub/x.txt"
+
+	_, stderr, err := RunAuthenticatedCliCmd(t, "nsfiles", "upload", "system", "./README.md", keep)
+	require.Empty(t, stderr)
+	require.NoError(t, err)
+
+	_, stderr, err = RunAuthenticatedCliCmd(t, "nsfiles", "upload", "system", "./README.md", nested)
+	require.Empty(t, stderr)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_, _, _ = RunAuthenticatedCliCmd(t, "nsfiles", "delete", "system", dir, "--recursive", "--force")
+	})
+
+	_, stderr, err = RunAuthenticatedCliCmd(t, "nsfiles", "delete", "system", dir+"/sub", "--recursive")
+	require.Empty(t, stderr)
+	require.NoError(t, err)
+
+	_, _, err = RunAuthenticatedCliCmd(t, "nsfiles", "get", "system", nested)
+	require.Error(t, err, "deleted file should be gone")
+
+	stdout, stderr, err := RunAuthenticatedCliCmd(t, "nsfiles", "get", "system", keep)
+	require.Empty(t, stderr)
+	require.NoError(t, err, "sibling file must survive a recursive delete of a subdirectory")
+	require.Contains(t, stdout, "e2e tests")
+}
+
 func getRandomNsFilePath() string {
 	return "e2e-nsfiles-tests/" + randomId()
 }

--- a/src/cli/nsfiles.go
+++ b/src/cli/nsfiles.go
@@ -512,7 +512,6 @@ func runNamespaceFilesDelete(client *Client, namespace, targetPath string, recur
 	// the deepest-first walk reaches the directory itself that path no longer
 	// exists — and a DELETE on a path that does not exist deletes its *parent*,
 	// taking every sibling file with it.
-	failed := 0
 	deleteErr := deleteNamespaceFilePath(client, namespace, normalizedPath)
 	for _, target := range deleteTargets {
 		result := namespaceFileDeleteResult{
@@ -522,11 +521,17 @@ func runNamespaceFilesDelete(client *Client, namespace, targetPath string, recur
 		if deleteErr != nil {
 			result.Success = false
 			result.Error = deleteErr.Error()
-			failed++
 		} else {
 			result.Success = true
 		}
 		results = append(results, result)
+	}
+
+	// One request, so at most one failure — counting the reported rows instead
+	// would claim "6 error(s)" for a single 403 on a directory of five entries.
+	failed := 0
+	if deleteErr != nil {
+		failed = 1
 	}
 
 	if err := renderNamespaceFilesDeleteResults(results, renderer); err != nil {

--- a/src/cli/nsfiles.go
+++ b/src/cli/nsfiles.go
@@ -504,16 +504,24 @@ func runNamespaceFilesDelete(client *Client, namespace, targetPath string, recur
 		})
 	}
 
+	// One DELETE removes the whole subtree, so the enumerated targets are only
+	// there to report what went away.
+	//
+	// Deleting them one by one instead destroys data (issue #130): the server
+	// prunes a directory as soon as its last child is removed, so by the time
+	// the deepest-first walk reaches the directory itself that path no longer
+	// exists — and a DELETE on a path that does not exist deletes its *parent*,
+	// taking every sibling file with it.
 	failed := 0
+	deleteErr := deleteNamespaceFilePath(client, namespace, normalizedPath)
 	for _, target := range deleteTargets {
-		err := deleteNamespaceFilePath(client, namespace, target.Path)
 		result := namespaceFileDeleteResult{
 			Path: target.Path,
 			Type: target.Type,
 		}
-		if err != nil {
+		if deleteErr != nil {
 			result.Success = false
-			result.Error = err.Error()
+			result.Error = deleteErr.Error()
 			failed++
 		} else {
 			result.Success = true
@@ -731,8 +739,14 @@ func ensureNamespaceDirectories(client *Client, namespace, dirPath string) error
 	return nil
 }
 
+// deleteNamespaceFilePath removes a namespace file, or a directory and
+// everything under it, in a single request.
+//
+// The path is sent slash-prefixed so the server resolves it absolutely rather
+// than relative to anything: a DELETE that misses its target does not fail, it
+// deletes the parent directory instead (issue #130).
 func deleteNamespaceFilePath(client *Client, namespace, path string) error {
-	_, err := client.API.FilesAPI.DeleteFileDirectory(client.Ctx, namespace, client.Tenant).Path(path).Execute()
+	_, err := client.API.FilesAPI.DeleteFileDirectory(client.Ctx, namespace, client.Tenant).Path(absoluteNamespacePath(path)).Execute()
 	if err != nil {
 		return formatSDKError(err)
 	}
@@ -907,6 +921,15 @@ func normalizeNamespacePath(path string) string {
 		return ""
 	}
 	return trimmed
+}
+
+// absoluteNamespacePath turns a normalized (slash-less) namespace path into the
+// absolute form the API resolves unambiguously. An empty path stays empty.
+func absoluteNamespacePath(path string) string {
+	if path == "" || strings.HasPrefix(path, "/") {
+		return path
+	}
+	return "/" + path
 }
 
 func joinNamespacePath(base, child string) string {

--- a/src/cli/nsfiles.go
+++ b/src/cli/nsfiles.go
@@ -527,11 +527,12 @@ func runNamespaceFilesDelete(client *Client, namespace, targetPath string, recur
 		results = append(results, result)
 	}
 
-	// One request, so at most one failure — counting the reported rows instead
-	// would claim "6 error(s)" for a single 403 on a directory of five entries.
+	// The report is path-shaped: the one request removes or fails the whole
+	// subtree, so on failure every enumerated path is reported as not deleted
+	// and the error count matches the rows the report marks failed.
 	failed := 0
 	if deleteErr != nil {
-		failed = 1
+		failed = len(results)
 	}
 
 	if err := renderNamespaceFilesDeleteResults(results, renderer); err != nil {

--- a/src/cli/nsfiles_test.go
+++ b/src/cli/nsfiles_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -352,6 +354,86 @@ func TestNamespaceFilesExportCommand_NoArgs(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "accepts 1 arg") {
 		t.Fatalf("expected args error, got: %v", err)
+	}
+}
+
+// Regression test for #130: `delete /qa/sub --recursive` used to DELETE each
+// enumerated child before the directory itself, which wiped /qa. The server
+// prunes a directory once its last child goes, and a DELETE on a path that no
+// longer exists deletes the parent. One slash-prefixed DELETE on the directory
+// is the only safe request.
+func TestRunNamespaceFilesDelete_RecursiveIssuesOneDirectoryDelete(t *testing.T) {
+	var deletedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Query().Get("path")
+		switch {
+		case r.Method == http.MethodDelete:
+			deletedPaths = append(deletedPaths, path)
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "/files/stats"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"fileName":"sub","type":"Directory","size":0}`))
+		case strings.HasSuffix(r.URL.Path, "/files/directory"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"fileName":"nested.py","type":"File","size":3}]`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var out bytes.Buffer
+	renderer, err := NewRenderer("json", &out)
+	if err != nil {
+		t.Fatalf("NewRenderer() returned error: %v", err)
+	}
+
+	if err := runNamespaceFilesDelete(newTestClient(t, server.URL), "qa.ns", "/qa/sub", true, false, renderer); err != nil {
+		t.Fatalf("runNamespaceFilesDelete() returned error: %v", err)
+	}
+
+	if len(deletedPaths) != 1 || deletedPaths[0] != "/qa/sub" {
+		t.Fatalf("expected exactly one DELETE for [/qa/sub], got %v", deletedPaths)
+	}
+
+	// The single request removes the subtree, but the report still names every
+	// path that went away.
+	for _, reported := range []string{"qa/sub/nested.py", "qa/sub"} {
+		if !strings.Contains(out.String(), reported) {
+			t.Errorf("expected %q in the delete report, got: %s", reported, out.String())
+		}
+	}
+}
+
+func TestRunNamespaceFilesDelete_SingleFileSendsSlashPrefixedPath(t *testing.T) {
+	var deletedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete:
+			deletedPaths = append(deletedPaths, r.URL.Query().Get("path"))
+			w.WriteHeader(http.StatusOK)
+		case strings.HasSuffix(r.URL.Path, "/files/stats"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"fileName":"hello.txt","type":"File","size":3}`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	renderer, err := NewRenderer("json", io.Discard)
+	if err != nil {
+		t.Fatalf("NewRenderer() returned error: %v", err)
+	}
+
+	if err := runNamespaceFilesDelete(newTestClient(t, server.URL), "qa.ns", "qa/hello.txt", false, false, renderer); err != nil {
+		t.Fatalf("runNamespaceFilesDelete() returned error: %v", err)
+	}
+
+	if len(deletedPaths) != 1 || deletedPaths[0] != "/qa/hello.txt" {
+		t.Fatalf("expected DELETE path [/qa/hello.txt], got %v", deletedPaths)
 	}
 }
 

--- a/src/cli/nsfiles_test.go
+++ b/src/cli/nsfiles_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -402,6 +403,58 @@ func TestRunNamespaceFilesDelete_RecursiveIssuesOneDirectoryDelete(t *testing.T)
 	for _, reported := range []string{"qa/sub/nested.py", "qa/sub"} {
 		if !strings.Contains(out.String(), reported) {
 			t.Errorf("expected %q in the delete report, got: %s", reported, out.String())
+		}
+	}
+}
+
+// A recursive delete is one request, so a failure is one failure — however many
+// paths the report names.
+func TestRunNamespaceFilesDelete_RecursiveFailureCountsOnce(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodDelete:
+			w.WriteHeader(http.StatusInternalServerError)
+		case strings.HasSuffix(r.URL.Path, "/files/stats"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"fileName":"sub","type":"Directory","size":0}`))
+		case strings.HasSuffix(r.URL.Path, "/files/directory"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[{"fileName":"a.py","type":"File","size":3},{"fileName":"b.py","type":"File","size":3}]`))
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var out bytes.Buffer
+	renderer, err := NewRenderer("json", &out)
+	if err != nil {
+		t.Fatalf("NewRenderer() returned error: %v", err)
+	}
+
+	err = runNamespaceFilesDelete(newTestClient(t, server.URL), "qa.ns", "/qa/sub", true, false, renderer)
+	if err == nil {
+		t.Fatal("expected an error when the DELETE fails")
+	}
+	if !strings.Contains(err.Error(), "1 error(s)") {
+		t.Errorf("expected the summary to report 1 error, got: %v", err)
+	}
+
+	// Every reported row still carries the failure, so the report stays useful.
+	var summary namespaceFileDeleteSummary
+	if err := json.Unmarshal(out.Bytes(), &summary); err != nil {
+		t.Fatalf("could not decode the delete report: %v (%s)", err, out.String())
+	}
+	if len(summary.Results) != 3 {
+		t.Fatalf("expected 3 reported rows, got %d: %s", len(summary.Results), out.String())
+	}
+	for _, result := range summary.Results {
+		if result.Success {
+			t.Errorf("expected row %q to be marked failed", result.Path)
+		}
+		if result.Error == "" {
+			t.Errorf("expected row %q to carry the error", result.Path)
 		}
 	}
 }

--- a/src/cli/nsfiles_test.go
+++ b/src/cli/nsfiles_test.go
@@ -405,11 +405,22 @@ func TestRunNamespaceFilesDelete_RecursiveIssuesOneDirectoryDelete(t *testing.T)
 			t.Errorf("expected %q in the delete report, got: %s", reported, out.String())
 		}
 	}
+
+	// The report is path-shaped: on success every enumerated path counts as
+	// deleted.
+	var summary namespaceFileDeleteSummary
+	if err := json.Unmarshal(out.Bytes(), &summary); err != nil {
+		t.Fatalf("could not decode the delete report: %v (%s)", err, out.String())
+	}
+	if summary.Total != 2 || summary.Success != 2 || summary.Failed != 0 {
+		t.Errorf("expected total 2 / success 2 / failed 0, got total %d / success %d / failed %d", summary.Total, summary.Success, summary.Failed)
+	}
 }
 
-// A recursive delete is one request, so a failure is one failure — however many
-// paths the report names.
-func TestRunNamespaceFilesDelete_RecursiveFailureCountsOnce(t *testing.T) {
+// The delete report is path-shaped and all-or-nothing: when the single DELETE
+// fails, every enumerated path is reported as not deleted and the returned
+// error counts the same paths.
+func TestRunNamespaceFilesDelete_RecursiveFailureIsConsistentAcrossReportAndError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodDelete:
@@ -437,17 +448,20 @@ func TestRunNamespaceFilesDelete_RecursiveFailureCountsOnce(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error when the DELETE fails")
 	}
-	if !strings.Contains(err.Error(), "1 error(s)") {
-		t.Errorf("expected the summary to report 1 error, got: %v", err)
+	if !strings.Contains(err.Error(), "3 error(s)") {
+		t.Errorf("expected the error to count the 3 undeleted paths, got: %v", err)
 	}
 
 	// Every reported row still carries the failure, so the report stays useful.
 	var summary namespaceFileDeleteSummary
-	if err := json.Unmarshal(out.Bytes(), &summary); err != nil {
-		t.Fatalf("could not decode the delete report: %v (%s)", err, out.String())
+	if jsonErr := json.Unmarshal(out.Bytes(), &summary); jsonErr != nil {
+		t.Fatalf("could not decode the delete report: %v (%s)", jsonErr, out.String())
 	}
 	if len(summary.Results) != 3 {
 		t.Fatalf("expected 3 reported rows, got %d: %s", len(summary.Results), out.String())
+	}
+	if summary.Total != 3 || summary.Success != 0 || summary.Failed != 3 {
+		t.Errorf("expected total 3 / success 0 / failed 3, got total %d / success %d / failed %d", summary.Total, summary.Success, summary.Failed)
 	}
 	for _, result := range summary.Results {
 		if result.Success {


### PR DESCRIPTION
## Summary

`kestractl nsfiles delete <ns> /dir/sub --recursive` deleted every file under `/dir`, not just `/dir/sub`. Reproduced locally on Kestra EE **2.0.0-rc13** and **1.3.35**.

## Root cause

Not the leading slash. The delete path enumerated the subtree and issued **one DELETE per path, deepest first**:

```
DELETE /files?path=qa%2Fsub%2Fnested.py   200
DELETE /files?path=qa%2Fsub               200   <- this one wipes /qa
```

Two server behaviours combine:

1. A directory is pruned as soon as its last child is removed. After the first DELETE, `qa/sub` no longer exists.
2. `DELETE /files?path=<missing path>` returns **200** and deletes the **parent** directory.

Verified with raw curl on both versions:

```
# /t130d contains keep.txt only
DELETE .../files?path=%2Ft130d%2Fnope   -> 200
GET    .../files/directory?path=%2Ft130d -> 404 "Directory not found: /t130d"
```

So the second DELETE — a well-formed request for a path the client had just caused to disappear — took the parent with it. A single DELETE on an existing directory was always correct and recursive:

```
# /t130b contains keep.txt and sub/x.txt
DELETE .../files?path=%2Ft130b%2Fsub    -> 200
GET    .../files/directory?path=%2Ft130b -> [keep.txt]   # sibling intact
```

## Fix

`runNamespaceFilesDelete` now issues **exactly one** DELETE, on the target path. The enumerated subtree is kept only to build the report, so `--output json` fields, the table rows, and the `N path(s) deleted successfully` line are unchanged.

`deleteNamespaceFilePath` also sends the path slash-prefixed, so the server resolves it absolutely. That is not what fixed this bug, but given that a DELETE which misses its target destroys the parent rather than failing, sending an unambiguous path is cheap insurance — and the issue reporter saw the slash-less form wipe the parent on 1.3.37.

Scope check: the only other `deleteNamespaceFilePath` caller (upload with `--override`) is already guarded by an existence check, so it can never issue a DELETE for a missing path.

## Tests

Unit (TDD — written first, confirmed failing with the pre-fix two slash-less DELETEs):

- `TestRunNamespaceFilesDelete_RecursiveIssuesOneDirectoryDelete` — asserts exactly one DELETE for `/qa/sub`, and that the report still names both paths.
- `TestRunNamespaceFilesDelete_SingleFileSendsSlashPrefixedPath`

```
go build -o kestractl .        PASS
go test ./src/...              PASS
go vet ./src/...               PASS
gofmt -l src/cli/nsfiles*.go   clean
```

(`gofmt -l src/` also flags `src/cli/apps.go` and `src/cli/test_suites.go`; both are pre-existing on `main` and untouched here.)

E2E — `TestNsfilesDeleteRecursive_keepsSiblings` in `e2e_tests/nsfiles_usecases_test.go`: uploads `<dir>/keep.txt` and `<dir>/sub/x.txt`, deletes `<dir>/sub --recursive`, asserts the nested file is gone and `keep.txt` still reads back.

```
cd e2e_tests && go vet ./...                          PASS
cd e2e_tests && go test ./... -run TestNsfiles        PASS  (vs local EE 2.0.0-rc13)
```

Also reproduced and re-verified by hand against **1.3.35** (the e2e suite hard-codes `localhost:9801`, so the 1.3 run was manual):

```
nsfiles delete system t130h/sub --recursive --verbose
  -> single DELETE ...files?path=%2Ft130h%2Fsub
nsfiles list system --path t130h --recursive
  -> t130h/keep.txt   # survived
```

Not verified: 1.3.37 and 2.0.0-rc14 exactly as reported in the issue — the local instances available were 1.3.35 and 2.0.0-rc13. The mechanism is identical on both of those, and the fix removes the offending request entirely rather than relying on a version-specific server behaviour.

## Note for the server team

Worth filing upstream independently of this client fix: `DELETE /api/v1/{tenant}/namespaces/{ns}/files?path=<missing>` returning 200 and deleting the parent directory is a data-loss primitive. Any client that races the empty-directory pruning can destroy an unrelated subtree. It should 404.

Fixes #130