### PR TITLE
fix(logs): send the level operation the server accepts on logs search

### DIFF
--- a/e2e_tests/logs_usecases_test.go
+++ b/e2e_tests/logs_usecases_test.go
@@ -1,0 +1,94 @@
+package e2e_tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const logsTestNamespace = "e2e.logs"
+
+// TestLogs_searchMinLevel covers #132: `logs search --min-level` sent
+// filters[level][EQUALS], which Kestra 2.0 rejects with
+// "Operation EQUALS is not supported for field LEVEL". The two server lines
+// accept different operations on that field and each 400s the other's, so this
+// runs on both halves of the version matrix and is the assertion that neither
+// regresses.
+//
+// The subject is a flow that logs one line per level, so "minimum level" has an
+// observable meaning: searching from WARN up must return the WARN and ERROR
+// lines and never the INFO one.
+func TestLogs_searchMinLevel(t *testing.T) {
+	marker := "kestractl-e2e-minlevel-" + randomId()
+	flowID := "e2e-logs-min-level-" + randomId()
+
+	deployLogLevelsFlow(t, flowID, marker)
+	runLogLevelsExecution(t, flowID)
+
+	// The log store is written asynchronously by the worker, so the search can
+	// legitimately be empty for a moment after the execution terminates.
+	var stdout string
+	require.Eventually(t, func() bool {
+		out, stderr, err := RunAuthenticatedCliCmd(t,
+			"logs", "search", "-n", logsTestNamespace, "-q", marker, "--min-level", "WARN")
+		if err != nil {
+			t.Logf("logs search failed, retrying\nstdout: %s\nstderr: %s", out, stderr)
+			return false
+		}
+		stdout = out
+		return strings.Contains(out, marker+"-warn") && strings.Contains(out, marker+"-error")
+	}, 60*time.Second, 2*time.Second, "expected the WARN and ERROR lines in the search output")
+
+	require.NotContains(t, stdout, marker+"-info",
+		"--min-level WARN must not return the INFO line:\n%s", stdout)
+	require.Contains(t, stdout, "WARN")
+	require.Contains(t, stdout, "ERROR")
+}
+
+// deployLogLevelsFlow deploys a flow that logs one message per level, each
+// tagged with marker so the search can find exactly these lines. It uses only
+// io.kestra.plugin.core.log.Log, which the plugin-less image this suite runs
+// against ships, and --override so a rerun against a persistent instance is
+// not a hard failure.
+func deployLogLevelsFlow(t *testing.T, flowID, marker string) {
+	t.Helper()
+
+	source := fmt.Sprintf(`id: %s
+namespace: %s
+tasks:
+  - id: log-info
+    type: io.kestra.plugin.core.log.Log
+    level: INFO
+    message: %s-info
+  - id: log-warn
+    type: io.kestra.plugin.core.log.Log
+    level: WARN
+    message: %s-warn
+  - id: log-error
+    type: io.kestra.plugin.core.log.Log
+    level: ERROR
+    message: %s-error
+`, flowID, logsTestNamespace, marker, marker, marker)
+
+	path := filepath.Join(t.TempDir(), flowID+".yml")
+	require.NoError(t, os.WriteFile(path, []byte(source), 0o600))
+
+	stdout, stderr, err := RunAuthenticatedCliCmd(t, "flows", "deploy", path, "--override")
+	require.NoError(t, err, "deploy failed\nstdout: %s\nstderr: %s", stdout, stderr)
+	require.Contains(t, stdout, "1 flow(s) deployed successfully")
+}
+
+// runLogLevelsExecution runs the flow to completion. A Log task at level ERROR
+// does not fail the flow, so the execution is expected to succeed.
+func runLogLevelsExecution(t *testing.T, flowID string) {
+	t.Helper()
+
+	stdout, stderr, err := RunAuthenticatedCliCmd(t, "executions", "run", logsTestNamespace, flowID, "--wait")
+	require.NoError(t, err, "run failed\nstdout: %s\nstderr: %s", stdout, stderr)
+	require.Contains(t, stdout, "State: SUCCESS", "expected a terminated execution:\n%s", stdout)
+}

--- a/src/cli/logs.go
+++ b/src/cli/logs.go
@@ -244,7 +244,7 @@ Results are paginated. Use --page and --size to navigate larger result sets.`,
 				return err
 			}
 
-			filters := buildLogSearchFilters(query, namespace, flowID, triggerID, minLevel)
+			filters := buildLogSearchFilters(client, query, namespace, flowID, triggerID, minLevel)
 			return runLogsSearch(client, filters, page, size, sort, renderer)
 		},
 	}
@@ -261,27 +261,45 @@ Results are paginated. Use --page and --size to navigate larger result sets.`,
 	return cmd
 }
 
-// buildLogSearchFilters assembles EQUALS SearchFilters for a log search from
-// the optional query, namespace, flow, trigger, and level selectors.
-func buildLogSearchFilters(query, namespace, flowID, triggerID, minLevel string) []kestra.SearchFilter {
+// buildLogSearchFilters assembles the SearchFilters for a log search from the
+// optional query, namespace, flow, trigger, and level selectors. Every field is
+// matched with EQUALS except the level, whose accepted operation differs by
+// server era (see minLevelSearchOp).
+func buildLogSearchFilters(client *Client, query, namespace, flowID, triggerID, minLevel string) []kestra.SearchFilter {
 	filters := make([]kestra.SearchFilter, 0, 5)
-	add := func(field kestra.SearchFilterField, value string) {
+	add := func(field kestra.SearchFilterField, op kestra.SearchFilterOp, value string) {
 		if value != "" {
 			filters = append(filters, kestra.SearchFilter{
 				Field:     field,
-				Operation: kestra.OpEquals,
+				Operation: op,
 				Value:     value,
 			})
 		}
 	}
-	add(kestra.FilterQuery, query)
-	add(kestra.FilterNamespace, namespace)
-	add(kestra.FilterFlowId, flowID)
-	add(kestra.FilterTriggerId, triggerID)
-	if minLevel != "" {
-		add(kestra.FilterMinLevel, strings.ToUpper(minLevel))
-	}
+	add(kestra.FilterQuery, kestra.OpEquals, query)
+	add(kestra.FilterNamespace, kestra.OpEquals, namespace)
+	add(kestra.FilterFlowId, kestra.OpEquals, flowID)
+	add(kestra.FilterTriggerId, kestra.OpEquals, triggerID)
+	add(kestra.FilterMinLevel, minLevelSearchOp(client), strings.ToUpper(minLevel))
 	return filters
+}
+
+// minLevelSearchOp returns the operation the log-search endpoint accepts on the
+// level field. The two server lines disagree, and each rejects the other's
+// operation with a 400, so this cannot be a single value:
+//
+//   - Kestra 2.0 exposes the field as LEVEL and accepts only
+//     GREATER_THAN_OR_EQUAL_TO / LESS_THAN_OR_EQUAL_TO / IN / NOT_IN.
+//   - Kestra 1.x exposes it as MIN_LEVEL — already a minimum server-side — and
+//     accepts only EQUALS / NOT_EQUALS.
+//
+// An unknown server (develop build, unreachable /configs) gets the 2.0
+// operation, matching the rest of the compat layer's default.
+func minLevelSearchOp(client *Client) kestra.SearchFilterOp {
+	if client != nil && client.isLegacyServer() {
+		return kestra.OpEquals
+	}
+	return kestra.OpGreaterThanOrEqualTo
 }
 
 func runLogsSearch(client *Client, filters []kestra.SearchFilter, page, size int32, sort []string, renderer *Renderer) error {

--- a/src/cli/logs_test.go
+++ b/src/cli/logs_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -143,21 +144,26 @@ func TestLogsDownloadCommand_ClientError(t *testing.T) {
 
 func TestBuildLogSearchFilters(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		filters := buildLogSearchFilters("", "", "", "", "")
+		filters := buildLogSearchFilters(nil, "", "", "", "", "")
 		if len(filters) != 0 {
 			t.Fatalf("expected no filters, got %d", len(filters))
 		}
 	})
 
 	t.Run("all filters with upper-cased level", func(t *testing.T) {
-		filters := buildLogSearchFilters("boom", "my.ns", "my-flow", "trg-1", "warn")
+		filters := buildLogSearchFilters(nil, "boom", "my.ns", "my-flow", "trg-1", "warn")
 		if len(filters) != 5 {
 			t.Fatalf("expected 5 filters, got %d", len(filters))
 		}
 		got := map[kestra.SearchFilterField]any{}
 		for _, f := range filters {
-			if f.Operation != kestra.OpEquals {
-				t.Errorf("expected EQUALS op, got %v", f.Operation)
+			wantOp := kestra.OpEquals
+			if f.Field == kestra.FilterMinLevel {
+				// LEVEL is a minimum, and 2.0 rejects EQUALS on it.
+				wantOp = kestra.OpGreaterThanOrEqualTo
+			}
+			if f.Operation != wantOp {
+				t.Errorf("field %v: expected op %v, got %v", f.Field, wantOp, f.Operation)
 			}
 			got[f.Field] = f.Value
 		}
@@ -245,4 +251,56 @@ func TestRunLogsList_LevelHasNoQuotes(t *testing.T) {
 			t.Errorf("table output missing level:\n%s", out)
 		}
 	})
+}
+
+// The two server lines accept different operations on the level field, and
+// each answers the other's with a 400 (#132):
+//
+//   - 2.0: "Operation EQUALS is not supported for field LEVEL. Supported
+//     operations are GREATER_THAN_OR_EQUAL_TO, LESS_THAN_OR_EQUAL_TO, IN, NOT_IN"
+//   - 1.3: "Operation GREATER_THAN_OR_EQUAL_TO is not supported for field
+//     MIN_LEVEL. Supported operations are EQUALS, NOT_EQUALS"
+func TestRunLogsSearch_MinLevelOperationPerServerEra(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		version string
+		wantOp  string
+		badOp   string
+	}{
+		{name: "kestra 2.0", version: "2.0.0-rc13", wantOp: "GREATER_THAN_OR_EQUAL_TO", badOp: "EQUALS"},
+		{name: "kestra 1.3", version: "1.3.35", wantOp: "EQUALS", badOp: "GREATER_THAN_OR_EQUAL_TO"},
+		// A develop build gets the 2.0 shape, like the rest of the compat layer.
+		{name: "unknown version", version: "develop", wantOp: "GREATER_THAN_OR_EQUAL_TO", badOp: "EQUALS"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var rawQuery string
+			server := httptest.NewServer(versionHandler(tt.version, func(w http.ResponseWriter, r *http.Request) {
+				rawQuery = r.URL.RawQuery
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"total":0,"results":[]}`))
+			}))
+			t.Cleanup(server.Close)
+
+			var buf bytes.Buffer
+			client := newTestClient(t, server.URL)
+			filters := buildLogSearchFilters(client, "intentional", "qa.ns", "", "", "ERROR")
+			if err := runLogsSearch(client, filters, 1, 50, nil, newTableRenderer(&buf)); err != nil {
+				t.Fatalf("runLogsSearch error: %v", err)
+			}
+
+			decoded, err := url.QueryUnescape(rawQuery)
+			if err != nil {
+				t.Fatalf("unescape query %q: %v", rawQuery, err)
+			}
+			if want := "filters[level][" + tt.wantOp + "]=ERROR"; !strings.Contains(decoded, want) {
+				t.Errorf("expected %q, got query: %s", want, decoded)
+			}
+			if bad := "filters[level][" + tt.badOp + "]"; strings.Contains(decoded, bad) {
+				t.Errorf("level must not use %q on this server, got query: %s", bad, decoded)
+			}
+			if !strings.Contains(decoded, "filters[namespace][EQUALS]=qa.ns") {
+				t.Errorf("expected namespace EQUALS filter, got query: %s", decoded)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

`kestractl logs search --min-level ERROR` failed on Kestra 2.0 with:

```
Error: API error: Invalid query filters: Provided query filters are invalid: Operation EQUALS is not supported for field LEVEL. Supported operations are GREATER_THAN_OR_EQUAL_TO, LESS_THAN_OR_EQUAL_TO, IN, NOT_IN
```

The same command worked on 1.3, and dropping `--min-level` worked on both.

## Root cause

`buildLogSearchFilters` in `src/cli/logs.go` built every filter with `EQUALS`, including the level, so the request went out as
`filters[level][EQUALS]=ERROR`. Kestra 2.0 renamed the field to `LEVEL` and restricted its operations to
`GREATER_THAN_OR_EQUAL_TO`, `LESS_THAN_OR_EQUAL_TO`, `IN`, `NOT_IN`, rejecting `EQUALS` outright.

## Fix

The obvious swap to `GREATER_THAN_OR_EQUAL_TO` unconditionally would have broken 1.3, so the operation is now picked from the
existing `serverEra` probe (`Client.isLegacyServer`) in a new `minLevelSearchOp`:

- Kestra 2.0 and later, and unknown versions (develop builds, unreachable `/configs`) → `GREATER_THAN_OR_EQUAL_TO`
- Kestra 1.x → `EQUALS`, which is what its `MIN_LEVEL` field accepts

Defaulting an unknown server to the 2.0 operation matches the rest of the compat layer.

Only `logs search` was affected. Checked the other level-carrying commands:

- `logs list` / `logs download` / `logs follow` go through the SDK, whose `logExecutionFilters` already uses
  `OpGreaterThanOrEqualTo` for `FilterMinLevel`
- `logs delete` and `apps logs` still send the legacy scalar `minLevel` query param, not a filter

## 1.3 compatibility evidence

Verified live against two local Docker EE instances — 2.0.0-rc13 (`:9801`) and 1.3.35 (`:9802`). **1.3 rejects
`GREATER_THAN_OR_EQUAL_TO`**, which is why the fix is gated rather than a plain swap:

| server | `filters[level][EQUALS]=ERROR` | `filters[level][GREATER_THAN_OR_EQUAL_TO]=ERROR` |
| --- | --- | --- |
| 2.0.0-rc13 | 400 `Operation EQUALS is not supported for field LEVEL` | 200, rows returned |
| 1.3.35 | 200, rows returned | 400 `Operation GREATER_THAN_OR_EQUAL_TO is not supported for field MIN_LEVEL. Supported operations are EQUALS, NOT_EQUALS` |

`--min-level WARN` on 1.3.35 returns both `WARN` and `ERROR` rows, confirming its `MIN_LEVEL`/`EQUALS` really is minimum
semantics, so both server lines agree on the meaning of the flag and the e2e assertions hold on either.

With the patched binary, `logs search -n qa.kestractl --min-level ERROR` returns rows on **both** 9801 and 9802.

## Tests

Written failing-first: the new unit test reproduced the issue's exact query string
(`filters[level][EQUALS]=ERROR&filters[namespace][EQUALS]=qa.ns&filters[q][EQUALS]=intentional&page=1&size=50`) before the fix.

- `src/cli/logs_test.go`: `TestRunLogsSearch_MinLevelOperationPerServerEra` asserts the URL-decoded request query per era
  (2.0 → `GREATER_THAN_OR_EQUAL_TO`, 1.3 → `EQUALS`, unknown → `GREATER_THAN_OR_EQUAL_TO`), and that the rejected operation is
  absent in each case. `TestBuildLogSearchFilters` updated for the new signature and per-field operation.
- `e2e_tests/logs_usecases_test.go` (new): `TestLogs_searchMinLevel` deploys a flow logging one line per level with a unique
  marker, runs it with `--wait`, then asserts `logs search --min-level WARN` returns the WARN and ERROR lines and not the INFO
  one. Wrapped in `require.Eventually` because the log store is written asynchronously.

Commands run:

- `go build -o kestractl .` — ok
- `go test ./src/...` — ok
- `go vet ./src/...` — ok
- `gofmt -l src/cli/logs.go src/cli/logs_test.go` — clean (`src/cli/apps.go` and `src/cli/test_suites.go` are unformatted on
  `main` already and were left alone)
- `cd e2e_tests && go vet ./...` — ok
- `cd e2e_tests && go test -run TestLogs_searchMinLevel -v ./...` against 2.0.0-rc13 — **PASS (6.05s)**

Not verified: the e2e test was not executed against 1.3.35, because `e2e_tests/utils_test.go` hard-codes `:9801`. The 1.3 half
of the behaviour was verified with the patched CLI and raw API calls against the 1.3.35 instance instead (table above); CI's
version matrix will run it.

Fixes #132
