### PR TITLE
fix(namespaces): decode inherited variables from the flat server shape

### DIFF
--- a/e2e_tests/namespaces_usecases_test.go
+++ b/e2e_tests/namespaces_usecases_test.go
@@ -2,8 +2,11 @@ package e2e_tests
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNamespacesList_system(t *testing.T) {
@@ -28,4 +31,47 @@ func TestNamespacesList_system_json(t *testing.T) {
 	require.NoError(t, err, "json from --output json should be valid")
 	require.NotEmpty(t, parsedJson)
 	require.Equal(t, "system", parsedJson[0]["id"])
+}
+
+// Both Kestra 1.3 and 2.0 answer /inherited-variables with a flat
+// {variable: value} map, which the SDK's map-of-maps type cannot decode as soon
+// as one value is a scalar; the command used to fail outright on 2.0. A value
+// above 2^53 must also keep every digit rather than being rendered through
+// float64. See https://github.com/kestra-io/kestractl/issues/128.
+func TestNamespacesInheritedVariables_flatScalarsAndLargeIntegers(t *testing.T) {
+	parent := "e2e-inherited-vars-" + randomId()
+	child := parent + ".child"
+
+	variablesFile := filepath.Join(t.TempDir(), "variables.yml")
+	require.NoError(t, os.WriteFile(variablesFile, []byte("big: 1725000000000000001\nname: hello\nnested:\n  a: 1\n"), 0o600))
+
+	_, stderr, err := RunAuthenticatedCliCmd(t, "namespaces", "create", parent, "--variables-file", variablesFile)
+	require.NoError(t, err, "stderr: %s", stderr)
+	t.Cleanup(func() { _, _, _ = RunAuthenticatedCliCmd(t, "namespaces", "delete", parent) })
+
+	_, stderr, err = RunAuthenticatedCliCmd(t, "namespaces", "create", child)
+	require.NoError(t, err, "stderr: %s", stderr)
+	t.Cleanup(func() { _, _, _ = RunAuthenticatedCliCmd(t, "namespaces", "delete", child) })
+
+	stdout, stderr, err := RunAuthenticatedCliCmd(t, "namespaces", "inherited-variables", child)
+	require.NoError(t, err, "stderr: %s", stderr)
+	require.Contains(t, stdout, "hello")
+	require.Contains(t, stdout, "1725000000000000001", "a large integer must not be rendered through float64")
+	require.NotContains(t, stdout, "e+18")
+
+	stdout, stderr, err = RunAuthenticatedCliCmd(t, "namespaces", "inherited-variables", child, "--output", "json")
+	require.NoError(t, err, "stderr: %s", stderr)
+
+	var rows []map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &rows), "json from --output json should be valid")
+
+	values := map[string]interface{}{}
+	for _, row := range rows {
+		key, _ := row["key"].(string)
+		values[key] = row["value"]
+		require.Equal(t, child, row["namespace"])
+	}
+	require.Equal(t, "1725000000000000001", values["big"])
+	require.Equal(t, "hello", values["name"])
+	require.Equal(t, `{"a":1}`, values["nested"])
 }

--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -265,6 +267,82 @@ func normalizeHost(host string) string {
 	}
 
 	return normalized
+}
+
+// doRawRequest issues a request the generated SDK cannot express usefully and
+// returns the raw response body.
+//
+// Two kinds of endpoint need it: ones the SDK builds a URL for that the server
+// rejects (the path-less webhook, whose only SDK helpers append a trailing
+// segment answered with 404) and ones the SDK mistypes, where the typed decode
+// fails or silently rounds the payload before kestractl sees it (namespace
+// inherited variables — see issue #128). Callers decode the body themselves.
+//
+// The request reuses the SDK's resolved host, HTTP client (so the compat.go
+// shims still apply), default headers, and context-based authentication.
+// segments are the path below /api/v1/{tenant}/ and are escaped here, so a
+// namespace or flow id containing a slash or space cannot break out of its
+// position.
+//
+// Known limitation: --verbose is wired to the SDK's own debug logger inside
+// callAPI, so a request issued here does not appear in the verbose dump. That
+// has always been true of the webhook path; fixing it belongs in the shared
+// transport, not in each caller.
+func (c *Client) doRawRequest(method string, segments ...string) ([]byte, error) {
+	cfg := c.API.GetConfig()
+
+	base := ""
+	if len(cfg.Servers) > 0 {
+		base = cfg.Servers[0].URL
+	}
+	if base == "" {
+		base = cfg.Scheme + "://" + cfg.Host
+	}
+	base = strings.TrimRight(base, "/")
+
+	escaped := make([]string, 0, len(segments)+1)
+	escaped = append(escaped, url.PathEscape(c.Tenant))
+	for _, segment := range segments {
+		escaped = append(escaped, url.PathEscape(segment))
+	}
+	endpoint := base + "/api/v1/" + strings.Join(escaped, "/")
+
+	req, err := http.NewRequestWithContext(c.Ctx, method, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	// Reuse the auth the SDK stored on the context.
+	if auth, ok := c.Ctx.Value(kestra.ContextBasicAuth).(kestra.BasicAuth); ok {
+		req.SetBasicAuth(auth.UserName, auth.Password)
+	}
+	if token, ok := c.Ctx.Value(kestra.ContextAccessToken).(string); ok {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	for h, v := range cfg.DefaultHeader {
+		req.Header.Set(h, v)
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, formatErrorBody(body, fmt.Sprintf("status %d", resp.StatusCode))
+	}
+	return body, nil
 }
 
 // formatSDKError extracts a user-friendly message from SDK errors. It handles

--- a/src/cli/client.go
+++ b/src/cli/client.go
@@ -284,10 +284,8 @@ func normalizeHost(host string) string {
 // namespace or flow id containing a slash or space cannot break out of its
 // position.
 //
-// Known limitation: --verbose is wired to the SDK's own debug logger inside
-// callAPI, so a request issued here does not appear in the verbose dump. That
-// has always been true of the webhook path; fixing it belongs in the shared
-// transport, not in each caller.
+// Because that HTTP client is the shared compat transport, a request issued here
+// gets the same --verbose masked dump as any SDK call.
 func (c *Client) doRawRequest(method string, segments ...string) ([]byte, error) {
 	cfg := c.API.GetConfig()
 

--- a/src/cli/client_test.go
+++ b/src/cli/client_test.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -13,6 +16,128 @@ import (
 	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/spf13/viper"
 )
+
+// doRawRequest is the shared path for the endpoints the SDK cannot express
+// (the path-less webhook) or mistypes (namespace inherited variables), so its
+// URL building, auth and error handling are covered here rather than only
+// transitively through those two callers.
+func TestClientDoRawRequest(t *testing.T) {
+	t.Run("builds the tenant path and returns the body", func(t *testing.T) {
+		var gotPath, gotMethod, gotAccept string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath, gotMethod, gotAccept = r.URL.Path, r.Method, r.Header.Get("Accept")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}))
+		t.Cleanup(server.Close)
+
+		body, err := newTestClient(t, server.URL).doRawRequest(http.MethodGet, "namespaces", "my.namespace", "inherited-variables")
+		if err != nil {
+			t.Fatalf("doRawRequest error: %v", err)
+		}
+		if string(body) != `{"ok":true}` {
+			t.Fatalf("unexpected body: %s", body)
+		}
+		if gotPath != "/api/v1/main/namespaces/my.namespace/inherited-variables" {
+			t.Fatalf("unexpected path: %s", gotPath)
+		}
+		if gotMethod != http.MethodGet || gotAccept != "application/json" {
+			t.Fatalf("unexpected method/accept: %s %s", gotMethod, gotAccept)
+		}
+	})
+
+	t.Run("escapes path segments", func(t *testing.T) {
+		var gotRawPath string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotRawPath = r.URL.EscapedPath()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		t.Cleanup(server.Close)
+
+		if _, err := newTestClient(t, server.URL).doRawRequest(http.MethodGet, "namespaces", "a b/c"); err != nil {
+			t.Fatalf("doRawRequest error: %v", err)
+		}
+		// A segment containing a slash must not add a path element.
+		if gotRawPath != "/api/v1/main/namespaces/a%20b%2Fc" {
+			t.Fatalf("unexpected escaped path: %s", gotRawPath)
+		}
+	})
+
+	t.Run("sends the token from the context", func(t *testing.T) {
+		var gotAuth string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		t.Cleanup(server.Close)
+
+		client := newTestClient(t, server.URL)
+		client.Ctx = context.WithValue(client.Ctx, kestra.ContextAccessToken, "s3cret-token")
+
+		if _, err := client.doRawRequest(http.MethodGet, "namespaces"); err != nil {
+			t.Fatalf("doRawRequest error: %v", err)
+		}
+		if gotAuth != "Bearer s3cret-token" {
+			t.Fatalf("unexpected Authorization header: %q", gotAuth)
+		}
+	})
+
+	t.Run("sends basic auth from the context", func(t *testing.T) {
+		var gotUser string
+		var gotOK bool
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotUser, _, gotOK = r.BasicAuth()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		t.Cleanup(server.Close)
+
+		client := newTestClient(t, server.URL)
+		client.Ctx = context.WithValue(client.Ctx, kestra.ContextBasicAuth, kestra.BasicAuth{UserName: "root@root.com", Password: "pw"})
+
+		if _, err := client.doRawRequest(http.MethodGet, "namespaces"); err != nil {
+			t.Fatalf("doRawRequest error: %v", err)
+		}
+		if !gotOK || gotUser != "root@root.com" {
+			t.Fatalf("expected basic auth to be sent, got user %q (ok=%v)", gotUser, gotOK)
+		}
+	})
+
+	t.Run("formats the error body on 404", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"message":"namespace not found"}`))
+		}))
+		t.Cleanup(server.Close)
+
+		_, err := newTestClient(t, server.URL).doRawRequest(http.MethodGet, "namespaces", "missing")
+		if err == nil {
+			t.Fatal("expected an error for a 404 response")
+		}
+		if !strings.Contains(err.Error(), "namespace not found") {
+			t.Fatalf("expected the server message in the error, got: %v", err)
+		}
+	})
+
+	t.Run("falls back to the status when the body carries no message", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`boom`))
+		}))
+		t.Cleanup(server.Close)
+
+		_, err := newTestClient(t, server.URL).doRawRequest(http.MethodGet, "namespaces")
+		if err == nil {
+			t.Fatal("expected an error for a 500 response")
+		}
+		if !strings.Contains(err.Error(), "status 500") {
+			t.Fatalf("expected the status in the error, got: %v", err)
+		}
+	})
+}
 
 func setGenericOpenAPIErrorBody(err *kestra.GenericOpenAPIError, body []byte) {
 	field := reflect.ValueOf(err).Elem().FieldByName("body")

--- a/src/cli/client_test.go
+++ b/src/cli/client_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -567,5 +568,48 @@ func TestIsProblemDocument_StatusNumberForms(t *testing.T) {
 				t.Fatal("expected a rendered problem message")
 			}
 		})
+	}
+}
+
+// doRawRequest sends through the shared compat transport, so --verbose dumps it
+// like any SDK call — with the same header masking (issue #119).
+func TestDoRawRequest_VerboseDumpGoesThroughCompatTransport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var out bytes.Buffer
+	httpClient, transport := newCompatHTTPClient()
+	transport.verbose = true
+	transport.logger = &out
+
+	cfg := kestra.NewConfiguration()
+	cfg.Servers = kestra.ServerConfigurations{{URL: server.URL}}
+	cfg.HTTPClient = httpClient
+	client := &Client{
+		API:    kestra.NewAPIClient(cfg),
+		Ctx:    context.WithValue(context.Background(), kestra.ContextAccessToken, "faketoken123"),
+		Tenant: "main",
+	}
+	transport.era = client.serverEra
+
+	if _, err := client.doRawRequest(http.MethodGet, "namespaces", "my.namespace", "inherited-variables"); err != nil {
+		t.Fatalf("doRawRequest error: %v", err)
+	}
+
+	dump := out.String()
+	for _, want := range []string{
+		"> GET " + server.URL + "/api/v1/main/namespaces/my.namespace/inherited-variables",
+		"< 200 OK",
+		`{"ok":true}`,
+	} {
+		if !strings.Contains(dump, want) {
+			t.Fatalf("expected %q in the verbose dump, got:\n%s", want, dump)
+		}
+	}
+	if strings.Contains(dump, "faketoken123") {
+		t.Fatalf("verbose dump leaked the token:\n%s", dump)
 	}
 }

--- a/src/cli/executions.go
+++ b/src/cli/executions.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -2359,62 +2357,12 @@ func webhookResponseRow(result *kestra.WebhookResponse) map[string]any {
 // triggerWebhookDirect issues a path-less webhook request with the given method.
 // The SDK only exposes *WebhookWithPath helpers for POST/PUT, which append a
 // trailing path segment the server rejects with 404, so we build the request
-// directly while reusing the SDK's configured host, default headers, and
-// context-based authentication.
+// directly (see Client.doRawRequest) while reusing the SDK's configured host,
+// default headers, and context-based authentication.
 func triggerWebhookDirect(client *Client, method, namespace, flowID, key string) (map[string]any, error) {
-	cfg := client.API.GetConfig()
-
-	base := ""
-	if len(cfg.Servers) > 0 {
-		base = cfg.Servers[0].URL
-	}
-	if base == "" {
-		base = cfg.Scheme + "://" + cfg.Host
-	}
-	base = strings.TrimRight(base, "/")
-
-	endpoint := fmt.Sprintf("%s/api/v1/%s/executions/webhook/%s/%s/%s",
-		base,
-		url.PathEscape(client.Tenant),
-		url.PathEscape(namespace),
-		url.PathEscape(flowID),
-		url.PathEscape(key),
-	)
-
-	req, err := http.NewRequestWithContext(client.Ctx, method, endpoint, nil)
+	body, err := client.doRawRequest(method, "executions", "webhook", namespace, flowID, key)
 	if err != nil {
 		return nil, err
-	}
-	req.Header.Set("Accept", "application/json")
-
-	// Reuse the auth the SDK stored on the context.
-	if auth, ok := client.Ctx.Value(kestra.ContextBasicAuth).(kestra.BasicAuth); ok {
-		req.SetBasicAuth(auth.UserName, auth.Password)
-	}
-	if token, ok := client.Ctx.Value(kestra.ContextAccessToken).(string); ok {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-	for h, v := range cfg.DefaultHeader {
-		req.Header.Set(h, v)
-	}
-
-	httpClient := cfg.HTTPClient
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read webhook response: %w", err)
-	}
-	if resp.StatusCode >= 400 {
-		return nil, formatErrorBody(body, fmt.Sprintf("status %d", resp.StatusCode))
 	}
 
 	result := map[string]any{}

--- a/src/cli/namespaces.go
+++ b/src/cli/namespaces.go
@@ -1,8 +1,14 @@
 package cli
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -563,9 +569,9 @@ func newNamespacesInheritedVariablesCommand() *cobra.Command {
 }
 
 func runNamespacesInheritedVariables(client *Client, id string, renderer *Renderer) error {
-	resp, _, err := client.API.NamespacesAPI.InheritedVariables(client.Ctx, id, client.Tenant).Execute()
+	variables, err := fetchInheritedVariables(client, id)
 	if err != nil {
-		return formatSDKError(err)
+		return err
 	}
 
 	type row struct {
@@ -574,11 +580,18 @@ func runNamespacesInheritedVariables(client *Client, id string, renderer *Render
 		Value     string `json:"value"`
 	}
 
-	var rows []row
-	for ns, vars := range resp {
-		for k, v := range vars {
-			rows = append(rows, row{Namespace: ns, Key: k, Value: fmt.Sprintf("%v", v)})
-		}
+	keys := make([]string, 0, len(variables))
+	for k := range variables {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	rows := make([]row, 0, len(keys))
+	for _, k := range keys {
+		// stringify keeps a json.Number's digits verbatim and renders a
+		// structured value as JSON; fmt.Sprintf("%v") turned a large integer
+		// into float notation and a map into Go's map[k:v] syntax.
+		rows = append(rows, row{Namespace: id, Key: k, Value: stringify(variables[k])})
 	}
 
 	jsonRows := make([]map[string]any, len(rows))
@@ -594,6 +607,101 @@ func runNamespacesInheritedVariables(client *Client, id string, renderer *Render
 		fmt.Fprintf(w, "\nTotal variables: %d\n", len(rows))
 		return nil
 	})
+}
+
+// fetchInheritedVariables reads a namespace's inherited variables with a direct
+// HTTP request instead of the SDK.
+//
+// The generated SDK types this endpoint's response as
+// map[string]map[string]interface{}, but both Kestra 1.3 and 2.0 answer with
+// the already-merged flat map of variable name to value — so any scalar value
+// fails the typed decode with "cannot unmarshal number into Go value of type
+// map[string]interface {}" and the command errors before rendering anything
+// (issue #128). Reading the body here also lets it be decoded with UseNumber,
+// which keeps integers above 2^53 exact rather than routing them through
+// float64.
+//
+// The URL mirrors the SDK's InheritedVariables endpoint, and the request reuses
+// the SDK's configured host, HTTP client, default headers and context-based
+// auth so the verbose dump and the 1.x compat shims still apply.
+func fetchInheritedVariables(client *Client, id string) (map[string]any, error) {
+	cfg := client.API.GetConfig()
+
+	base := ""
+	if len(cfg.Servers) > 0 {
+		base = cfg.Servers[0].URL
+	}
+	if base == "" {
+		base = cfg.Scheme + "://" + cfg.Host
+	}
+	base = strings.TrimRight(base, "/")
+
+	endpoint := fmt.Sprintf("%s/api/v1/%s/namespaces/%s/inherited-variables",
+		base,
+		url.PathEscape(client.Tenant),
+		url.PathEscape(id),
+	)
+
+	req, err := http.NewRequestWithContext(client.Ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	if auth, ok := client.Ctx.Value(kestra.ContextBasicAuth).(kestra.BasicAuth); ok {
+		req.SetBasicAuth(auth.UserName, auth.Password)
+	}
+	if token, ok := client.Ctx.Value(kestra.ContextAccessToken).(string); ok {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	for h, v := range cfg.DefaultHeader {
+		req.Header.Set(h, v)
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read inherited variables response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, formatErrorBody(body, resp.Status)
+	}
+
+	return parseInheritedVariables(body)
+}
+
+// parseInheritedVariables decodes an inherited-variables body into a flat map,
+// preserving number literals as json.Number.
+//
+// A response that still uses the nested {namespace: {variable: value}} shape the
+// SDK models decodes into this map too: the inner object lands as the value and
+// renders as JSON, which is lossless, rather than being rejected.
+func parseInheritedVariables(body []byte) (map[string]any, error) {
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(trimmed))
+	// UseNumber keeps a variable's digits verbatim: decoding into float64 would
+	// round anything above 2^53 on the way back out.
+	decoder.UseNumber()
+
+	var variables map[string]any
+	if err := decoder.Decode(&variables); err != nil {
+		return nil, fmt.Errorf("failed to parse inherited variables response: %w", err)
+	}
+	return variables, nil
 }
 
 func newNamespacesSearchCommand() *cobra.Command {

--- a/src/cli/namespaces.go
+++ b/src/cli/namespaces.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -621,62 +619,12 @@ func runNamespacesInheritedVariables(client *Client, id string, renderer *Render
 // which keeps integers above 2^53 exact rather than routing them through
 // float64.
 //
-// The URL mirrors the SDK's InheritedVariables endpoint, and the request reuses
-// the SDK's configured host, HTTP client, default headers and context-based
-// auth so the verbose dump and the 1.x compat shims still apply.
+// The path mirrors the SDK's InheritedVariables endpoint.
 func fetchInheritedVariables(client *Client, id string) (map[string]any, error) {
-	cfg := client.API.GetConfig()
-
-	base := ""
-	if len(cfg.Servers) > 0 {
-		base = cfg.Servers[0].URL
-	}
-	if base == "" {
-		base = cfg.Scheme + "://" + cfg.Host
-	}
-	base = strings.TrimRight(base, "/")
-
-	endpoint := fmt.Sprintf("%s/api/v1/%s/namespaces/%s/inherited-variables",
-		base,
-		url.PathEscape(client.Tenant),
-		url.PathEscape(id),
-	)
-
-	req, err := http.NewRequestWithContext(client.Ctx, http.MethodGet, endpoint, nil)
+	body, err := client.doRawRequest(http.MethodGet, "namespaces", id, "inherited-variables")
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Accept", "application/json")
-
-	if auth, ok := client.Ctx.Value(kestra.ContextBasicAuth).(kestra.BasicAuth); ok {
-		req.SetBasicAuth(auth.UserName, auth.Password)
-	}
-	if token, ok := client.Ctx.Value(kestra.ContextAccessToken).(string); ok {
-		req.Header.Set("Authorization", "Bearer "+token)
-	}
-	for h, v := range cfg.DefaultHeader {
-		req.Header.Set(h, v)
-	}
-
-	httpClient := cfg.HTTPClient
-	if httpClient == nil {
-		httpClient = http.DefaultClient
-	}
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read inherited variables response: %w", err)
-	}
-	if resp.StatusCode >= 400 {
-		return nil, formatErrorBody(body, resp.Status)
-	}
-
 	return parseInheritedVariables(body)
 }
 

--- a/src/cli/namespaces.go
+++ b/src/cli/namespaces.go
@@ -548,6 +548,12 @@ func newNamespacesInheritedVariablesCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inherited-variables <namespace_id>",
 		Short: "List inherited variables for a namespace.",
+		Long: `List inherited variables for a namespace.
+
+The server merges the inheritance chain before answering, so the NAMESPACE
+column (and the "namespace" JSON field) is the namespace that was queried, not
+the parent namespace that defined each variable — that information is not part
+of the response.`,
 		Example: `  kestractl namespaces inherited-variables my.namespace
   kestractl namespaces inherited-variables my.namespace --output json`,
 		Args: cobra.ExactArgs(1),
@@ -610,14 +616,17 @@ func runNamespacesInheritedVariables(client *Client, id string, renderer *Render
 // fetchInheritedVariables reads a namespace's inherited variables with a direct
 // HTTP request instead of the SDK.
 //
-// The generated SDK types this endpoint's response as
-// map[string]map[string]interface{}, but both Kestra 1.3 and 2.0 answer with
-// the already-merged flat map of variable name to value — so any scalar value
-// fails the typed decode with "cannot unmarshal number into Go value of type
-// map[string]interface {}" and the command errors before rendering anything
-// (issue #128). Reading the body here also lets it be decoded with UseNumber,
-// which keeps integers above 2^53 exact rather than routing them through
-// float64.
+// Neither SDK client can be used as-is (issue #128). The generated client types
+// this endpoint's response as map[string]map[string]interface{}, but both Kestra
+// 1.3 and 2.0 answer with the already-merged flat map of variable name to value,
+// so any scalar value fails that typed decode with "cannot unmarshal number into
+// Go value of type map[string]interface {}" and the command errors before
+// rendering anything. The hand-written client
+// (client.Kestra.Namespaces().InheritedVariables) already has the right shape,
+// map[string]interface{}, but decodes with a plain json.Unmarshal: without
+// UseNumber every value goes through float64, which rounds integers above 2^53.
+// Reading the body here is what lets it be decoded with UseNumber, keeping a
+// variable's digits verbatim.
 //
 // The path mirrors the SDK's InheritedVariables endpoint.
 func fetchInheritedVariables(client *Client, id string) (map[string]any, error) {
@@ -631,9 +640,12 @@ func fetchInheritedVariables(client *Client, id string) (map[string]any, error) 
 // parseInheritedVariables decodes an inherited-variables body into a flat map,
 // preserving number literals as json.Number.
 //
-// A response that still uses the nested {namespace: {variable: value}} shape the
-// SDK models decodes into this map too: the inner object lands as the value and
-// renders as JSON, which is lossless, rather than being rejected.
+// A response using the nested {namespace: {variable: value}} shape the generated
+// SDK models decodes into this map too, rather than being rejected — but it is
+// not the intended shape: each namespace becomes a KEY and its whole variable
+// object is JSON-encoded into VALUE, so the variable names only survive inside
+// the value. That is readable but not what the columns promise. No supported
+// server version returns it; both Kestra 1.3 and 2.0 answer flat.
 func parseInheritedVariables(body []byte) (map[string]any, error) {
 	trimmed := bytes.TrimSpace(body)
 	if len(trimmed) == 0 {
@@ -647,7 +659,17 @@ func parseInheritedVariables(body []byte) (map[string]any, error) {
 
 	var variables map[string]any
 	if err := decoder.Decode(&variables); err != nil {
-		return nil, fmt.Errorf("failed to parse inherited variables response: %w", err)
+		// A 2xx body that is not JSON is usually an SSO or reverse proxy
+		// answering with an HTML login page. Route that through
+		// formatErrorBody, whose HTML branch explains to check the host URL and
+		// authentication; an empty errMsg selects that hint instead of echoing
+		// the parser error. Any other unparseable body keeps the decode error,
+		// which says what is actually wrong with it.
+		const prefix = "failed to parse inherited variables response"
+		if trimmed[0] == '<' {
+			return nil, fmt.Errorf("%s: %w", prefix, formatErrorBody(trimmed, ""))
+		}
+		return nil, fmt.Errorf("%s: %w", prefix, err)
 	}
 	return variables, nil
 }

--- a/src/cli/namespaces_test.go
+++ b/src/cli/namespaces_test.go
@@ -568,3 +568,117 @@ func TestNamespacesCreateCommand_InvalidQuota(t *testing.T) {
 		t.Fatalf("expected missing-key error, got: %v", err)
 	}
 }
+
+// The inherited-variables endpoint answers with a flat {variable: value} map on
+// both Kestra 1.3 and 2.0, while the SDK types it as map[string]map[string]any
+// (issue #128). Any scalar value fails that decode.
+func TestRunNamespacesInheritedVariables_FlatMapWithScalarValues(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/main/namespaces/my.namespace/inherited-variables" {
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":7,"name":"hello","nested":{"a":1},"flag":true}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesInheritedVariables(newTestClient(t, server.URL), "my.namespace", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesInheritedVariables error: %v", err)
+	}
+
+	out := buf.String()
+	for _, want := range []string{"NAMESPACE", "KEY", "VALUE", "my.namespace", "count", "7", "name", "hello", "flag", "true", "nested", `{"a":1}`, "Total variables: 4"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+}
+
+// A variable above 2^53 must render with every digit, not in float notation.
+func TestRunNamespacesInheritedVariables_PreservesLargeIntegers(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"big":1725000000000000001}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesInheritedVariables(newTestClient(t, server.URL), "my.namespace", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesInheritedVariables error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "1725000000000000001") {
+		t.Fatalf("expected the exact integer in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "e+18") {
+		t.Fatalf("expected no float notation in output, got:\n%s", out)
+	}
+}
+
+func TestRunNamespacesInheritedVariables_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"big":1725000000000000001,"name":"hello"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesInheritedVariables(newTestClient(t, server.URL), "my.namespace", newJSONRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesInheritedVariables error: %v", err)
+	}
+
+	var rows []map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rows); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d: %s", len(rows), buf.String())
+	}
+	// Rows are sorted by key, so "big" comes first.
+	if rows[0]["namespace"] != "my.namespace" || rows[0]["key"] != "big" || rows[0]["value"] != "1725000000000000001" {
+		t.Fatalf("unexpected first row: %v", rows[0])
+	}
+	if rows[1]["key"] != "name" || rows[1]["value"] != "hello" {
+		t.Fatalf("unexpected second row: %v", rows[1])
+	}
+}
+
+func TestRunNamespacesInheritedVariables_EmptyResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesInheritedVariables(newTestClient(t, server.URL), "my.namespace", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runNamespacesInheritedVariables error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Total variables: 0") {
+		t.Fatalf("expected an empty listing, got:\n%s", buf.String())
+	}
+}
+
+func TestRunNamespacesInheritedVariables_ServerError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"status":404,"message":"namespace not found"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesInheritedVariables(newTestClient(t, server.URL), "missing.namespace", newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected an error for a 404 response")
+	}
+	if !strings.Contains(err.Error(), "namespace not found") {
+		t.Fatalf("expected the server message in the error, got: %v", err)
+	}
+}

--- a/src/cli/namespaces_test.go
+++ b/src/cli/namespaces_test.go
@@ -682,3 +682,41 @@ func TestRunNamespacesInheritedVariables_ServerError(t *testing.T) {
 		t.Fatalf("expected the server message in the error, got: %v", err)
 	}
 }
+
+// An SSO or reverse proxy in front of Kestra can answer an unauthenticated GET
+// with a 200 login page. The decode failure must still surface the actionable
+// "check your host URL and authentication" hint rather than a raw parser error.
+func TestRunNamespacesInheritedVariables_HTMLResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<!doctype html><html><body>login</body></html>"))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesInheritedVariables(newTestClient(t, server.URL), "my.namespace", newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected an error for an HTML response")
+	}
+	if !strings.Contains(err.Error(), "HTML response") {
+		t.Fatalf("expected the HTML hint in the error, got: %v", err)
+	}
+}
+
+// A 200 body that is neither JSON nor HTML must still name what failed.
+func TestRunNamespacesInheritedVariables_UnparseableResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("not json at all"))
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runNamespacesInheritedVariables(newTestClient(t, server.URL), "my.namespace", newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected an error for an unparseable response")
+	}
+	if !strings.Contains(err.Error(), "inherited variables") {
+		t.Fatalf("expected the error to name the failed parse, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`kestractl namespaces inherited-variables <ns>` failed before rendering anything on Kestra 2.0:

```
Error: json: cannot unmarshal number into Go value of type map[string]interface{}
```

The command now decodes the response shape the server actually sends, and renders values without losing precision. A second commit extracts the raw-request plumbing this needed into one helper shared with the pre-existing webhook path.

## Root cause

The generated Go SDK types `GET /api/v1/{tenant}/namespaces/{id}/inherited-variables` as `map[string]map[string]interface{}` (`ApiInheritedVariablesRequest.Execute`). Both server lines answer with the **already-merged flat map** of variable name to value, so the first scalar value fails the typed decode and the whole call errors out.

Secondary bug: once decoding worked, the render used `fmt.Sprintf("%v")`, so a variable above 2^53 printed as `1.725e+18` and a structured value printed in Go's `map[a:1]` syntax.

## Raw response shapes observed live

Namespaces `iv` (`big`, `name`) and `iv.compat` (`nested`, `flag`) created as parents, then `GET .../namespaces/iv.compat.test/inherited-variables`:

Kestra **2.0.0-rc13** (localhost:9801):
```json
{"big":1725000000000000001,"name":"hello","nested":{"a":1},"flag":true}
```

Kestra **1.3.35** (localhost:9802):
```json
{"name":"hello","big":1725000000000000001,"flag":true,"nested":{"a":1}}
```

Both are flat — **1.3 does not return the nested shape the SDK models**, so no version-conditional path is needed. (For contrast, the sibling `inherited-secrets` endpoint *is* genuinely nested — `{"iv":[],"iv.compat":[]}` — on both servers, and is untouched here.)

## Fix

`fix(namespaces): decode inherited variables from the flat server shape`

- `fetchInheritedVariables` in `src/cli/namespaces.go` performs the request directly instead of via the typed SDK method, mirroring the SDK's URL and reusing its configured host, HTTP client (so the `compat.go` 1.x shims still apply), default headers and context-based auth. Errors go through `formatErrorBody`, matching the existing raw-JSON precedent (`tryParse*FromError`).
- `parseInheritedVariables` decodes with `json.Decoder.UseNumber`, so integers keep their digits verbatim rather than round-tripping through `float64`. A response that still used the nested shape decodes here too instead of being rejected, though it is not the intended shape: each namespace would land in `KEY` with its variables JSON-encoded into `VALUE`. No supported server version returns it.
- Values render through the existing `stringify` helper (a `json.Number` is a `fmt.Stringer`, so its digits pass through exactly, and a map is JSON-encoded). This is the same number-preserving intent as the `#121` work; a small local decode is used rather than importing that PR's `decodeJSONPreservingNumbers`, which is not on `main` yet — no symbol clash either way.
- Rows are sorted by variable name (output was previously in Go map order, i.e. random) and `NAMESPACE` reports the namespace that was queried, since the server no longer attributes each variable to its defining namespace. Column names and JSON keys (`namespace`, `key`, `value`, all strings) are unchanged.

Live output on both servers after the fix:

```
NAMESPACE       KEY     VALUE
iv.compat.test  big     1725000000000000001
iv.compat.test  flag    true
iv.compat.test  name    hello
iv.compat.test  nested  {"a":1}

Total variables: 4
```

## Follow-up commit: one shared raw-request helper

`refactor(cli): share the raw request helper between webhook and inherited-variables`

The fix above initially repeated ~40 lines verbatim from `triggerWebhookDirect` in `src/cli/executions.go` (base URL resolution, context auth, default headers, `HTTPClient` fallback, body read, `formatErrorBody` on >= 400). Both callers now go through one helper in `client.go`:

```go
func (c *Client) doRawRequest(method string, segments ...string) ([]byte, error)
```

It builds `/api/v1/{tenant}/<segments>` with each segment `url.PathEscape`d, so a namespace or flow id containing a slash or space cannot break out of its position. The webhook path keeps its exact previous behaviour, including the `"status %d"` message its error text is built from; **its unit tests are untouched and still pass**. Net effect on the two callers: 58 lines removed from `executions.go`, 56 from `namespaces.go`.

New `TestClientDoRawRequest` covers the helper directly: tenant path building, segment escaping, `Authorization: Bearer` from the token context, basic auth from the context, the 404 body being formatted into the message, and the status fallback when the body carries no message.

## `--verbose` does cover the raw path

An earlier version of this description claimed `--verbose` misses requests issued through `doRawRequest`. **That is wrong on current `main`**, and the note (plus the matching "Known limitation" comment in `client.go`) has been removed. Verbose dumping now lives in `compatTransport` (`dumpRequest`/`dumpResponse`, with `writeMaskedHeaders` masking credential-bearing headers), and `doRawRequest` sends through `cfg.HTTPClient`, which *is* that transport — so a raw request gets exactly the same masked dump as any SDK call. The `-v` run quoted earlier predates that transport dump landing on `main`.

Covered by `TestDoRawRequest_VerboseDumpGoesThroughCompatTransport`: the raw inherited-variables request produces `> GET …/namespaces/my.namespace/inherited-variables`, `< 200 OK` and the response body in the dump, with the bearer token masked.

## Tests

Written test-first; the three decoding unit tests fail on `main` with the exact reported error before the fix.

| command | result |
|---|---|
| `go build -o kestractl` | ok |
| `go test ./src/...` | ok |
| `go test ./src/cli/... -run TestRunNamespacesInheritedVariables` | ok (5 tests) |
| `go test ./src/cli/... -run TestClientDoRawRequest` | ok (6 subtests) |
| `go test ./src/cli/... -run Webhook` | ok (6 tests, unchanged) |
| `go vet ./src/...` | clean |
| `gofmt -l src/cli` | only pre-existing `apps.go`, `test_suites.go` (untouched here) |
| `cd e2e_tests && go vet ./...` | clean |
| `cd e2e_tests && go test ./...` | full suite PASS (65.6s) against 2.0.0-rc13 |

New unit tests for the command: flat map with scalar/bool/object values, exact rendering of `1725000000000000001` (and no `e+18`), `--output json` row shape and ordering, empty `{}` response, and a 404 surfacing the server message.

New e2e test `TestNamespacesInheritedVariables_flatScalarsAndLargeIntegers` creates a parent namespace with a `--variables-file` (YAML so the large value is sent as a JSON number, not a string), a child namespace, asserts both table and JSON output, and deletes both in `t.Cleanup`.

### Not verified

- The e2e suite hard-codes `localhost:9801`, so the new e2e case ran only against 2.0.0-rc13. The 1.3.35 behaviour was verified by hand with the built binary and with `curl` (shapes above), not by the suite.
- There is no e2e coverage of the webhook command on either server, so the refactor of `triggerWebhookDirect` is covered by unit tests only (all passing, untouched).
- `go.mod`/`go.sum` untouched; no SDK bump.

Fixes #128

