### PR TITLE
test(e2e): cover the trigger decode fix on both server lines

### DIFF
--- a/e2e_tests/triggers_usecases_test.go
+++ b/e2e_tests/triggers_usecases_test.go
@@ -1,0 +1,143 @@
+package e2e_tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Coverage for the trigger read commands across the version matrix.
+//
+// Kestra 2.0 changed the shape of every /triggers/** response: a per-flow
+// search that used to answer with a flat `Trigger` (namespace/flowId/triggerId/
+// date/nextExecutionDate) now answers with an `ApiTriggerState` (updatedAt/
+// nextEvaluationDate, no `date` at all), and the paged search nests the two
+// halves under `trigger` and `state`. The generated Go SDK still marks the 1.x
+// `date` required, so reading a 2.0 body through it failed the whole command
+// with "no value given for required property date" — issue #131 for
+// search-for-flow and the single backfill ops, #118 for `triggers list`.
+//
+// The unit tests pin each shape against a fake server; these run the real
+// binary against every version in COMPATIBLE_KESTRA_VERSION.properties, which
+// is the gap that let the decode failure reach a release unnoticed.
+
+const triggersTestNamespace = "e2e.triggers"
+
+// triggersTestTriggerID is the trigger id deployScheduledTestFlow declares.
+const triggersTestTriggerID = "every_min"
+
+// triggerDecodeFailure is the error a trigger response that the SDK model
+// rejects produces. It can never be a legitimate answer, on either server line,
+// so its absence is the assertion these tests are built around.
+const triggerDecodeFailure = "no value given for required property"
+
+// deployScheduledTestFlow deploys a flow carrying one disabled Schedule
+// trigger, and returns its flow id.
+//
+// The trigger is disabled so a run of this suite does not leave a schedule
+// firing every few minutes behind on a persistent instance; a disabled trigger
+// still gets a trigger state row, which is what these commands read.
+func deployScheduledTestFlow(t *testing.T, flowID string) string {
+	t.Helper()
+
+	source := fmt.Sprintf(`id: %s
+namespace: %s
+triggers:
+  - id: %s
+    type: io.kestra.plugin.core.trigger.Schedule
+    cron: "*/5 * * * *"
+    disabled: true
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: kestractl e2e
+`, flowID, triggersTestNamespace, triggersTestTriggerID)
+
+	path := filepath.Join(t.TempDir(), flowID+".yml")
+	require.NoError(t, os.WriteFile(path, []byte(source), 0o600))
+
+	stdout, stderr, err := RunAuthenticatedCliCmd(t, "flows", "deploy", path, "--override")
+	require.NoError(t, err, "deploy failed\nstdout: %s\nstderr: %s", stdout, stderr)
+	require.Contains(t, stdout, "1 flow(s) deployed successfully")
+
+	return flowID
+}
+
+// eventuallyTriggerListed runs the given command until its output contains
+// want, and returns that output.
+//
+// The wait is for the server, not the CLI: a trigger state row appears only
+// once the scheduler has registered the freshly deployed flow, which on a 1.x
+// instance takes a few seconds. A decode failure is not waited out — it is a
+// terminal answer, and the whole point of these tests — so the loop fails on it
+// immediately rather than retrying until the deadline.
+func eventuallyTriggerListed(t *testing.T, want string, args ...string) string {
+	t.Helper()
+
+	deadline := time.Now().Add(60 * time.Second)
+	var stdout, stderr string
+	var err error
+	for {
+		stdout, stderr, err = RunAuthenticatedCliCmd(t, args...)
+		require.NotContains(t, stdout+stderr, triggerDecodeFailure,
+			"the trigger response was rejected at decode\nstdout: %s\nstderr: %s", stdout, stderr)
+
+		if err == nil && strings.Contains(stdout, want) {
+			return stdout
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%q never listed %q within the deadline: %v\nstdout: %s\nstderr: %s",
+				strings.Join(args, " "), want, err, stdout, stderr)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// TestTriggers_searchForFlow_decodes covers issue #131: on Kestra 2.0 the server
+// answers 200 and kestractl exited 1 on the response body alone.
+func TestTriggers_searchForFlow_decodes(t *testing.T) {
+	flowID := deployScheduledTestFlow(t, "e2e-triggers-search")
+
+	stdout := eventuallyTriggerListed(t, flowID,
+		"triggers", "search-for-flow", triggersTestNamespace, flowID)
+
+	require.Contains(t, stdout, triggersTestTriggerID, "the trigger id is missing from the output")
+	require.Contains(t, stdout, triggersTestNamespace, "the namespace is missing from the output")
+}
+
+// TestTriggers_backfillOps_decode covers the other half of issue #131. Whether
+// a backfill exists to act on differs by server line — 1.x answers 404 for a
+// trigger that has none, 2.0 accepts the call — so the assertion is only that
+// the response is read rather than rejected over a missing property.
+func TestTriggers_backfillOps_decode(t *testing.T) {
+	flowID := deployScheduledTestFlow(t, "e2e-triggers-backfill")
+
+	for _, op := range []string{"backfill-pause", "backfill-unpause", "backfill-delete"} {
+		t.Run(op, func(t *testing.T) {
+			// A non-zero exit is a legitimate outcome here: a server with no
+			// backfill for this trigger reports that. Being unable to read the
+			// answer at all is not.
+			stdout, stderr, _ := RunAuthenticatedCliCmd(t, "triggers", op,
+				triggersTestNamespace, flowID, triggersTestTriggerID)
+			require.NotContains(t, stdout+stderr, triggerDecodeFailure,
+				"%s: the trigger response was rejected at decode\nstdout: %s\nstderr: %s", op, stdout, stderr)
+		})
+	}
+}
+
+// TestTriggers_list_rendersRows covers issue #118: the 2.0 {trigger, state}
+// body decoded into empty fields, so every row rendered blank.
+func TestTriggers_list_rendersRows(t *testing.T) {
+	flowID := deployScheduledTestFlow(t, "e2e-triggers-list")
+
+	stdout := eventuallyTriggerListed(t, flowID, "triggers", "list", "--size", "200")
+
+	require.Contains(t, stdout, triggersTestTriggerID, "the trigger id is missing from the listing")
+	require.Contains(t, stdout, "io.kestra.plugin.core.trigger.Schedule",
+		"the trigger type is missing, so the row rendered blank")
+}

--- a/e2e_tests/triggers_usecases_test.go
+++ b/e2e_tests/triggers_usecases_test.go
@@ -1,6 +1,7 @@
 package e2e_tests
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -31,10 +32,18 @@ const triggersTestNamespace = "e2e.triggers"
 // triggersTestTriggerID is the trigger id deployScheduledTestFlow declares.
 const triggersTestTriggerID = "every_min"
 
+// triggersTestTriggerType is the trigger type deployScheduledTestFlow declares,
+// and the column that rendered blank under issue #118.
+const triggersTestTriggerType = "io.kestra.plugin.core.trigger.Schedule"
+
 // triggerDecodeFailure is the error a trigger response that the SDK model
 // rejects produces. It can never be a legitimate answer, on either server line,
 // so its absence is the assertion these tests are built around.
 const triggerDecodeFailure = "no value given for required property"
+
+// triggerRegistrationTimeout bounds the wait for the scheduler to register a
+// freshly deployed flow, which is what makes a trigger state row exist.
+const triggerRegistrationTimeout = 60 * time.Second
 
 // deployScheduledTestFlow deploys a flow carrying one disabled Schedule
 // trigger, and returns its flow id.
@@ -49,14 +58,14 @@ func deployScheduledTestFlow(t *testing.T, flowID string) string {
 namespace: %s
 triggers:
   - id: %s
-    type: io.kestra.plugin.core.trigger.Schedule
+    type: %s
     cron: "*/5 * * * *"
     disabled: true
 tasks:
   - id: hello
     type: io.kestra.plugin.core.log.Log
     message: kestractl e2e
-`, flowID, triggersTestNamespace, triggersTestTriggerID)
+`, flowID, triggersTestNamespace, triggersTestTriggerID, triggersTestTriggerType)
 
 	path := filepath.Join(t.TempDir(), flowID+".yml")
 	require.NoError(t, os.WriteFile(path, []byte(source), 0o600))
@@ -68,24 +77,32 @@ tasks:
 	return flowID
 }
 
+// requireNoTriggerDecodeFailure fails the test at once when a trigger command
+// could not read the server's answer.
+//
+// This is never waited out: a decode failure is a terminal answer, and the whole
+// point of these tests, so a poll loop stops on it rather than retrying until
+// its deadline and reporting a timeout instead of the real cause.
+func requireNoTriggerDecodeFailure(t *testing.T, label, stdout, stderr string) {
+	t.Helper()
+
+	require.NotContains(t, stdout+stderr, triggerDecodeFailure,
+		"%s: the trigger response was rejected at decode\nstdout: %s\nstderr: %s", label, stdout, stderr)
+}
+
 // eventuallyTriggerListed runs the given command until its output contains
 // want, and returns that output.
 //
 // The wait is for the server, not the CLI: a trigger state row appears only
 // once the scheduler has registered the freshly deployed flow, which on a 1.x
-// instance takes a few seconds. A decode failure is not waited out — it is a
-// terminal answer, and the whole point of these tests — so the loop fails on it
-// immediately rather than retrying until the deadline.
+// instance takes a few seconds.
 func eventuallyTriggerListed(t *testing.T, want string, args ...string) string {
 	t.Helper()
 
-	deadline := time.Now().Add(60 * time.Second)
-	var stdout, stderr string
-	var err error
+	deadline := time.Now().Add(triggerRegistrationTimeout)
 	for {
-		stdout, stderr, err = RunAuthenticatedCliCmd(t, args...)
-		require.NotContains(t, stdout+stderr, triggerDecodeFailure,
-			"the trigger response was rejected at decode\nstdout: %s\nstderr: %s", stdout, stderr)
+		stdout, stderr, err := RunAuthenticatedCliCmd(t, args...)
+		requireNoTriggerDecodeFailure(t, strings.Join(args, " "), stdout, stderr)
 
 		if err == nil && strings.Contains(stdout, want) {
 			return stdout
@@ -93,6 +110,73 @@ func eventuallyTriggerListed(t *testing.T, want string, args ...string) string {
 		if time.Now().After(deadline) {
 			t.Fatalf("%q never listed %q within the deadline: %v\nstdout: %s\nstderr: %s",
 				strings.Join(args, " "), want, err, stdout, stderr)
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
+// triggerRow is one row of `triggers list --output json`.
+type triggerRow struct {
+	Namespace         string `json:"namespace"`
+	FlowID            string `json:"flowId"`
+	TriggerID         string `json:"triggerId"`
+	Type              string `json:"type"`
+	Disabled          bool   `json:"disabled"`
+	NextExecutionDate string `json:"nextExecutionDate"`
+}
+
+// triggersListPageSize and triggersListMaxPages bound the paging below.
+const (
+	triggersListPageSize = 200
+	triggersListMaxPages = 50
+)
+
+// findListedTriggerRow returns the `triggers list` row for the given flow.
+//
+// The listing is tenant-wide with no server-side filter for a flow, so it is
+// paged through rather than assuming the row under test lands on page 1: the
+// docker-setup README documents reusing one instance across runs, and on an
+// instance carrying more triggers than a single page the row is simply
+// elsewhere — which would read as a render regression that does not exist.
+func findListedTriggerRow(t *testing.T, flowID string) (triggerRow, bool) {
+	t.Helper()
+
+	for page := 1; page <= triggersListMaxPages; page++ {
+		args := []string{"triggers", "list", "--output", "json",
+			"--page", fmt.Sprint(page), "--size", fmt.Sprint(triggersListPageSize)}
+		stdout, stderr, err := RunAuthenticatedCliCmd(t, args...)
+		requireNoTriggerDecodeFailure(t, strings.Join(args, " "), stdout, stderr)
+		require.NoError(t, err, "triggers list failed\nstdout: %s\nstderr: %s", stdout, stderr)
+
+		var rows []triggerRow
+		require.NoError(t, json.Unmarshal([]byte(stdout), &rows),
+			"json from --output json should be valid, got: %s", stdout)
+
+		for _, row := range rows {
+			if row.FlowID == flowID && row.Namespace == triggersTestNamespace {
+				return row, true
+			}
+		}
+		if len(rows) < triggersListPageSize {
+			return triggerRow{}, false
+		}
+	}
+	return triggerRow{}, false
+}
+
+// eventuallyListedTriggerRow waits for the row of the flow under test to appear
+// in `triggers list`, and returns it.
+func eventuallyListedTriggerRow(t *testing.T, flowID string) triggerRow {
+	t.Helper()
+
+	deadline := time.Now().Add(triggerRegistrationTimeout)
+	for {
+		if row, ok := findListedTriggerRow(t, flowID); ok {
+			return row
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("`triggers list` never listed a row for flow %q in namespace %q within the deadline",
+				flowID, triggersTestNamespace)
 		}
 		time.Sleep(2 * time.Second)
 	}
@@ -117,6 +201,13 @@ func TestTriggers_searchForFlow_decodes(t *testing.T) {
 func TestTriggers_backfillOps_decode(t *testing.T) {
 	flowID := deployScheduledTestFlow(t, "e2e-triggers-backfill")
 
+	// Wait for the trigger to exist server-side first. Called straight after the
+	// deploy, the ops answer not-found before the scheduler has registered the
+	// flow, and every subtest would go green without ever decoding a trigger
+	// body — letting the regression these tests exist to catch re-land.
+	eventuallyTriggerListed(t, triggersTestTriggerID,
+		"triggers", "search-for-flow", triggersTestNamespace, flowID)
+
 	for _, op := range []string{"backfill-pause", "backfill-unpause", "backfill-delete"} {
 		t.Run(op, func(t *testing.T) {
 			// A non-zero exit is a legitimate outcome here: a server with no
@@ -124,20 +215,24 @@ func TestTriggers_backfillOps_decode(t *testing.T) {
 			// answer at all is not.
 			stdout, stderr, _ := RunAuthenticatedCliCmd(t, "triggers", op,
 				triggersTestNamespace, flowID, triggersTestTriggerID)
-			require.NotContains(t, stdout+stderr, triggerDecodeFailure,
-				"%s: the trigger response was rejected at decode\nstdout: %s\nstderr: %s", op, stdout, stderr)
+			requireNoTriggerDecodeFailure(t, op, stdout, stderr)
 		})
 	}
 }
 
 // TestTriggers_list_rendersRows covers issue #118: the 2.0 {trigger, state}
 // body decoded into empty fields, so every row rendered blank.
+//
+// The assertions are made against the single row for the flow under test, not
+// against the whole listing: any other flow on the instance carrying a Schedule
+// trigger — a leftover from an earlier run of this suite included — would
+// satisfy a listing-wide type assertion even while the row under test rendered
+// its TYPE column blank, which is exactly what #118 was.
 func TestTriggers_list_rendersRows(t *testing.T) {
 	flowID := deployScheduledTestFlow(t, "e2e-triggers-list")
 
-	stdout := eventuallyTriggerListed(t, flowID, "triggers", "list", "--size", "200")
+	row := eventuallyListedTriggerRow(t, flowID)
 
-	require.Contains(t, stdout, triggersTestTriggerID, "the trigger id is missing from the listing")
-	require.Contains(t, stdout, "io.kestra.plugin.core.trigger.Schedule",
-		"the trigger type is missing, so the row rendered blank")
+	require.Equal(t, triggersTestTriggerID, row.TriggerID, "the trigger id is missing from the row")
+	require.Equal(t, triggersTestTriggerType, row.Type, "the trigger type is missing, so the row rendered blank")
 }


### PR DESCRIPTION
## Summary

Issue #131 needs no new code: **the fix already sits in open PR #127**, which rewrites exactly the two functions the issue names. What was missing is e2e coverage, so this PR is stacked on `emdash/bug-fix-sawvr` and adds `e2e_tests/triggers_usecases_test.go` — three tests that run the real binary against whichever Kestra the suite is pointed at, so both server lines in `COMPATIBLE_KESTRA_VERSION.properties` assert the decode.

> Base is #127's branch, not `main`, deliberately: on `main` these tests fail (that is the bug), so a PR against `main` would be red until #127 lands. Merge #127 first, then this.

## Root cause

Kestra 2.0 reshaped every `/triggers/**` response, and the generated Go SDK still ships the 1.x models for those paths. `runTriggersSearchForFlow` and `runTriggersBackfillOp` decoded into `kestra.Trigger`, whose `date` is required and which a 2.0 server never sends — so the SDK rejected an HTTP 200 body and the command exited 1.

Raw `GET /api/v1/main/triggers/{namespace}/{flowId}?page=1&size=50`, captured live:

**Kestra 1.3.35** — flat `Trigger`, carries `date`:
```json
{"results":[{"tenantId":"main","namespace":"bug131","flowId":"sched131","triggerId":"every_min",
  "date":"2026-09-04T15:10:10Z","nextExecutionDate":"2026-09-04T15:15:00Z","disabled":false}],"total":1}
```

**Kestra 2.0.0-rc13** — `ApiTriggerState`, no `date` at all:
```json
{"results":[{"namespace":"bug131","flowId":"sched131","triggerId":"every_min",
  "updatedAt":"2026-09-04T15:08:55Z","nextEvaluationDate":"2026-09-04T15:10:00Z",
  "disabled":true,"locked":false,"kind":"SCHEDULE"}],"total":1}
```

The paged `/triggers/search` used by `triggers list` changed the same way, nesting the two halves under `trigger` and `state` — that is #118, the blank-row symptom of the same shape change.

## Fix

None here. #127's `src/cli/compat_triggers.go` dispatches on server era and funnels both shapes into era-agnostic values (`fetchFlowTriggerRefs`, `backfillTriggerRef`), reading the 2.x bodies with the hand-written client that models them and the 1.x bodies raw. Adding a shim in `fillCompatDefaults` instead was considered and rejected for the same reason #127 documents: the transport would have to invent an `updatedAt` a 1.3 server legitimately omits.

## Relationship to PR #127

- #127 fixes #131 in full — its body already calls out `search-for-flow`, `unlock` and the single backfill ops, and its unit tests (`TestFetchFlowTriggerRefs_BothEras`, `TestBackfillTriggerRef_BothEras`, plus the dateless-1.3 regression bodies) cover every shape.
- This PR duplicates none of it: it touches only `e2e_tests/`, a module #127 does not modify, so there is no conflict surface.
- #131 should be closed by whichever of the two merges last; `Fixes #131` is on this one because it is the later half.

## Tests

Local Docker EE instances: **2.0.0-rc13** on `:9801`, **1.3.35** on `:9802`. A flow with one disabled `Schedule` trigger was deployed to both.

Reproduction on `main` (`6bb00bc`), against 2.0.0-rc13 — all four commands from the issue:
```
=== search-for-flow    Error: API error: no value given for required property date
=== backfill-pause     Error: API error: no value given for required property date
=== backfill-unpause   Error: API error: no value given for required property date
=== backfill-delete    Error: API error: no value given for required property date
=== triggers list      rows render blank (#118)
```

New e2e tests, `cd e2e_tests && go test -run 'TestTriggers_' -count=1 ./...`:

| code | server | result |
|---|---|---|
| `main` | 2.0.0-rc13 | **FAIL** ×3 — the reported error, verbatim |
| this branch (#127 + tests) | 2.0.0-rc13 | **PASS** — `ok e2e_tests 10.475s` |
| this branch (#127 + tests) | 1.3.35 | **PASS** — `ok e2e_tests 3.685s` |

Also on this branch: `go build`, `go test ./src/...` (ok), `go vet ./src/...`, `cd e2e_tests && go vet ./...`, `gofmt -l` clean on the new file.

### Not verified
- CI's own matrix (only rc13 and 1.3.35 were reachable locally); the version the issue reports, 2.0.0-rc14, and 1.3.37 were not.
- `triggers backfill-*` against a trigger that actually **has** a backfill. On both servers the trigger under test had none — 1.3 answers 404 for that, 2.0 accepts the call — which is why those subtests assert only that the response is readable, not a success message.
- The full e2e suite was not re-run end to end; only `-run TestTriggers_`.

Fixes #131
