### PR TITLE
fix(logs): require --trigger-id on logs delete-flow

### DIFF
--- a/e2e_tests/logs_delete_usecases_test.go
+++ b/e2e_tests/logs_delete_usecases_test.go
@@ -1,0 +1,75 @@
+package e2e_tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Coverage for 'logs delete-flow' (#133).
+//
+// The flow-scoped log deletion endpoint declares triggerId as a *required*
+// query parameter on both server lines, so the command used to fail with a raw
+// server 400 whenever --trigger-id was omitted — while its help text advertised
+// deleting "all logs for a flow". Verified by raw curl on 1.3.35 and
+// 2.0.0-rc13:
+//
+//	DELETE /api/v1/main/logs/<ns>/<flow>              -> 400 (triggerId not specified)
+//	DELETE /api/v1/main/logs/<ns>/<flow>?triggerId=   -> 200, but deletes nothing
+//
+// An empty value is therefore not a usable stand-in: it is a silent no-op. The
+// command now rejects a missing --trigger-id itself, before any request, and
+// this test pins that on every version in the matrix.
+
+const logsDeleteTestNamespace = "e2e.logsdelete"
+
+// deployLogsDeleteFlow deploys the one-task subject flow. --override keeps a
+// rerun against a persistent instance from being a hard failure, and
+// io.kestra.plugin.core.log.Log is available in the plugin-less image this
+// suite runs against.
+func deployLogsDeleteFlow(t *testing.T, flowID string) {
+	t.Helper()
+
+	source := fmt.Sprintf(`id: %s
+namespace: %s
+tasks:
+  - id: hello
+    type: io.kestra.plugin.core.log.Log
+    message: kestractl e2e logs delete
+`, flowID, logsDeleteTestNamespace)
+
+	path := filepath.Join(t.TempDir(), flowID+".yml")
+	require.NoError(t, os.WriteFile(path, []byte(source), 0o600))
+
+	stdout, stderr, err := RunAuthenticatedCliCmd(t, "flows", "deploy", path, "--override")
+	require.NoError(t, err, "deploy failed\nstdout: %s\nstderr: %s", stdout, stderr)
+	require.Contains(t, stdout, "1 flow(s) deployed successfully")
+}
+
+// TestLogs_deleteFlow_withoutTrigger asserts the command fails locally with its
+// own message when --trigger-id is omitted, and reaches the endpoint
+// successfully when it is supplied.
+func TestLogs_deleteFlow_withoutTrigger(t *testing.T) {
+	flowID := "e2e-logs-delete-flow"
+	deployLogsDeleteFlow(t, flowID)
+
+	t.Run("without --trigger-id", func(t *testing.T) {
+		stdout, stderr, err := RunAuthenticatedCliCmd(t, "logs", "delete-flow", logsDeleteTestNamespace, flowID)
+
+		require.Error(t, err, "expected a non-zero exit\nstdout: %s\nstderr: %s", stdout, stderr)
+		require.Contains(t, stderr, "--trigger-id is required")
+		// The point of the fix: kestractl answers, the server is never asked.
+		require.NotContains(t, stderr, "triggerId] not specified")
+	})
+
+	t.Run("with --trigger-id", func(t *testing.T) {
+		stdout, stderr, err := RunAuthenticatedCliCmd(t,
+			"logs", "delete-flow", logsDeleteTestNamespace, flowID, "--trigger-id", "e2e-trigger")
+
+		require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
+		require.Contains(t, stdout, "deleted")
+	})
+}

--- a/src/cli/logs.go
+++ b/src/cli/logs.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -106,15 +107,14 @@ func newLogsDeleteFlowCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "delete-flow <namespace> <flow_id>",
-		Short: "Delete all logs for a flow.",
-		Long: `Delete every log entry produced by a flow across all of its executions.
+		Short: "Delete the logs a trigger of a flow produced.",
+		Long: `Delete the log entries recorded against a specific trigger of a flow.
 
-Use --trigger-id to restrict deletion to logs produced by a specific
-trigger of the flow.`,
-		Example: `  # Delete all logs for a flow
-	  kestractl logs delete-flow my.namespace my-flow
-
-	  # Delete only logs produced by a specific trigger
+--trigger-id is required: the server declares triggerId as a mandatory query
+parameter and the endpoint deletes only the logs attributed to that trigger.
+Logs produced by the flow's executions are not affected — remove those with
+'kestractl logs delete <execution_id>'.`,
+		Example: `  # Delete the logs produced by a flow's trigger
 	  kestractl logs delete-flow my.namespace my-flow --trigger-id my-trigger`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -122,32 +122,43 @@ trigger of the flow.`,
 			if err != nil {
 				return err
 			}
+			if triggerID == "" {
+				return errTriggerIDRequired
+			}
 			client, err := NewClient()
 			if err != nil {
 				return err
 			}
 
-			var triggerFilter *string
-			if triggerID != "" {
-				triggerFilter = &triggerID
-			}
-			return runLogsDeleteFlow(client, args[0], args[1], triggerFilter, renderer)
+			return runLogsDeleteFlow(client, args[0], args[1], triggerID, renderer)
 		},
 	}
 
-	cmd.Flags().StringVar(&triggerID, "trigger-id", "", "Only delete logs produced by this trigger ID")
+	cmd.Flags().StringVar(&triggerID, "trigger-id", "", "Trigger ID whose logs are deleted (required)")
 
 	return cmd
 }
 
-func runLogsDeleteFlow(client *Client, namespace, flowID string, triggerID *string, renderer *Renderer) error {
-	err := client.Kestra.Logs().DeleteLogsFromFlow(client.Ctx, namespace, flowID, client.Tenant, triggerID)
+// errTriggerIDRequired explains why 'logs delete-flow' cannot run without
+// --trigger-id: the server declares triggerId as a required query parameter
+// (400 when omitted) and treats it as an exact filter, so sending an empty
+// value would be accepted with a 200 while deleting nothing.
+var errTriggerIDRequired = errors.New(
+	"--trigger-id is required: the server only deletes the logs attributed to a specific trigger of the flow. " +
+		"To delete an execution's logs, use 'kestractl logs delete <execution_id>'")
+
+func runLogsDeleteFlow(client *Client, namespace, flowID, triggerID string, renderer *Renderer) error {
+	if triggerID == "" {
+		return errTriggerIDRequired
+	}
+
+	err := client.Kestra.Logs().DeleteLogsFromFlow(client.Ctx, namespace, flowID, client.Tenant, &triggerID)
 	if err != nil {
 		return formatSDKError(err)
 	}
 
-	return renderStatus(renderer, fmt.Sprintf("Logs for flow '%s' in namespace '%s' deleted.", flowID, namespace),
-		map[string]any{"namespace": namespace, "flowId": flowID, "status": "deleted"})
+	return renderStatus(renderer, fmt.Sprintf("Logs for trigger '%s' of flow '%s' in namespace '%s' deleted.", triggerID, flowID, namespace),
+		map[string]any{"namespace": namespace, "flowId": flowID, "triggerId": triggerID, "status": "deleted"})
 }
 
 func newLogsDeleteCommand() *cobra.Command {

--- a/src/cli/logs_test.go
+++ b/src/cli/logs_test.go
@@ -105,7 +105,7 @@ func TestLogsDeleteFlowCommand_ClientError(t *testing.T) {
 	defer func() { newClientFunc = original }()
 
 	cmd := newLogsDeleteFlowCommand()
-	_, err := executeCommand(cmd, "my.ns", "my-flow")
+	_, err := executeCommand(cmd, "my.ns", "my-flow", "--trigger-id", "my-trigger")
 	if err == nil {
 		t.Fatal("expected client error")
 	}
@@ -302,5 +302,71 @@ func TestRunLogsSearch_MinLevelOperationPerServerEra(t *testing.T) {
 				t.Errorf("expected namespace EQUALS filter, got query: %s", decoded)
 			}
 		})
+	}
+}
+
+// The flow-scoped log deletion endpoint declares triggerId as a required query
+// parameter on both Kestra 1.3 and 2.x, and an empty value is accepted but
+// deletes nothing. Omitting --trigger-id must therefore fail locally with a
+// helpful message rather than round-trip to a 400 or silently no-op.
+func TestRunLogsDeleteFlow_MissingTriggerIDFailsWithoutRequest(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runLogsDeleteFlow(newTestClient(t, server.URL), "my.ns", "my-flow", "", newTableRenderer(&buf))
+	if err == nil {
+		t.Fatal("expected an error when --trigger-id is omitted")
+	}
+	if !strings.Contains(err.Error(), "--trigger-id is required") {
+		t.Fatalf("expected a --trigger-id error, got: %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("expected no request to be sent, got %d", requests)
+	}
+}
+
+func TestRunLogsDeleteFlow_SendsTriggerID(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath, gotQuery = r.Method, r.URL.Path, r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	var buf bytes.Buffer
+	err := runLogsDeleteFlow(newTestClient(t, server.URL), "my.ns", "my-flow", "my-trigger", newTableRenderer(&buf))
+	if err != nil {
+		t.Fatalf("runLogsDeleteFlow error: %v", err)
+	}
+	if gotMethod != http.MethodDelete {
+		t.Errorf("expected DELETE, got %s", gotMethod)
+	}
+	if gotPath != "/api/v1/main/logs/my.ns/my-flow" {
+		t.Errorf("unexpected path: %s", gotPath)
+	}
+	if gotQuery != "triggerId=my-trigger" {
+		t.Errorf("expected triggerId in query, got %q", gotQuery)
+	}
+}
+
+func TestLogsDeleteFlowCommand_MissingTriggerID(t *testing.T) {
+	original := newClientFunc
+	newClientFunc = func() (*Client, error) {
+		return nil, errors.New("client error")
+	}
+	defer func() { newClientFunc = original }()
+
+	cmd := newLogsDeleteFlowCommand()
+	_, err := executeCommand(cmd, "my.ns", "my-flow")
+	if err == nil {
+		t.Fatal("expected an error when --trigger-id is omitted")
+	}
+	if !strings.Contains(err.Error(), "--trigger-id is required") {
+		t.Fatalf("expected a --trigger-id error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

`kestractl logs delete-flow <ns> <flow>` documented `--trigger-id` as optional, but the server rejects the request without it. This makes the flag required, rejects a missing value locally before any request is sent, and corrects the help text to describe what the endpoint actually does.

## Evidence

Raw curl against two local Kestra EE instances — `localhost:9802` (**1.3.35**) and `localhost:9801` (**2.0.0-rc13**) — after deploying a one-task flow and running it to completion so the flow definitely had logs:

| request | 1.3.35 | 2.0.0-rc13 |
| --- | --- | --- |
| `DELETE /api/v1/main/logs/<ns>/<flow>` | `400 Bad Request: Required QueryValue [triggerId] not specified` | `400 Invalid query parameter: Required QueryValue [triggerId] not specified` |
| `DELETE …?triggerId=` (empty) | `200` | `200` |
| `DELETE …?triggerId=nope` | `200` | not retested (same handler) |

The decisive part is what the accepted calls actually did: **nothing.** Before and after `?triggerId=`, `GET /api/v1/main/logs/<executionId>` returned the identical single log entry on both versions:

```
--- logs before
[{"namespace":"e2e.dbg133","flowId":"dbg133","taskId":"hello", … "message":"hello from dbg133"}]
--- DELETE ?triggerId=   status=200
--- logs after
[{"namespace":"e2e.dbg133","flowId":"dbg133","taskId":"hello", … "message":"hello from dbg133"}]
```

I also checked whether a *real* trigger id deletes a flow's logs, using a flow with a `Schedule` trigger (`id: sched`, `cron: '* * * * *'`) on 1.3.35. After two scheduled executions, `logs/search` reported `"total":2`; after `DELETE …?triggerId=sched` returned `200`, it still reported `"total":2`. The logs of trigger-launched executions carry no `triggerId` field at all.

So `triggerId` is a genuine exact-match filter on the trigger a log entry is attributed to, not merely a required-but-ignored parameter — and execution logs are never attributed to a trigger. This endpoint cannot delete "all logs for a flow" under any argument.

## Decision

**Option (b): make `--trigger-id` required, with an accurate help text and a clear local error.**

Option (a) is ruled out by the evidence above: an empty value is accepted with a `200` on both versions but deletes nothing, so "always send the parameter" would turn a visible `400` into a silent no-op reported to the user as `deleted` — strictly worse than the bug.

Option (c) (implementing "all logs of a flow" over the execution-scoped delete) is a new feature — it would need to enumerate the flow's executions and delete each one's logs, with its own paging, partial-failure and confirmation semantics. That is out of scope for a bug fix and deserves its own issue; #133 is about the command not matching its own documentation.

Changes:

- `--trigger-id` is validated in `runLogsDeleteFlow` and in the command's `RunE` **before the client is built**, so no request is sent and the user gets:
  `--trigger-id is required: the server only deletes the logs attributed to a specific trigger of the flow. To delete an execution's logs, use 'kestractl logs delete <execution_id>'`
- `Short` / `Long` / `Example` and the flag description now say the command deletes a *trigger's* logs, and point at `logs delete <execution_id>` for execution logs.
- The signature drops the now-meaningless `*string`, and the success line plus JSON payload name the trigger (`triggerId` added to the JSON object — additive).

## Tests

Written test-first. With the signature change in place but no validation, the new tests failed for the intended reason:

```
--- FAIL: TestRunLogsDeleteFlow_MissingTriggerIDFailsWithoutRequest
    logs_test.go:222: expected an error when --trigger-id is omitted
--- FAIL: TestLogsDeleteFlowCommand_MissingTriggerID
    logs_test.go:269: expected a --trigger-id error, got: client error
```

New unit tests in `src/cli/logs_test.go` (httptest, following the `newTestClient` pattern):

- `TestRunLogsDeleteFlow_MissingTriggerIDFailsWithoutRequest` — asserts the error **and** that the handler saw zero requests.
- `TestRunLogsDeleteFlow_SendsTriggerID` — pins `DELETE /api/v1/main/logs/my.ns/my-flow?triggerId=my-trigger`.
- `TestLogsDeleteFlowCommand_MissingTriggerID` — the flag error wins over a failing client, i.e. validation really is pre-request.

`TestLogsDeleteFlowCommand_ClientError` now passes `--trigger-id`, since it can no longer reach the client without it.

New e2e test `TestLogs_deleteFlow_withoutTrigger` in a **new** file `e2e_tests/logs_delete_usecases_test.go` with its own namespace `e2e.logsdelete` and helper `deployLogsDeleteFlow`, to avoid conflicting with #136's `e2e_tests/logs_usecases_test.go`.

Commands run:

```
$ go build -o kestractl .                      # ok
$ go test ./src/...                            # ok  github.com/kestra-io/kestractl/src/cli
$ go vet ./src/...                             # clean
$ gofmt -l src/cli                             # src/cli/apps.go, src/cli/test_suites.go (pre-existing, untouched here)
$ cd e2e_tests && go vet ./... && gofmt -l .   # clean

$ cd e2e_tests && go test -run TestLogs_deleteFlow_withoutTrigger -v ./...   # against 2.0.0-rc13
--- PASS: TestLogs_deleteFlow_withoutTrigger (3.64s)
    --- PASS: TestLogs_deleteFlow_withoutTrigger/without_--trigger-id (0.52s)
    --- PASS: TestLogs_deleteFlow_withoutTrigger/with_--trigger-id (0.76s)
```

Both paths were also exercised by hand against **1.3.35** (the e2e suite pins `e2eHost` to `:9801`, so 1.3 could not be driven through `go test` locally):

```
$ ./kestractl logs delete-flow e2e.dbg133 dbg133 --host http://localhost:9802 …
Error: --trigger-id is required: the server only deletes the logs attributed to a specific
trigger of the flow. To delete an execution's logs, use 'kestractl logs delete <execution_id>'
exit=1

$ ./kestractl logs delete-flow e2e.dbg133 dbg133 --trigger-id e2e-trigger --host http://localhost:9802 …
Logs for trigger 'e2e-trigger' of flow 'dbg133' in namespace 'e2e.dbg133' deleted.
```

### Not verified

- The e2e job in CI is what will run `TestLogs_deleteFlow_withoutTrigger` across the full version matrix; locally it ran only against 2.0.0-rc13.
- That deleting by a trigger id ever removes *anything* — I could not produce a log entry carrying a `triggerId` with the plugin-less image (a `Schedule` trigger logs nothing of its own). The command's contract is unchanged for that case; the fix only concerns the missing parameter.
- `go.mod` / `go.sum` untouched.

Fixes #133
