### PR TITLE
fix(executions): send `run --wait` progress to stderr

### DIFF
--- a/e2e_tests/executions_usecases_test.go
+++ b/e2e_tests/executions_usecases_test.go
@@ -1,6 +1,7 @@
 package e2e_tests
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -208,4 +209,27 @@ func TestExecutionsBulk_reportsTheAffectedCount(t *testing.T) {
 	require.NoError(t, err, "stdout: %s\nstderr: %s", stdout, stderr)
 	require.Contains(t, stdout, "1 execution(s) affected",
 		"the affected count was dropped at decode\nstdout: %s", stdout)
+}
+
+// TestExecutionsRun_waitJSONIsParseable pins #135: `--wait` used to print its
+// two progress lines to stdout, so `-o json` output could not be piped into a
+// JSON parser. The progress now goes to stderr and stdout stays machine
+// readable.
+func TestExecutionsRun_waitJSONIsParseable(t *testing.T) {
+	flowID := "e2e-executions-run-json"
+	deployExecutionsTestFlow(t, flowID)
+
+	stdout, stderr, err := RunAuthenticatedCliCmd(t, "executions", "run", executionsTestNamespace, flowID, "--wait", "--output", "json")
+	require.NoError(t, err, "run failed\nstdout: %s\nstderr: %s", stdout, stderr)
+
+	var execution struct {
+		ID    string `json:"id"`
+		State struct {
+			Current string `json:"current"`
+		} `json:"state"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &execution),
+		"stdout is not parseable JSON:\n%s", stdout)
+	require.NotEmpty(t, execution.ID)
+	require.Equal(t, "SUCCESS", execution.State.Current)
 }

--- a/src/cli/executions.go
+++ b/src/cli/executions.go
@@ -954,6 +954,7 @@ the execution completes (SUCCESS, FAILED, or other terminal state).`,
 			if err != nil {
 				return err
 			}
+			renderer.WithErrWriter(cmd.ErrOrStderr())
 			client, err := NewClient()
 			if err != nil {
 				return err
@@ -970,8 +971,10 @@ the execution completes (SUCCESS, FAILED, or other terminal state).`,
 
 func runExecutionsRun(client *Client, namespace, flowID string, wait bool, renderer *Renderer) error {
 	if wait {
-		fmt.Fprintf(renderer.Writer(), "Triggering execution of flow '%s' in namespace '%s'...\n", flowID, namespace)
-		fmt.Fprintln(renderer.Writer(), "Waiting for execution to complete...")
+		// Progress goes to stderr so it never mixes into the rendered output,
+		// which would make `--output json` unparseable.
+		fmt.Fprintf(renderer.ErrWriter(), "Triggering execution of flow '%s' in namespace '%s'...\n", flowID, namespace)
+		fmt.Fprintln(renderer.ErrWriter(), "Waiting for execution to complete...")
 	}
 
 	// POST /executions/{namespace}/{flowId} is shaped exactly like a 1.x action

--- a/src/cli/executions_test.go
+++ b/src/cli/executions_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -1565,5 +1566,61 @@ func TestExecutionsWatchCommand_ClientError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "client error") {
 		t.Fatalf("expected client error, got: %v", err)
+	}
+}
+
+func TestRunExecutionsRun_WaitJSONOutputIsParseable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"exec-1","namespace":"my.ns","flowId":"my-flow","state":{"current":"SUCCESS"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var out, errOut bytes.Buffer
+	renderer := newJSONRenderer(&out).WithErrWriter(&errOut)
+	if err := runExecutionsRun(newTestClient(t, server.URL), "my.ns", "my-flow", true, renderer); err != nil {
+		t.Fatalf("runExecutionsRun error: %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(out.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\nstdout:\n%s", err, out.String())
+	}
+	if payload["id"] != "exec-1" {
+		t.Errorf("expected execution id exec-1, got %v", payload["id"])
+	}
+}
+
+func TestRunExecutionsRun_WaitProgressGoesToErrWriter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"exec-1","namespace":"my.ns","flowId":"my-flow","state":{"current":"SUCCESS"}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	var out, errOut bytes.Buffer
+	renderer := newTableRenderer(&out).WithErrWriter(&errOut)
+	if err := runExecutionsRun(newTestClient(t, server.URL), "my.ns", "my-flow", true, renderer); err != nil {
+		t.Fatalf("runExecutionsRun error: %v", err)
+	}
+
+	progress := errOut.String()
+	if !strings.Contains(progress, "Triggering execution of flow 'my-flow' in namespace 'my.ns'...") {
+		t.Errorf("expected triggering notice on the error writer, got:\n%s", progress)
+	}
+	if !strings.Contains(progress, "Waiting for execution to complete...") {
+		t.Errorf("expected waiting notice on the error writer, got:\n%s", progress)
+	}
+
+	stdout := out.String()
+	if strings.Contains(stdout, "Triggering execution") || strings.Contains(stdout, "Waiting for execution") {
+		t.Errorf("progress lines must not reach stdout, got:\n%s", stdout)
+	}
+	// The result lines stay on stdout.
+	if !strings.Contains(stdout, "Execution ID: exec-1") {
+		t.Errorf("expected execution result on stdout, got:\n%s", stdout)
+	}
+	if !strings.Contains(stdout, "SUCCESS") {
+		t.Errorf("expected state on stdout, got:\n%s", stdout)
 	}
 }

--- a/src/cli/render.go
+++ b/src/cli/render.go
@@ -18,6 +18,7 @@ const (
 type Renderer struct {
 	format string
 	out    io.Writer
+	errOut io.Writer
 }
 
 func NewRenderer(output string, out io.Writer) (*Renderer, error) {
@@ -48,6 +49,23 @@ func (r *Renderer) IsJSON() bool {
 
 func (r *Renderer) Writer() io.Writer {
 	return r.out
+}
+
+// WithErrWriter sets the stream progress and diagnostic messages are written
+// to, keeping them out of the rendered output on Writer(). It returns the
+// receiver so it can be chained onto a constructor.
+func (r *Renderer) WithErrWriter(errOut io.Writer) *Renderer {
+	r.errOut = errOut
+	return r
+}
+
+// ErrWriter returns the stream for progress and diagnostic messages, which is
+// never the rendered-output stream. Defaults to os.Stderr.
+func (r *Renderer) ErrWriter() io.Writer {
+	if r.errOut == nil {
+		return os.Stderr
+	}
+	return r.errOut
 }
 
 func (r *Renderer) Render(value any, renderTable func(w *tabwriter.Writer) error) error {


### PR DESCRIPTION
## Summary

`kestractl executions run <ns> <flow> --wait -o json` emitted two prose progress lines before the JSON document, so `| jq .id` failed with a parse error. Table mode had the same problem in milder form: the progress was on stdout, mixed into the result. The progress lines now go to stderr; stdout carries only the rendered execution.

```
$ kestractl executions run e2e.executions e2e-executions-run-json --wait -o json 2>/dev/null | jq -r .id
zmMkiqi6hbLQpSJdI3OzW
```

## Root cause

`runExecutionsRun` (`src/cli/executions.go`) wrote both messages with `fmt.Fprintf(renderer.Writer(), …)`. `renderer.Writer()` is the command's stdout — the very stream `renderer.Render` then writes the JSON (or table) to.

A grep confirms these were the only two progress prints using the renderer's writer this way. The other two `renderer.Writer()` callers — `flows get` printing flow source and `flows usage-report` printing markdown — write actual output, not progress, and are untouched.

## Fix

- `Renderer` gained an optional `errOut` writer next to `out`, exposed as `ErrWriter()` (defaulting to `os.Stderr`) and settable via a chainable `WithErrWriter()`. This is additive: `NewRenderer` / `NewRendererFromFlags` signatures are unchanged, so no other command or test had to move, and `runX` stays testable with two buffers.
- `newExecutionsRunCommand` wires `cmd.ErrOrStderr()` into the renderer, matching how the version-check notice in `root.go` already reaches stderr.
- The two progress lines print via `renderer.ErrWriter()`. They still print — they are useful during a long wait.

**The result lines did not move.** `Execution ID: …`, `Flow: …`, `Namespace: …` and `State: …` are still rendered to stdout inside `renderer.Render`, so the `require.Contains(t, stdout, "State: SUCCESS")` pattern used by `e2e_tests/executions_usecases_test.go` (and, per the issue, by the pending #136 / #139 log suites) keeps working unchanged.

**No e2e assertion needed adjusting.** The only e2e caller of `executions run --wait` is `runTerminatedExecution`, which reads the id from stdout by regex and asserts `State: SUCCESS` in stdout — it does not assert an empty stderr. No `require.Empty(t, stderr)` exists on any `executions run` path.

Exit-code behaviour on a FAILED execution is explicitly **out of scope** here, as the issue notes.

## Tests

Written first, confirmed red for the right reason (`stdout is not valid JSON: invalid character 'T' looking for beginning of value`, with the two progress lines shown ahead of the JSON), then green.

New unit tests in `src/cli/executions_test.go`:
- `TestRunExecutionsRun_WaitJSONOutputIsParseable` — `--wait` with a JSON renderer over a buffer; `json.Unmarshal` of stdout must succeed and carry the execution id.
- `TestRunExecutionsRun_WaitProgressGoesToErrWriter` — both progress lines land on the error buffer, neither reaches stdout, and `Execution ID:` / `SUCCESS` still do.

New e2e test `TestExecutionsRun_waitJSONIsParseable` in `e2e_tests/executions_usecases_test.go` — runs `--wait --output json` for real, unmarshals stdout, asserts `.id` non-empty and `.state.current == "SUCCESS"`.

Commands run:

| command | result |
| --- | --- |
| `go build -o kestractl .` | ok |
| `go test ./src/...` | ok |
| `gofmt -l src/cli` | only pre-existing `apps.go`, `test_suites.go` (untouched by this PR) |
| `go vet ./src/...` | clean |
| `cd e2e_tests && go vet ./...` + `gofmt -l .` | clean |
| `cd e2e_tests && go test -run TestExecutionsRun_waitJSONIsParseable` | PASS (4.8s) against local Docker EE 2.0.0-rc13 on :9801 |
| `cd e2e_tests && go test -run TestExecution` | ok (29.4s) — whole executions suite, no regression |

Manual verification of `--wait -o json \| jq` on both server lines: EE 2.0.0-rc13 (:9801) and 1.3.35 (:9802) — both return a clean id and `SUCCESS`. Table mode manually checked too: result on stdout, the two progress lines on stderr.

Not verified: the full e2e matrix (`sh run-e2e-tests.sh`) across every version in `COMPATIBLE_KESTRA_VERSION.properties`; only the two locally running instances were exercised. CI covers the rest.

Fixes #135
