### PR TITLE
chore(release): yield GitHub's "latest" pointer to the v2 line

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,10 +46,12 @@ checksum:
 release:
   name_template: "{{ .Version }}"
   prerelease: auto
-  # releases/v1 is the default install channel: explicitly claim GitHub's
-  # repo-wide "latest" flag so the install script's default keeps resolving
-  # to v1 even after v2 releases are published from main.
-  make_latest: "true"
+  # v1 is the legacy maintenance line now that 2.0 is GA, so it yields GitHub's
+  # repo-wide "latest" pointer to main. This flag never drove the install
+  # default anyway -- install.sh resolves the newest release of a major line
+  # itself and defaults to VERSION=2 -- it drives the GitHub UI badge and the
+  # in-CLI update notifier, which reads /releases/latest.
+  make_latest: "false"
 
 changelog:
   sort: asc

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ A Go-based command-line interface for managing Kestra flows, executions, trigger
 ## Installation
 
 ### use convenience script installer
-Install the latest release (macOS/Linux):
+Install the latest kestractl **v1** release (macOS/Linux). `VERSION=1` is required: the
+installer defaults to the v2 line, so a bare invocation gives you kestractl 2.x, which
+targets Kestra 2.x.
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION=1 bash
 ```
 
 Install a specific version or custom directory:


### PR DESCRIPTION
Mirror of the GA cutover on `main` (#143), which claims `make_latest` for 2.0.0. GitHub has one repo-wide "latest" release, so exactly one branch can hold it — v1 is the legacy maintenance line now and gives it up.

**Merge this together with the `main` side**, so the two branches are never both claiming or both disclaiming the pointer.

## What actually changes

`make_latest` never drove the install default: `install.sh` resolves the newest release of a major line itself and has defaulted to `VERSION=2` since #123. The flag drives the GitHub UI badge and the in-CLI update notifier, which reads `/releases/latest`.

So the visible effect is that **v1 users start seeing a 2.x upgrade notice** on their next command. That is the intent of the cutover, not a side effect — worth being sure you want it at the same moment GA ships.

## Also in here

The install instruction on this branch told a v1 reader to run the installer bare:

```bash
curl -fsSL .../install.sh | bash
```

That has been handing them kestractl **2.x** ever since the installer default flipped to the v2 line — on the v1 branch's own README. Now passes `VERSION=1` and says why. Bundled rather than split out because it is the same "docs still describe the pre-cutover world" defect, on the one page a v1 user reads to install.