### PR TITLE
test: keep the test suites off the network

### DIFF
--- a/e2e_tests/utils_test.go
+++ b/e2e_tests/utils_test.go
@@ -140,6 +140,14 @@ func RunCliCmd(t *testing.T, args ...string) (stdout string, stderr string, err 
 //
 // Pointing HOME at a per-test temp dir makes the suite hermetic. The KESTRACTL_*
 // credential variables are dropped for the same reason, minus the harness's own.
+//
+// Telemetry and the update notifier are switched off here too. Every CLI run
+// otherwise calls api.kestra.io for the PostHog config, ships an event to
+// PostHog, and asks api.github.com for the latest release — third-party hosts
+// this suite has no business depending on, and real telemetry from a test run
+// lands in the production project. Note the KESTRACTL_* filter below drops
+// these if they come in from the ambient environment, so they are set after it,
+// not before.
 func isolatedEnv(t *testing.T) []string {
 	t.Helper()
 
@@ -162,7 +170,10 @@ func isolatedEnv(t *testing.T) []string {
 		}
 		env = append(env, kv)
 	}
-	return env
+	return append(env,
+		"KESTRACTL_TELEMETRY_DISABLED=true",
+		"KESTRACTL_VERSION_CHECK_DISABLED=true",
+	)
 }
 
 func cliExeName() string {

--- a/src/cli/main_test.go
+++ b/src/cli/main_test.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestMain fences the unit suite off from the network.
+//
+// Several commands talk to hosts we do not control — api.kestra.io for the
+// PostHog telemetry config, api.github.com for the update notifier,
+// repo1.maven.org for plugin downloads — and every test that exercises them is
+// expected to point the corresponding package var at an httptest server. That
+// convention is invisible until it is broken: a test that forgets an override
+// still passes, quietly making a real request, and only shows up later as a
+// flake on an offline machine or a rate-limited CI runner.
+//
+// So the dialer under the tests refuses anything that is not loopback. A missed
+// override fails with a message naming the address instead of succeeding by
+// accident.
+func TestMain(m *testing.M) {
+	blockExternalNetwork()
+	os.Exit(m.Run())
+}
+
+// errExternalNetwork is returned for any non-loopback dial attempt.
+type errExternalNetwork struct {
+	network string
+	address string
+}
+
+func (e *errExternalNetwork) Error() string {
+	return fmt.Sprintf(
+		"unit tests must not reach the network: blocked %s dial to %s. "+
+			"Point the relevant package var (telemetryConfigURL, newVersionCheckLatestReleaseURL, pluginsAPIBase, pluginsMavenBase, ...) at an httptest server",
+		e.network, e.address,
+	)
+}
+
+func blockExternalNetwork() {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		panic("http.DefaultTransport is not *http.Transport; cannot install the network guard")
+	}
+
+	// Mutated in place on purpose: newCompatHTTPClient captures
+	// http.DefaultTransport as its base at construction time, so replacing the
+	// package var would leave the SDK path unguarded.
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
+		if !isLoopbackAddress(address) {
+			return nil, &errExternalNetwork{network: network, address: address}
+		}
+		return dialer.DialContext(ctx, network, address)
+	}
+	// A proxy in the developer's or runner's environment would otherwise turn
+	// every external request into a loopback dial and slip past the guard.
+	transport.Proxy = nil
+}
+
+func isLoopbackAddress(address string) bool {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+
+	if host == "localhost" {
+		return true
+	}
+
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// TestNetworkGuard_BlocksExternalDialsAndAllowsLoopback keeps TestMain honest.
+// Without it the guard could become a silent no-op — a changed transport type, a
+// client that builds its own — and nothing else in the suite would notice.
+//
+// The external case is itself hermetic: http.Transport hands the dialer the
+// hostname, so the guard rejects it before any DNS lookup happens.
+func TestNetworkGuard_BlocksExternalDialsAndAllowsLoopback(t *testing.T) {
+	if _, err := http.Get("https://api.github.com/repos/kestra-io/kestractl/releases/latest"); err == nil {
+		t.Fatal("expected the external request to be blocked")
+	} else if !strings.Contains(err.Error(), "unit tests must not reach the network") {
+		t.Fatalf("expected the guard's error, got %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Close()
+
+	res, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("loopback request must still work, got %v", err)
+	}
+	_ = res.Body.Close()
+}

--- a/src/cli/main_test.go
+++ b/src/cli/main_test.go
@@ -7,7 +7,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -22,12 +24,67 @@ import (
 // still passes, quietly making a real request, and only shows up later as a
 // flake on an offline machine or a rate-limited CI runner.
 //
-// So the dialer under the tests refuses anything that is not loopback. A missed
-// override fails with a message naming the address instead of succeeding by
-// accident.
+// So the dialer under the tests refuses anything that is not loopback. Blocking
+// the dial is not enough on its own: several of those fetches are best-effort
+// and swallow the client error (fetchPosthogConfig returns "", ""; the update
+// notifier just gives up), so the test that forgot its override would still
+// pass. Every blocked address is therefore recorded, and the run fails here
+// after m.Run() even if no assertion noticed.
 func TestMain(m *testing.M) {
 	blockExternalNetwork()
-	os.Exit(m.Run())
+	code := m.Run()
+
+	if blocked := blockedExternalDials(); len(blocked) > 0 {
+		fmt.Fprintf(os.Stderr, "\nunit tests must not reach the network, but %d external dial(s) were attempted:\n", len(blocked))
+		for _, address := range blocked {
+			fmt.Fprintf(os.Stderr, "  - %s\n", address)
+		}
+		fmt.Fprint(os.Stderr, "Point the relevant package var (telemetryConfigURL, newVersionCheckLatestReleaseURL, pluginsAPIBase, pluginsMavenBase, ...) at an httptest server.\n")
+		if code == 0 {
+			code = 1
+		}
+	}
+
+	os.Exit(code)
+}
+
+// guardSelfTestHost is the target of the guard's own self-test. It is blocked
+// like any other external address but deliberately left out of the report, so
+// the self-test does not fail the run it is verifying. `.invalid` is reserved by
+// RFC 2606 and never resolves, which keeps the self-test offline-safe: if the
+// guard ever regresses into a no-op, the request fails on DNS rather than
+// actually reaching a host we do not control.
+const guardSelfTestHost = "kestractl-network-guard.invalid"
+
+var (
+	blockedDialsMu sync.Mutex
+	blockedDials   = map[string]struct{}{}
+)
+
+func recordBlockedDial(address string) {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		host = address
+	}
+	if host == guardSelfTestHost {
+		return
+	}
+
+	blockedDialsMu.Lock()
+	defer blockedDialsMu.Unlock()
+	blockedDials[address] = struct{}{}
+}
+
+func blockedExternalDials() []string {
+	blockedDialsMu.Lock()
+	defer blockedDialsMu.Unlock()
+
+	addresses := make([]string, 0, len(blockedDials))
+	for address := range blockedDials {
+		addresses = append(addresses, address)
+	}
+	sort.Strings(addresses)
+	return addresses
 }
 
 // errExternalNetwork is returned for any non-loopback dial attempt.
@@ -56,6 +113,7 @@ func blockExternalNetwork() {
 	dialer := &net.Dialer{Timeout: 5 * time.Second}
 	transport.DialContext = func(ctx context.Context, network, address string) (net.Conn, error) {
 		if !isLoopbackAddress(address) {
+			recordBlockedDial(address)
 			return nil, &errExternalNetwork{network: network, address: address}
 		}
 		return dialer.DialContext(ctx, network, address)
@@ -84,9 +142,11 @@ func isLoopbackAddress(address string) bool {
 // client that builds its own — and nothing else in the suite would notice.
 //
 // The external case is itself hermetic: http.Transport hands the dialer the
-// hostname, so the guard rejects it before any DNS lookup happens.
+// hostname, so the guard rejects it before any DNS lookup happens, and the
+// hostname is an unresolvable `.invalid` one so a regressed guard fails offline
+// rather than reaching a real host.
 func TestNetworkGuard_BlocksExternalDialsAndAllowsLoopback(t *testing.T) {
-	if _, err := http.Get("https://api.github.com/repos/kestra-io/kestractl/releases/latest"); err == nil {
+	if _, err := http.Get("https://" + guardSelfTestHost + "/repos/kestra-io/kestractl/releases/latest"); err == nil {
 		t.Fatal("expected the external request to be blocked")
 	} else if !strings.Contains(err.Error(), "unit tests must not reach the network") {
 		t.Fatalf("expected the guard's error, got %v", err)
@@ -100,4 +160,34 @@ func TestNetworkGuard_BlocksExternalDialsAndAllowsLoopback(t *testing.T) {
 		t.Fatalf("loopback request must still work, got %v", err)
 	}
 	_ = res.Body.Close()
+}
+
+// TestNetworkGuard_ReportsBlockedDialsExceptTheSelfTest covers the reporting
+// half of the guard: a blocked address must land in the report TestMain reads,
+// while the self-test's own target must not.
+func TestNetworkGuard_ReportsBlockedDialsExceptTheSelfTest(t *testing.T) {
+	recordBlockedDial(guardSelfTestHost + ":443")
+	for _, address := range blockedExternalDials() {
+		if strings.HasPrefix(address, guardSelfTestHost) {
+			t.Fatalf("the self-test target must not be reported, got %q", address)
+		}
+	}
+
+	const sentinel = "api.example.test:443"
+	recordBlockedDial(sentinel)
+	defer func() {
+		blockedDialsMu.Lock()
+		delete(blockedDials, sentinel)
+		blockedDialsMu.Unlock()
+	}()
+
+	found := false
+	for _, address := range blockedExternalDials() {
+		if address == sentinel {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected %q in the blocked-dial report, got %v", sentinel, blockedExternalDials())
+	}
 }


### PR DESCRIPTION
Tests should not depend on hosts we do not control. Two gaps here — one latent, one live.

## Unit suite: the convention was unenforced

`src/cli` already routes every external endpoint through a package var (`telemetryConfigURL`, `newVersionCheckLatestReleaseURL`, `pluginsAPIBase`, `pluginsMavenBase`) so tests can point it at an `httptest` server. Nothing enforced that. A test that forgot the override still passed while quietly calling `api.kestra.io`, `api.github.com` or `repo1.maven.org` — surfacing later as a flake on an offline machine or a rate-limited runner.

`src/cli/main_test.go` adds a `TestMain` that installs a dialer rejecting any non-loopback address, with an error naming the address and the vars to override. Two details worth knowing:

- The transport is **mutated in place** rather than replaced. `newCompatHTTPClient` captures `http.DefaultTransport` as its base at construction time, so swapping the package var would have left the SDK path unguarded.
- `Proxy` is nilled, otherwise an ambient `HTTP_PROXY` turns every external request into a loopback dial and slips past the guard.

`TestNetworkGuard_BlocksExternalDialsAndAllowsLoopback` keeps the guard from silently degrading into a no-op. It is hermetic: `http.Transport` hands the dialer the hostname, so the rejection happens before any DNS lookup.

**No existing test was blocked** — the suite was already clean. This only keeps it that way.

## E2E suite: a live leak

`isolatedEnv` strips every `KESTRACTL_*` variable to keep the developer's own credentials out of a run. That also stripped `KESTRACTL_TELEMETRY_DISABLED`, so every CLI invocation in the e2e suite fetched the PostHog config from `api.kestra.io` and shipped a `cli_command_executed` event to the **production** PostHog project.

Both switches are now set *after* the filter loop. The update notifier was already inert there (`go build` with no ldflags leaves `version == "dev"`, which `newVersionCheckSkipped` bails on), but it is set explicitly so it does not come back to life if the harness ever stamps a version.

## Verification

- `go test ./src/...` — pass, including `-race`
- `gofmt` / `go vet` clean on both modules (the pre-existing `gofmt` diffs in `apps.go` and `test_suites.go` are untouched and unrelated)
- Guard confirmed to block external and allow loopback via its own test

`test:` prefix, so no version bump.