### PR TITLE
installer: authenticate GitHub API calls when a token is available

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,15 +37,24 @@ jobs:
           .github/scripts/next-version_test.sh
           .github/scripts/check-sdk-pin_test.sh
 
+      # GITHUB_TOKEN: the installer reads release metadata from the GitHub REST API,
+      # which is rate-limited per IP for anonymous callers. Runners share egress IPs,
+      # so without a token these steps intermittently fail with HTTP 403.
       - name: Check installer defaults to the v2 line
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat ./install-scripts/install.sh | INSTALL_DIR=./ bash
           ./kestractl version | grep -E '(^|[^0-9.])2\.[0-9]+\.[0-9]+'
       - name: Check installer is working when specifying the v1 line
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat ./install-scripts/install.sh | VERSION=1 INSTALL_DIR=./ bash
           ./kestractl version | grep -E '(^|[^0-9.])1\.[0-9]+\.[0-9]+'
       - name: Check installer is working when specifying an exact version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cat ./install-scripts/install.sh | VERSION=1.0.0 INSTALL_DIR=./ bash
           ./kestractl --help

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Install a specific version or custom directory:
 curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | VERSION=1.18.1 INSTALL_DIR=~/.local/bin bash
 ```
 
+The script resolves the release through the GitHub REST API, which is rate-limited per IP for anonymous callers — shared CI egress IPs can hit that limit and fail with `HTTP 403`. Set `GITHUB_TOKEN` (or `GH_TOKEN`) and the API calls are authenticated instead; it is optional and no token is needed for a normal install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/kestra-io/kestractl/main/install-scripts/install.sh | GITHUB_TOKEN="$GITHUB_TOKEN" bash
+```
+
 ### or choose and download the proper binary for your OS/arch
 download the compressed or plain binary for your platform at https://github.com/kestra-io/kestractl/releases
 

--- a/install-scripts/install.sh
+++ b/install-scripts/install.sh
@@ -9,6 +9,12 @@ INSTALL_DIR="${INSTALL_DIR:-}"
 # VERSION=1 selects the legacy v1 line, VERSION=x.y.z an exact release.
 DEFAULT_MAJOR="2"
 VERSION="${VERSION:-}"
+# Release metadata comes from the GitHub REST API, which is rate-limited per IP
+# for anonymous callers. CI runners share egress IPs and do hit that limit
+# (HTTP 403), so the API calls are authenticated whenever a token is available.
+# Both names GitHub Actions exposes are accepted; without either one the calls
+# stay anonymous and the script works exactly as before.
+GITHUB_API_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
 
 err() {
   printf "Error: %s\n" "$1" >&2
@@ -23,9 +29,20 @@ download() {
   local url="$1"
   local output="$2"
   local http_code
+  local token=""
+
+  # Only api.github.com is authenticated: it is the rate-limited endpoint, while
+  # release assets are public and served from another host that rejects GitHub
+  # tokens. The header is built as an array so the token is never word-split nor
+  # echoed; ${a[@]+"${a[@]}"} keeps an empty array safe under `set -u` on bash 3.2.
+  case "$url" in
+    https://api.github.com/*) token="$GITHUB_API_TOKEN" ;;
+  esac
 
   if command -v curl >/dev/null 2>&1; then
-    http_code="$(curl -sSL -w "%{http_code}" -o "$output" "$url" || true)"
+    local auth=()
+    [ -z "$token" ] || auth=(-H "Authorization: Bearer $token")
+    http_code="$(curl -sSL ${auth[@]+"${auth[@]}"} -w "%{http_code}" -o "$output" "$url" || true)"
     if [ -z "$http_code" ]; then
       rm -f "$output"
       err "Download failed: $url"
@@ -39,7 +56,9 @@ download() {
       err "Download failed (HTTP $http_code): $url"
     fi
   elif command -v wget >/dev/null 2>&1; then
-    http_code="$(wget -q --server-response --spider "$url" 2>&1 | awk '/^  HTTP/{code=$2} END{print code}')"
+    local auth=()
+    [ -z "$token" ] || auth=(--header="Authorization: Bearer $token")
+    http_code="$(wget -q --server-response --spider ${auth[@]+"${auth[@]}"} "$url" 2>&1 | awk '/^  HTTP/{code=$2} END{print code}')"
     if [ -z "$http_code" ]; then
       err "Download failed: $url"
     fi
@@ -49,7 +68,7 @@ download() {
     if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 400 ]; then
       err "Download failed (HTTP $http_code): $url"
     fi
-    if ! wget -qO "$output" "$url"; then
+    if ! wget ${auth[@]+"${auth[@]}"} -qO "$output" "$url"; then
       err "Download failed: $url"
     fi
   else


### PR DESCRIPTION
## What

`install-scripts/install.sh` resolves the release to install through the GitHub REST API. Those calls are anonymous, and anonymous API calls are rate-limited **per IP** — our CI runners share egress IPs, so the release pipeline fails with:

```
Error: Download failed (HTTP 403): https://api.github.com/repos/kestra-io/kestractl/releases/tags/v2.0.0
```

(seen in the v1.3.38 `Publish docker` run, step "Install kestractl" — https://github.com/kestra-io/kestra/actions/runs/34234285461)

## How

- `download()` sends `Authorization: Bearer <token>` when `GITHUB_TOKEN` or `GH_TOKEN` is set. Anonymous installs are unchanged, so external users are unaffected — the token is optional everywhere.
- Only `https://api.github.com/*` URLs get the header. Release assets are public and served from a different host that rejects GitHub tokens.
- The header is passed as an array element, so the token is never word-split and never printed (errors only ever show the URL). `${a[@]+"${a[@]}"}` keeps the empty case safe under `set -u` on bash 3.2 (macOS).
- The installer smoke tests in `tests.yml` hit the same endpoint anonymously today; they now get `secrets.GITHUB_TOKEN`.
- README documents the optional variable.

## Testing

Ran the patched script under macOS bash 3.2: anonymous install OK, `GITHUB_TOKEN` install OK, `GH_TOKEN` fallback confirmed (a bogus token yields `HTTP 401`, proving the header is sent, with no token in the output).

The caller side (passing the token from the release workflows) is a companion PR in `kestra-io/actions`.