### PR TITLE
docs: generate the README's compatible-Kestra-version badges

### DIFF
--- a/.github/scripts/render-compat-badges.sh
+++ b/.github/scripts/render-compat-badges.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Render the README's compatible-Kestra-version badges from
+# COMPATIBLE_KESTRA_VERSION.properties, the single source of truth that also
+# drives the e2e matrix (see .github/workflows/list-versions.yml).
+#
+# Usage:
+#   render-compat-badges.sh            rewrite the README block in place
+#   render-compat-badges.sh --check    exit 1 if the README block is stale (CI)
+#
+# Env overrides, used by render-compat-badges_test.sh:
+#   PROPERTIES  path to the properties file (default: repo root)
+#   README      path to the README to rewrite (default: repo root)
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+properties="${PROPERTIES:-$root/COMPATIBLE_KESTRA_VERSION.properties}"
+readme="${README:-$root/README.md}"
+
+start_marker='<!-- compat-badges:start -->'
+end_marker='<!-- compat-badges:end -->'
+
+# Kept in one place so a rebrand is a one-line change.
+released_color='8405FF'   # Kestra purple: version lines with a release behind them
+moving_color='6B4BA8'     # dimmed: moving targets like `develop`, not a release
+label_color='15112B'
+badge_style='for-the-badge'
+properties_link='COMPATIBLE_KESTRA_VERSION.properties'
+
+for f in "$properties" "$readme"; do
+  [ -f "$f" ] || { printf 'render-compat-badges: %s not found\n' "$f" >&2; exit 1; }
+done
+
+mode=rewrite
+case "${1:-}" in
+  --check) mode=check ;;
+  '') ;;
+  *) printf 'render-compat-badges: unknown argument %s (want --check or nothing)\n' "$1" >&2; exit 1 ;;
+esac
+
+# shields.io reserves `-` (field separator) and `_` (space); both are escaped by
+# doubling. A literal space becomes %20 and the separator pipe %7C.
+shields_escape() {
+  printf '%s' "$1" | sed -e 's/-/--/g' -e 's/_/__/g' -e 's/|/%7C/g' -e 's/ /%20/g'
+}
+
+# Split the file into release lines (numeric, e.g. v1.3) and moving targets
+# (anything else, e.g. develop). `|| [ -n "$line" ]` so the last line still
+# counts when the file has no trailing newline -- this one currently doesn't.
+releases=''
+moving=''
+while IFS= read -r line || [ -n "$line" ]; do
+  # Trim surrounding whitespace, skip blanks and `#` comments.
+  version="$(printf '%s' "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+  [ -n "$version" ] || continue
+  case "$version" in \#*) continue ;; esac
+
+  if printf '%s' "$version" | grep -qE '^v?[0-9]'; then
+    # Display without the `v` prefix; newest first, so prepend.
+    releases="${version#v}${releases:+ | }$releases"
+  else
+    moving="${moving:+$moving }$version"
+  fi
+done <"$properties"
+
+[ -n "$releases" ] || { printf 'render-compat-badges: %s lists no version lines\n' "$properties" >&2; exit 1; }
+
+# Newest-first ordering comes from reversing the file, which is maintained in
+# ascending order. Deliberately NOT a version sort: neither `sort -V` nor
+# `sort -t. -k1,1n` is semver-correct on prerelease suffixes (see AGENTS.md).
+block="$start_marker
+[![Compatible Kestra versions](https://img.shields.io/badge/Kestra-$(shields_escape "$releases")-${released_color}?style=${badge_style}&labelColor=${label_color})](${properties_link})"
+
+for target in $moving; do
+  block="$block
+[![Kestra $target](https://img.shields.io/badge/$(shields_escape "$target")-tracked-${moving_color}?style=${badge_style}&labelColor=${label_color})](${properties_link})"
+done
+
+block="$block
+$end_marker"
+
+grep -qF "$start_marker" "$readme" || {
+  printf 'render-compat-badges: %s has no %s marker\n' "$readme" "$start_marker" >&2
+  exit 1
+}
+grep -qF "$end_marker" "$readme" || {
+  printf 'render-compat-badges: %s has no %s marker\n' "$readme" "$end_marker" >&2
+  exit 1
+}
+
+# Replace everything between the markers, inclusive. Done in awk rather than
+# sed so the multi-line replacement needs no escaping of its own.
+rendered="$(BLOCK="$block" awk -v s="$start_marker" -v e="$end_marker" '
+  index($0, s) { print ENVIRON["BLOCK"]; skip = 1; next }
+  index($0, e) { skip = 0; next }
+  !skip
+' "$readme")"
+
+if [ "$mode" = check ]; then
+  if printf '%s\n' "$rendered" | diff -u "$readme" - >/dev/null; then
+    printf 'render-compat-badges: README badges match %s\n' "$(basename "$properties")"
+    exit 0
+  fi
+  printf 'render-compat-badges: README badges are stale (want <, got >):\n' >&2
+  printf '%s\n' "$rendered" | diff -u "$readme" - >&2 || true
+  printf 'render-compat-badges: run .github/scripts/render-compat-badges.sh to regenerate.\n' >&2
+  exit 1
+fi
+
+printf '%s\n' "$rendered" >"$readme"
+printf 'render-compat-badges: wrote %s\n' "$readme"

--- a/.github/scripts/render-compat-badges_test.sh
+++ b/.github/scripts/render-compat-badges_test.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Tests for render-compat-badges.sh, which keeps the README's compatibility
+# badges in sync with COMPATIBLE_KESTRA_VERSION.properties.
+set -uo pipefail
+
+here="$(cd "$(dirname "$0")" && pwd)"
+script="$here/render-compat-badges.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+failures=0
+
+fail() { printf 'FAIL %s: %s\n' "$1" "$2"; failures=$((failures + 1)); }
+pass() { printf 'ok   %s\n' "$1"; }
+
+# readme <marker-body> -- a minimal README with the markers in place.
+readme() {
+  printf '# kestractl\n\n<!-- compat-badges:start -->\n%s<!-- compat-badges:end -->\n\nprose below\n' "$1"
+}
+
+# render <name> <properties-body> <expected-badge-lines>
+render() {
+  local name="$1" props="$2" want="$3"
+  local p="$tmp/props" r="$tmp/README.md"
+  printf '%s' "$props" >"$p"
+  readme '' >"$r"
+
+  if ! PROPERTIES="$p" README="$r" bash "$script" >/dev/null 2>&1; then
+    fail "$name" 'script exited non-zero'
+    return
+  fi
+
+  local got
+  got="$(sed -n '/compat-badges:start/,/compat-badges:end/p' "$r" | sed -e '1d' -e '$d')"
+  if [ "$got" != "$want" ]; then
+    fail "$name" "badges differ
+--- want ---
+$want
+--- got ----
+$got"
+    return
+  fi
+  pass "$name"
+}
+
+# badge <alt-text> <label-and-message> <color> -- one expected markdown line.
+badge() {
+  printf '[![%s](https://img.shields.io/badge/%s-%s?style=for-the-badge&labelColor=15112B)](COMPATIBLE_KESTRA_VERSION.properties)' \
+    "$1" "$2" "$3"
+}
+versions() { badge 'Compatible Kestra versions' "Kestra-$1" '8405FF'; }
+tracked() { badge "Kestra $1" "$2-tracked" '6B4BA8'; }
+
+# --- rendering -------------------------------------------------------------
+
+# The file as it actually ships: ascending versions, `develop` last, and no
+# trailing newline on that last line.
+render 'repo shape' 'v1.0
+v1.1
+v1.2
+v1.3
+v2.0
+develop' \
+"$(versions '2.0%20%7C%201.3%20%7C%201.2%20%7C%201.1%20%7C%201.0')
+$(tracked develop develop)"
+
+# Newest first regardless of how many lines, `v` prefix stripped, and a file
+# that does end in a newline works the same.
+render 'trailing newline and single version' 'v2.0
+' \
+"$(versions '2.0')"
+
+render 'blank lines and comments skipped' '# only these matter
+
+v1.3
+
+v2.0
+' \
+"$(versions '2.0%20%7C%201.3')"
+
+render 'surrounding whitespace trimmed' '  v1.3
+	v2.0
+' \
+"$(versions '2.0%20%7C%201.3')"
+
+# shields.io treats `-` as its field separator and `_` as a space, so both must
+# be doubled or the badge renders as the wrong number of fields.
+render 'shields metacharacters escaped' 'v2.0
+develop-nightly
+some_branch
+' \
+"$(versions '2.0')
+$(tracked 'develop-nightly' 'develop--nightly')
+$(tracked 'some_branch' 'some__branch')"
+
+# --- README handling -------------------------------------------------------
+
+p="$tmp/props"; r="$tmp/README.md"
+printf 'v2.0\ndevelop' >"$p"
+
+# Content outside the markers must survive untouched.
+readme '' >"$r"
+PROPERTIES="$p" README="$r" bash "$script" >/dev/null 2>&1
+if grep -qF '# kestractl' "$r" && grep -qF 'prose below' "$r"; then
+  pass 'preserves content outside the markers'
+else
+  fail 'preserves content outside the markers' 'surrounding lines lost'
+fi
+
+# Running twice must not append or drift.
+first="$(cat "$r")"
+PROPERTIES="$p" README="$r" bash "$script" >/dev/null 2>&1
+if [ "$first" = "$(cat "$r")" ]; then
+  pass 'idempotent'
+else
+  fail 'idempotent' 'second run changed the README'
+fi
+
+# --check on the freshly rendered README.
+if PROPERTIES="$p" README="$r" bash "$script" --check >/dev/null 2>&1; then
+  pass '--check accepts a fresh README'
+else
+  fail '--check accepts a fresh README' 'reported stale'
+fi
+
+# --check must fail, and must not rewrite, when the badges are stale.
+readme 'stale badge\n' >"$r"
+before="$(cat "$r")"
+if PROPERTIES="$p" README="$r" bash "$script" --check >/dev/null 2>&1; then
+  fail '--check rejects a stale README' 'reported in sync'
+elif [ "$before" != "$(cat "$r")" ]; then
+  fail '--check rejects a stale README' '--check rewrote the file'
+else
+  pass '--check rejects a stale README'
+fi
+
+# A README that predates the markers must fail loudly, not silently no-op.
+printf '# kestractl\n\nno markers here\n' >"$r"
+if PROPERTIES="$p" README="$r" bash "$script" >/dev/null 2>&1; then
+  fail 'missing markers rejected' 'accepted a README without markers'
+else
+  pass 'missing markers rejected'
+fi
+
+# --- bad input -------------------------------------------------------------
+
+readme '' >"$r"
+printf '# comments only\n\n' >"$p"
+if PROPERTIES="$p" README="$r" bash "$script" >/dev/null 2>&1; then
+  fail 'empty properties rejected' 'accepted a file with no versions'
+else
+  pass 'empty properties rejected'
+fi
+
+printf 'v2.0\n' >"$p"
+if PROPERTIES="$p" README="$r" bash "$script" --oops >/dev/null 2>&1; then
+  fail 'unknown flag rejected' 'accepted --oops'
+else
+  pass 'unknown flag rejected'
+fi
+
+if PROPERTIES="$tmp/nope" README="$r" bash "$script" >/dev/null 2>&1; then
+  fail 'missing properties file rejected' 'accepted a nonexistent path'
+else
+  pass 'missing properties file rejected'
+fi
+
+# --- the real files --------------------------------------------------------
+
+# The committed README must already be in sync, so CI's --check is meaningful.
+if bash "$script" --check >/dev/null 2>&1; then
+  pass 'committed README is in sync'
+else
+  fail 'committed README is in sync' 'run .github/scripts/render-compat-badges.sh'
+fi
+
+if [ "$failures" -ne 0 ]; then
+  printf '\n%d test(s) failed\n' "$failures"
+  exit 1
+fi
+printf '\nall tests passed\n'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,10 +32,17 @@ jobs:
       - name: Run tests
         run: go test ./src/...
 
-      - name: Test the release automation scripts
+      - name: Test the automation scripts
         run: |
           .github/scripts/next-version_test.sh
           .github/scripts/check-sdk-pin_test.sh
+          .github/scripts/render-compat-badges_test.sh
+
+      # COMPATIBLE_KESTRA_VERSION.properties drives both the e2e matrix below and
+      # the README badges. Fail loudly rather than let the badges drift from the
+      # versions actually tested; the diff and the fix command are in the output.
+      - name: Check the README compatibility badges are up to date
+        run: .github/scripts/render-compat-badges.sh --check
 
       # GITHUB_TOKEN: the installer reads release metadata from the GitHub REST API,
       # which is rate-limited per IP for anonymous callers. Runners share egress IPs,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,13 @@ See `CONTRIBUTING.md` for the full checklist. Key points:
 
 `e2e_tests/` is a **separate Go module**. It builds the `kestractl` binary, then uses `os/exec` to run real CLI commands against a live Kestra EE instance. Compatible versions are listed in `COMPATIBLE_KESTRA_VERSION.properties`. Docker setup lives in `e2e_tests/docker-setup/`.
 
+`COMPATIBLE_KESTRA_VERSION.properties` has two consumers, so it is the single source of truth for "which Kestra versions does this support":
+
+- `.github/workflows/list-versions.yml` turns it into the e2e matrix.
+- `.github/scripts/render-compat-badges.sh` renders the README's compatibility badges between the `<!-- compat-badges:start -->` / `end` markers. Numeric lines are grouped into one badge, newest first; anything else (`develop`) gets its own dimmed "tracked" badge. Run it after editing the properties file — `--check` runs in the `Tests` workflow and fails with the diff if the README drifted.
+
+Keep the properties file in **ascending** order: the badge script renders newest-first by reversing it rather than version-sorting, deliberately, because no shell sort is semver-correct on prerelease suffixes (see the release traps above).
+
 ## Code Review & QA
 
 In addition to `Common pitfalls` above, check for:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # kestractl
 
+<!-- compat-badges:start -->
+[![Compatible Kestra versions](https://img.shields.io/badge/Kestra-2.0%20%7C%201.3%20%7C%201.2%20%7C%201.1%20%7C%201.0-8405FF?style=for-the-badge&labelColor=15112B)](COMPATIBLE_KESTRA_VERSION.properties)
+[![Kestra develop](https://img.shields.io/badge/develop-tracked-6B4BA8?style=for-the-badge&labelColor=15112B)](COMPATIBLE_KESTRA_VERSION.properties)
+<!-- compat-badges:end -->
+
 A Go-based command-line interface for managing Kestra flows, executions, triggers, namespaces, key-value store, namespace files, apps, dashboards, assets, blueprints, test suites, IAM users, groups, roles, service accounts, bindings, and invitations.
+
+Every version in the badges above is exercised by the e2e matrix on each run. The source of truth is [`COMPATIBLE_KESTRA_VERSION.properties`](COMPATIBLE_KESTRA_VERSION.properties) — edit that file, then run `.github/scripts/render-compat-badges.sh` to regenerate the badges (CI checks they are in sync).
 
 ## Installation
 


### PR DESCRIPTION
## What

The README now shows which Kestra versions kestractl is compatible with, as badges — and they are **generated** from `COMPATIBLE_KESTRA_VERSION.properties` rather than hand-maintained.

![Kestra 2.0 | 1.3 | 1.2 | 1.1 | 1.0](https://img.shields.io/badge/Kestra-2.0%20%7C%201.3%20%7C%201.2%20%7C%201.1%20%7C%201.0-8405FF?style=for-the-badge&labelColor=15112B)
![develop tracked](https://img.shields.io/badge/develop-tracked-6B4BA8?style=for-the-badge&labelColor=15112B)

## Why generated

That properties file already drove the e2e matrix (`list-versions.yml`). A hand-written badge next to it is a second answer to "which versions do we support" that can silently disagree with the one CI actually tests. Now there is one source of truth with two consumers.

## How

`.github/scripts/render-compat-badges.sh` rewrites the block between the `<!-- compat-badges:start/end -->` markers in the README:

- numeric lines are grouped into one Kestra-purple badge, newest first
- anything else (`develop`) gets its own dimmed "tracked" badge
- both badges link back to the properties file

Add a line to the properties file, run the script, done.

## CI

In the `Tests` workflow's `test` job:

- `render-compat-badges_test.sh` joins the existing script tests (14 cases: rendering, shields.io metacharacter escaping, idempotency, missing markers, bad input, and that the committed README is in sync)
- a `--check` step fails with the exact diff and the one command that fixes it

**A check, not a bot commit** — deliberately. `auto-tag.yml` fires on a green `Tests` run on `main`, so a CI push to `main` would retrigger the whole suite (unit + installer + e2e matrix) on every properties edit. The check costs a contributor one command; the auto-commit costs a redundant e2e matrix and a push to `main`. Easy to swap later if we'd rather have the bot.

## Reviewer note

Newest-first ordering comes from **reversing** the file, not sorting it, so `COMPATIBLE_KESTRA_VERSION.properties` must stay in ascending order. That is on purpose: no shell sort (`sort -V` included) is semver-correct on prerelease suffixes, which AGENTS.md already flags as a trap for the release tags — a `v2.0.0-rc.3` line would sort into the wrong place. The constraint is documented in AGENTS.md alongside the file's two consumers.

## Test plan

- [x] `go test ./src/...` — pass
- [x] `.github/scripts/render-compat-badges_test.sh` — 14/14 pass
- [x] `.github/scripts/render-compat-badges.sh --check` — clean on the committed README
- [x] Added a `v2.1` line by hand: `--check` failed with the expected diff, the script regenerated the badge to `2.1 | 2.0 | 1.3 | …`, restore left the properties file byte-identical
- [x] All four badge URLs return HTTP 200 from shields.io

No product code touched — README, CI config, AGENTS.md, and two new scripts.