### PR TITLE
fix(ci): publish images to GHCR only until Docker Hub is authorized

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ env:
   # Unlike GitHub's pointer this one is NOT inert on a prerelease, so the rolling
   # tag step below keeps an rc off `:latest` itself.
   DOCKER_LATEST: "true"
+  # Mapped here so the login step can be conditioned on them; `secrets` is not
+  # available in a step `if`.
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD || secrets.DOCKERHUB_TOKEN }}
 
 jobs:
   release:
@@ -105,11 +109,17 @@ jobs:
       - name: Docker init
         uses: kestra-io/actions/composite/setup-docker@main
 
+      # Skipped when the secret is absent rather than hard-failing: docker/login-action
+      # errors on an empty username, and this step runs before GoReleaser, so a
+      # missing or rotated secret would take down the binary release too. The
+      # secrets are mapped into `env` because the `secrets` context is not
+      # available in a step-level `if`.
       - name: Login to Docker Hub
+        if: env.DOCKERHUB_USERNAME != ''
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD || secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_PASSWORD }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -174,7 +184,11 @@ jobs:
             rolling="$major"
           fi
 
-          for repo in kestra/kestractl ghcr.io/kestra-io/kestractl; do
+          # Keep this list in step with `images:` in .goreleaser.yml. A repo listed
+          # here but not published there has no source manifest, so regctl fails
+          # and takes the release down -- add kestra/kestractl back to both at the
+          # same time, never to one alone.
+          for repo in ghcr.io/kestra-io/kestractl; do
             for suffix in "" "-static"; do
               src="${repo}:${version}${suffix}"
               for target in $rolling; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,12 +98,14 @@ jobs:
       - name: Smoke test images
         run: |
           set -euo pipefail
+          # Must match the (single) entry in `images:` in .goreleaser.yml.
+          image=ghcr.io/kestra-io/kestractl
           version=$(jq -r .version dist/metadata.json)
-          docker run --rm "kestra/kestractl:${version}-amd64" version
-          docker run --rm "kestra/kestractl:${version}-amd64" --help > /dev/null
-          docker run --rm --entrypoint sh "kestra/kestractl:${version}-amd64" \
+          docker run --rm "${image}:${version}-amd64" version
+          docker run --rm "${image}:${version}-amd64" --help > /dev/null
+          docker run --rm --entrypoint sh "${image}:${version}-amd64" \
             -c 'git --version && curl --version && bash --version' > /dev/null
-          docker run --rm "kestra/kestractl:${version}-static-amd64" version
+          docker run --rm "${image}:${version}-static-amd64" version
 
   e2e-tests:
     needs: list-versions

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -83,7 +83,16 @@ dockers_v2:
     ids: [kestractl]
     dockerfile: Dockerfile
     images:
-      - kestra/kestractl
+      # Docker Hub is disabled until the CI token can push to kestra/kestractl.
+      # It authenticates fine but the push is refused with "access token has
+      # insufficient scopes", and the repository does not exist for the push to
+      # auto-create -- a repository-scoped token cannot create one. Because
+      # dockers_v2 publishes before the GitHub release pipe, that failure took
+      # the whole v2.1.0 release down with it, binaries included.
+      # To re-enable: create kestra/kestractl in the kestra org, give the token
+      # behind DOCKERHUB_USERNAME Read & Write on it, then uncomment the line
+      # below in BOTH entries and update README.md + AGENTS.md.
+      # - kestra/kestractl
       - ghcr.io/kestra-io/kestractl
     tags:
       - "{{ .Version }}"
@@ -105,7 +114,16 @@ dockers_v2:
     ids: [kestractl]
     dockerfile: Dockerfile.static
     images:
-      - kestra/kestractl
+      # Docker Hub is disabled until the CI token can push to kestra/kestractl.
+      # It authenticates fine but the push is refused with "access token has
+      # insufficient scopes", and the repository does not exist for the push to
+      # auto-create -- a repository-scoped token cannot create one. Because
+      # dockers_v2 publishes before the GitHub release pipe, that failure took
+      # the whole v2.1.0 release down with it, binaries included.
+      # To re-enable: create kestra/kestractl in the kestra org, give the token
+      # behind DOCKERHUB_USERNAME Read & Write on it, then uncomment the line
+      # below in BOTH entries and update README.md + AGENTS.md.
+      # - kestra/kestractl
       - ghcr.io/kestra-io/kestractl
     tags:
       - "{{ .Version }}-static"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,9 @@ Each auto-tagged release is what a default `curl … | bash` install resolves to
 
 ### Container images
 
-Every release also publishes a multi-arch (`linux/amd64` + `linux/arm64`) image, built by GoReleaser from the same tag (`dockers_v2` in `.goreleaser.yml`) and pushed to both `kestra/kestractl` and `ghcr.io/kestra-io/kestractl`, in two variants: Alpine (default tag) and distroless (`-static`).
+Every release also publishes a multi-arch (`linux/amd64` + `linux/arm64`) image, built by GoReleaser from the same tag (`dockers_v2` in `.goreleaser.yml`) and pushed to `ghcr.io/kestra-io/kestractl`, in two variants: Alpine (default tag) and distroless (`-static`).
+
+**Docker Hub is currently disabled.** `kestra/kestractl` is commented out of `images:` in `.goreleaser.yml`: the CI token authenticates but the push is refused with "access token has insufficient scopes", and the repository does not exist for the push to auto-create. Because `dockers_v2` publishes *before* the GitHub release pipe, that failure aborted the whole `v2.1.0` release — binaries included, so `install.sh` kept serving `v2.0.0` and the `v2.1.0` tag is orphaned with no release behind it. Re-enabling means creating the repo, granting the token Read & Write, then uncommenting the line in **both** `dockers_v2` entries *and* adding the repo back to the `for repo in …` loop in `release.yml` — a registry in one but not the other either skips its rolling tags or fails `regctl` on a missing source.
 
 Four things to know before touching this:
 

--- a/README.md
+++ b/README.md
@@ -48,18 +48,19 @@ chmod +x kestractl
 
 ### or run it as a container
 
-Every release publishes a multi-arch (`linux/amd64` + `linux/arm64`) image to both
-Docker Hub and GitHub Container Registry:
+Every release publishes a multi-arch (`linux/amd64` + `linux/arm64`) image to GitHub
+Container Registry:
 
 ```bash
-docker run --rm kestra/kestractl:2 --help
 docker run --rm ghcr.io/kestra-io/kestractl:2 --help
 ```
 
+A Docker Hub mirror at `kestra/kestractl` is planned but not published yet.
+
 | Tag | Contents |
 | --- | --- |
-| `latest`, `2`, `2.0`, `2.0.0` | Alpine based, with `bash`, `git` and `curl` — use this in CI jobs that run scripts |
-| `latest-static`, `2-static`, `2.0-static`, `2.0.0-static` | distroless, no shell — smallest surface, runs `kestractl` only |
+| `latest`, `2`, `2.1`, `2.1.0` | Alpine based, with `bash`, `git` and `curl` — use this in CI jobs that run scripts |
+| `latest-static`, `2-static`, `2.1-static`, `2.1.0-static` | distroless, no shell — smallest surface, runs `kestractl` only |
 
 `latest`, `X` and `X.Y` follow the newest stable release. Pin `X.Y.Z` in CI if you want a
 release to stay put; a prerelease, should one be published, only ever moves `X`.
@@ -72,7 +73,7 @@ docker run --rm \
   -e KESTRACTL_TENANT=main \
   -e KESTRACTL_USERNAME=admin@example.com \
   -e KESTRACTL_PASSWORD='...' \
-  kestra/kestractl:2 flows list
+  ghcr.io/kestra-io/kestractl:2 flows list
 ```
 
 or by mounting a config file. The images run as a non-root user, so mount it at that
@@ -83,14 +84,14 @@ user's home: `/home/kestractl/.kestractl` (Alpine) or `/home/nonroot/.kestractl`
 docker run --rm \
   -v ~/.kestractl:/home/kestractl/.kestractl:ro \
   -v "$PWD/flows:/flows:ro" \
-  kestra/kestractl:2 flows deploy /flows
+  ghcr.io/kestra-io/kestractl:2 flows deploy /flows
 ```
 
 Deploying flows from GitLab CI:
 
 ```yaml
 deploy-flows:
-  image: kestra/kestractl:2
+  image: ghcr.io/kestra-io/kestractl:2
   variables:
     KESTRACTL_HOST: https://kestra.example.com
     KESTRACTL_TENANT: main


### PR DESCRIPTION
The `v2.1.0` release failed. The Docker Hub **login succeeded**, but the push was refused:

```
failed to push kestra/kestractl:2.1.0: failed to authorize: failed to fetch oauth token:
401 Unauthorized: access token has insufficient scopes
```

The CI token is valid but not authorized to push to `kestra/kestractl`, and the repository does not exist for the push to auto-create — a repository-scoped token cannot create one. Fixing that is a Docker Hub account action, tracked separately; this PR unblocks releases in the meantime.

### Why it took the whole release down

`dockers_v2` publishes *before* the GitHub release pipe (`internal/pipe/publish/publish.go`), so the Docker failure aborted the run before the release was created:

| | |
|---|---|
| Tag `v2.1.0` | exists (`ef0c87b`) |
| GitHub release for `v2.1.0` | **missing** — newest release is still `2.0.0` |
| `ghcr.io/kestra-io/kestractl` | `2.1.0`, `2.1.0-static` ✅ |
| `docker.io/kestra/kestractl` | nothing |
| Rolling tags | not applied |

So `curl … | bash` still installs v2.0.0. GHCR worked fine — the images pushed successfully before the Docker Hub leg failed — so this drops Docker Hub and keeps everything else.

### Four places had to move together

A registry listed in one place but not the others either fails or silently tests nothing:

- **`.goreleaser.yml`** — `kestra/kestractl` commented out of both `dockers_v2` entries, with the re-enable steps in the comment.
- **`release.yml`** — the rolling-tag loop no longer iterates Docker Hub. It would have run `regctl image copy` against a source manifest that was never pushed and **failed the next release too**, for a different reason.
- **`tests.yml`** — the smoke test pulled `kestra/kestractl:<v>-amd64`, which snapshot builds no longer produce, so `docker-build` would have failed. The image name is now derived once rather than repeated four times.
- **`README.md` / `AGENTS.md`** — documented as GHCR-only, with what to undo.

### Also fixes review finding #2

The incident vindicated it, so it is folded in: the Docker Hub login is now skipped when the secret is absent instead of hard-failing. It runs before GoReleaser, so a missing or rotated secret would otherwise take down the binary release as well.

Note the suggested `if: ${{ secrets.DOCKERHUB_USERNAME != '' }}` cannot work — `secrets` is not available in a step-level `if` (nor a job-level one) and raises `Unrecognized named-value`. The secrets are mapped into workflow `env` and the condition tests `env` instead.

### Verification

- `goreleaser check` clean; snapshot builds all four images, **all** under `ghcr.io`, none under `kestra/kestractl`.
- The smoke-test commands run green against the built images (version, `--help`, `git`/`curl`/`bash`, static variant).
- Rolling-tag script emits GHCR targets only — for `v2.1.1` with `DOCKER_LATEST=true`: `2.1`, `2`, `latest` plus the three `-static` forms.
- `render-compat-badges.sh --check` and `go test ./src/...` pass.

### After merge

This is a `fix:`, so Auto Tag will cut **`v2.1.1`** and release it. Retrying `v2.1.0` is not an option: `workflow_dispatch` checks out the tag's tree, which still has Docker Hub enabled. The `v2.1.0` tag stays orphaned with no release behind it — delete it or leave it, your call.

Worth a follow-up: the failed run burned **28 minutes** because GoReleaser retried the push 10 times with backoff on an auth error that could never succeed. Capping `dockers_v2`'s `retry` would fail fast.