### PR TITLE
ci: add Dependabot and security scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,94 @@
+# See GitHub's docs for more information on this file:
+# https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates
+
+# Commit-message prefixes are deliberate, not cosmetic: `main` auto-releases, and
+# `.github/scripts/next-version.sh` derives the version bump from the squashed
+# merge subject, which GitHub takes from the PR title.
+#
+# Every ecosystem here uses `ci(deps)`, which scores no bump: a routine version
+# update is not worth a release on its own, and they accumulate until the next
+# real change ships them. Security updates are the exception, and are handled
+# without a prefix of their own — Dependabot has no per-update-type prefix, so
+# `dependabot-security-prefix.yml` retitles a security PR to `fix(deps)`
+# (-> patch) once it can see the advisory metadata.
+#
+# See "Dependencies & Security Scanning" in AGENTS.md.
+version: 2
+
+updates:
+  # GitHub Actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    commit-message:
+      prefix: "ci(deps)"
+      prefix-development: "ci(deps)"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      timezone: "Europe/Paris"
+      time: "08:00"
+    open-pull-requests-limit: 50
+    labels: ["dependency-upgrade", "area/devops"]
+    groups:
+      actions:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  # Go modules for the CLI itself.
+  - package-ecosystem: "gomod"
+    directory: "/"
+    commit-message:
+      prefix: "ci(deps)"
+      prefix-development: "ci(deps)"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      timezone: "Europe/Paris"
+      time: "08:00"
+    open-pull-requests-limit: 50
+    labels: ["dependency-upgrade"]
+    groups:
+      # Everything but the SDK moves together; the SDK is the API contract with
+      # Kestra itself and is reviewed on its own.
+      go-minor-and-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        exclude-patterns: ["github.com/kestra-io/client-sdk/*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # The Go SDK major axis tracks the Kestra major line this branch targets
+      # (v2 here). A major bump is a deliberate migration, never a dep PR.
+      - dependency-name: "github.com/kestra-io/client-sdk/go-sdk/*"
+        update-types: ["version-update:semver-major"]
+
+  # e2e_tests is a separate Go module.
+  - package-ecosystem: "gomod"
+    directory: "/e2e_tests"
+    commit-message:
+      prefix: "ci(deps)"
+      prefix-development: "ci(deps)"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      timezone: "Europe/Paris"
+      time: "08:00"
+    open-pull-requests-limit: 50
+    labels: ["dependency-upgrade", "area/qa"]
+    groups:
+      e2e:
+        applies-to: version-updates
+        patterns: ["*"]
+
+  # Base images for the released containers (Dockerfile + Dockerfile.static).
+  - package-ecosystem: "docker"
+    directory: "/"
+    commit-message:
+      prefix: "ci(deps)"
+      prefix-development: "ci(deps)"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      timezone: "Europe/Paris"
+      time: "08:00"
+    open-pull-requests-limit: 50
+    labels: ["dependency-upgrade", "area/devops"]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,64 @@
+# CodeQL static analysis. Mirrors kestra-io/kestra's codeql-analysis.yml, with
+# `go` as the only language — this repo is a single Go module plus a second one
+# under e2e_tests/, both of which CodeQL's Go extractor picks up on its own.
+name: "CodeQL"
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths-ignore:
+      - "**.md"
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - "**.md"
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch: {}
+
+# Deliberately not part of the `Tests` workflow: `auto-tag.yml` releases on a
+# green `Tests` run, and a newly published CodeQL rule must not be able to
+# freeze the release line.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["go"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-security-prefix.yml
+++ b/.github/workflows/dependabot-security-prefix.yml
@@ -1,0 +1,75 @@
+# Retitles a Dependabot *security* PR from `ci(deps)` to `fix(deps)`, and labels
+# it `kind/security`.
+#
+# Why this exists: `main` auto-releases off the squashed merge subject, which
+# GitHub takes from the PR title, and `.github/scripts/next-version.sh` scores
+# `ci` as no bump and `fix` as a patch. That is the behaviour we want — a routine
+# version bump should not cut a release, a security fix should ship immediately —
+# but Dependabot has a single `commit-message.prefix` per ecosystem and no way to
+# vary it by update type. So `dependabot.yml` sets the release-neutral prefix and
+# this promotes the security ones.
+#
+# `pull_request_target` is required: on a PR from Dependabot the `pull_request`
+# token is read-only, so it cannot retitle. That is safe here only because this
+# workflow never checks out or executes the PR's code — it reads advisory
+# metadata and calls the API. Keep it that way.
+name: Dependabot Security Prefix
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  promote:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # `ghsa-id` is empty on a plain version update and set on a security one.
+      - name: Promote the title to fix(deps)
+        if: ${{ steps.metadata.outputs.ghsa-id != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          TITLE: ${{ github.event.pull_request.title }}
+          GHSA: ${{ steps.metadata.outputs.ghsa-id }}
+          CVE: ${{ steps.metadata.outputs.cve-id }}
+        run: |
+          set -euo pipefail
+
+          case "$TITLE" in
+            fix\(deps\):*)
+              echo "Already promoted: $TITLE"
+              exit 0
+              ;;
+            ci\(deps\):*)
+              new="fix(deps):${TITLE#ci\(deps\):}"
+              ;;
+            *)
+              # An unexpected prefix means dependabot.yml and this workflow have
+              # drifted apart. Fail loudly rather than release-scoring a security
+              # fix as `none` in silence.
+              echo "::error::Unrecognised Dependabot title prefix: $TITLE" >&2
+              echo "::error::Expected 'ci(deps):' — check .github/dependabot.yml." >&2
+              exit 1
+              ;;
+          esac
+
+          gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --title "$new"
+          gh pr edit "$PR" --repo "$GITHUB_REPOSITORY" --add-label kind/security
+          printf '%s\n' \
+            "Retitled to: $new" \
+            "Advisory: ${GHSA}${CVE:+ / $CVE}" \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,38 @@
+# Submits the resolved Go build list to GitHub's dependency graph, the Go
+# analogue of kestra-io/kestra's Gradle `dependency-submission.yml`.
+#
+# Why it matters here: Dependabot alerts are raised against the dependency
+# graph. Without a submission, GitHub infers the graph from go.mod alone, which
+# omits transitive modules pulled in only via go.sum — so an alert on one of
+# those would never fire. This makes the graph the real `go mod graph` output.
+name: Dependency Submission
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Generate and submit dependency graph
+        uses: actions/go-dependency-submission@v2
+        with:
+          go-mod-path: go.mod
+          go-build-target: .

--- a/.github/workflows/vulnerabilities-check.yml
+++ b/.github/workflows/vulnerabilities-check.yml
@@ -1,0 +1,131 @@
+# Vulnerability scanning. The Go analogue of kestra-io/kestra's
+# vulnerabilities-check.yml: `govulncheck` replaces the OWASP Gradle dependency
+# check (it reports only vulnerabilities actually reachable from our code, so it
+# needs no NVD API key and produces few false positives), and Trivy scans the
+# published container images exactly as it does there.
+#
+# Deliberately a workflow of its own rather than a job in `Tests`:
+# `auto-tag.yml` releases on a green `Tests` run, and a CVE published against an
+# already-released dependency must not be able to freeze the release line.
+name: Vulnerabilities Checks
+
+on:
+  pull_request:
+    paths:
+      - "go.mod"
+      - "go.sum"
+      - "e2e_tests/go.mod"
+      - "e2e_tests/go.sum"
+      - "Dockerfile*"
+      - ".github/workflows/vulnerabilities-check.yml"
+  push:
+    branches: ["main"]
+    paths:
+      - "go.mod"
+      - "go.sum"
+      - "e2e_tests/go.mod"
+      - "e2e_tests/go.sum"
+      - "Dockerfile*"
+  schedule:
+    - cron: "0 0 * * *" # Every day
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: Go Vulnerability Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both Go modules in the repo. See "E2E Tests" in AGENTS.md.
+        include:
+          - module: "."
+            name: kestractl
+          - module: "e2e_tests"
+            name: e2e-tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # `stable`, not go.mod's `go 1.25.0`: govulncheck v1.8+ itself requires Go
+      # >= 1.26 to build. Note this scans the standard library of the *current*
+      # toolchain, while releases are still built with 1.25 (see the `go-version`
+      # pins in tests.yml and release.yml) — worth keeping those in step.
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+          cache: true
+          cache-dependency-path: |
+            go.sum
+            e2e_tests/go.sum
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      # SARIF first so the findings reach the Security tab even when the
+      # human-readable run below fails the job.
+      - name: Run govulncheck (SARIF)
+        working-directory: ${{ matrix.module }}
+        run: govulncheck -format sarif ./... > "${RUNNER_TEMP}/govulncheck.sarif"
+
+      - name: Upload govulncheck results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: ${{ always() }}
+        with:
+          sarif_file: ${{ runner.temp }}/govulncheck.sarif
+          category: govulncheck-${{ matrix.name }}
+
+      - name: Run govulncheck
+        working-directory: ${{ matrix.module }}
+        run: govulncheck ./...
+
+  image-check:
+    name: Image Check (${{ matrix.image }})
+    # The images are built by GoReleaser at release time, so there is nothing to
+    # scan on a pull request.
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # The two variants published for every release: Alpine (default tag) and
+        # distroless (`-static`). See "Container images" in AGENTS.md.
+        image: ["kestra/kestractl:latest", "kestra/kestractl:latest-static"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Pinned by digest, same pin as kestra-io/kestra uses.
+      - name: Docker Vulnerabilities Check
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        with:
+          image-ref: ${{ matrix.image }}
+          format: "sarif"
+          scanners: vuln
+          severity: "CRITICAL,HIGH"
+          output: "trivy-results.sarif"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: ${{ always() }}
+        with:
+          sarif_file: "trivy-results.sarif"
+          category: docker-${{ matrix.image }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,25 @@ In addition to `Common pitfalls` above, check for:
 
 **Known EE gotcha:** a superadmin configured with only `kestra.security.super-admin.username`/`password` never gets a tenant or `ADMIN` role bound, so every API call 403s even though login succeeds. Fix is setting `kestra.security.super-admin.tenant-admin-access: [<tenant-id>]` (e.g. `[main]`) too, which triggers tenant auto-creation and binds the built-in `ADMIN` role on startup. Check for this config before assuming a kestractl auth/permission bug.
 
+## Dependencies & Security Scanning
+
+Five automated pieces, modelled on `kestra-io/kestra`'s setup and adapted to Go:
+
+- **`.github/dependabot.yml`** — weekly updates (Wednesday 08:00 Europe/Paris, matching the other repos) for GitHub Actions, the root Go module, the `e2e_tests` Go module, and the Docker base images.
+- **`dependabot-security-prefix.yml`** — retitles a Dependabot *security* PR to `fix(deps)` so it releases, and labels it `kind/security`.
+- **`codeql-analysis.yml`** — CodeQL for `go` with the `security-and-quality` query pack, on PRs to `main` and weekly.
+- **`vulnerabilities-check.yml`** — `govulncheck` on both Go modules (the Go analogue of kestra's OWASP `dependencyCheckAggregate`; it reports only vulnerabilities reachable from our code, so it needs no NVD API key), plus a daily Trivy scan of the published `kestra/kestractl:latest` and `:latest-static` images.
+- **`dependency-submission.yml`** — submits the resolved `go mod graph` to GitHub's dependency graph on every push to `main`. Without it, Dependabot alerts only see `go.mod`'s direct requirements, so an advisory against a transitive module never fires.
+
+Four things to know before touching this:
+
+- **A security bump releases; a routine bump does not.** `main` auto-releases off the squashed merge subject, which GitHub takes from the PR title. Every ecosystem in `dependabot.yml` therefore uses `ci(deps)`, which scores no bump — a routine version update is not urgent and rides along with the next real change. Security updates are the exception, and Dependabot has one `commit-message.prefix` per ecosystem with no way to vary it by update type, so `dependabot-security-prefix.yml` promotes those to `fix(deps)` (→ patch) off the advisory metadata. The two files are coupled: change a prefix in `dependabot.yml` and the promotion step fails loudly on the next security PR rather than silently scoring it `none`.
+- **That promotion workflow runs on `pull_request_target` and must never check out the PR.** A `pull_request` token is read-only on a Dependabot PR, so it cannot retitle; `pull_request_target` gets a writable token, which is only safe because the job reads advisory metadata and calls the API, never the branch's code.
+- **Neither scanner is a job in `Tests`, deliberately.** `auto-tag.yml` releases on a green `Tests` run, so a CVE published against an already-released dependency, or a newly shipped CodeQL rule, would otherwise freeze the release line on work unrelated to the merge.
+- **`govulncheck` runs on `stable` Go, not `go.mod`'s version.** govulncheck v1.8+ needs Go >= 1.26 to build at all. That means it scans the standard library of the current toolchain while releases are still built with the `go-version: "1.25"` pins in `tests.yml` and `release.yml` — bump those together, or the scan and the shipped binary disagree about which stdlib CVEs apply.
+
+Already enabled repo-side and needing no file here: secret scanning, push protection, and Dependabot security updates.
+
 ## Branching & Releases
 
 Two long-lived branches, two release lines:


### PR DESCRIPTION
No repo in the org has any security scanning on a Go codebase, and kestractl had no `dependabot.yml` at all. This ports `kestra-io/kestra`'s setup and adapts it to Go.

## What other kestra repos do

| Repo | Dependabot | Security scanning |
|---|---|---|
| `kestra` | Actions, Gradle, npm — weekly Wed 08:00 Europe/Paris, `dependency-upgrade` + `area/*` labels, grouped patterns | `codeql-analysis.yml` (java, javascript), `vulnerabilities-check.yml` (OWASP `dependencyCheckAggregate` + Trivy on `develop`/`latest` → SARIF), `dependency-submission.yml` |
| `kestra-ee` | same + a GAR maven registry | same minus CodeQL, on private runners |
| `terraform-provider-kestra` | Actions + gomod, daily | none |
| `plugin-*`, `client-sdk`, `docs` | Actions + Gradle/npm, weekly | none |

Already enabled repo-side and needing no file here: secret scanning, push protection, non-provider patterns, and Dependabot **security** updates. What was missing is version updates and every scanner.

## Added

- **`.github/dependabot.yml`** — Actions, root Go module, `e2e_tests` (a separate module), and the Docker base images, on the org's Wednesday 08:00 Europe/Paris cadence with the org's labels. Grouped to keep PR volume down; the `go-sdk` **major** axis is ignored, since that tracks the Kestra major line and is a deliberate migration, never a dep PR.
- **`dependabot-security-prefix.yml`** — promotes a Dependabot *security* PR's title to `fix(deps)` and labels it `kind/security`.
- **`codeql-analysis.yml`** — CodeQL for `go`, `security-and-quality` pack, on PRs to `main` and weekly.
- **`vulnerabilities-check.yml`** — `govulncheck` on both Go modules with SARIF to the Security tab, plus a daily Trivy scan of `kestra/kestractl:latest` and `:latest-static`. `govulncheck` is the Go analogue of kestra's OWASP check: it reports only vulnerabilities reachable from our code, so it needs no NVD API key and produces few false positives.
- **`dependency-submission.yml`** — submits the resolved `go mod graph`. Without it GitHub infers the graph from `go.mod` alone, so a Dependabot alert against a transitive module would never fire.
- **AGENTS.md** — a section documenting all of it, including the two couplings below.

## Two things this repo forced, worth a careful read

**1. A security bump releases; a routine bump does not.** `main` auto-releases off the squashed merge subject, which GitHub takes from the PR title, and `next-version.sh` scores `ci` as no bump and `fix` as a patch. Dependabot has a single `commit-message.prefix` per ecosystem and no way to vary it by update type, so every ecosystem here uses the release-neutral `ci(deps)` and `dependabot-security-prefix.yml` promotes the security ones to `fix(deps)` off the advisory metadata (`ghsa-id`). Net effect: a routine version bump accumulates and rides along with the next real change, a security fix ships a patch immediately.

The two files are coupled by that prefix. If it changes in `dependabot.yml`, the promotion step fails loudly on the next security PR rather than silently scoring it `none` — that error path is deliberate.

That workflow needs `pull_request_target`, because the `pull_request` token is read-only on a Dependabot PR and cannot retitle. It is safe only because the job never checks out or executes the PR's code — it reads metadata and calls the API. Please keep it that way if you touch it.

**2. A real finding: the Go toolchain is behind.** `govulncheck` v1.8+ won't build below Go 1.26, so the scan runs on `stable`. On Go 1.26.3 the shipped code has **8 reachable stdlib CVEs** (`crypto/x509`, `net/http`, via `render.go`, `compat.go`, `telemetry.go`, `plugins.go`); on 1.26.8 it is clean. But `tests.yml` and `release.yml` still pin `go-version: "1.25"`, so that is the stdlib we actually ship.

Bumping those pins is release-affecting and outside the scope of "add scanning", so I left it out rather than folding it in silently. It wants a follow-up PR, and it is the reason the AGENTS.md note tells you to bump the two together.

## Why neither scanner is a job in `Tests`

`auto-tag.yml` releases on a green `Tests` run. A CVE published against an already-released dependency, or a newly shipped CodeQL rule, would otherwise freeze the release line on something unrelated to the merge. Both run as their own workflows and report to the Security tab.

## Verification

- All five YAML files parse.
- `govulncheck` run locally on both modules: clean on current stable, and its SARIF output parses as valid SARIF 2.1.
- The title-rewrite shell logic exercised against `ci(deps):`, an already-promoted `fix(deps):`, and an unexpected prefix — promotes, skips, and errors respectively.
- The Trivy action is pinned to the same digest `kestra-io/kestra` uses.

Not exercised end-to-end: the promotion workflow can only really be seen on a live Dependabot security PR, and the image scan needs the published images, so it runs on schedule/dispatch only.
