### PR TITLE
fix(plugins): verify downloads with the strongest published checksum

### DIFF
--- a/src/cli/bindings.go
+++ b/src/cli/bindings.go
@@ -363,9 +363,18 @@ func runBindingsBulkCreate(client *Client, path string, renderer *Renderer) erro
 		return fmt.Errorf("failed to read file: %w", err)
 	}
 
-	var requests interface{}
+	// A slice of maps rather than the SDK's generated request model: the fields
+	// are forwarded to the API verbatim, so a server that accepts a key this
+	// SDK build does not model still works. It is also not a bare interface{} —
+	// that would accept any JSON at all (an object, a bare string, a number)
+	// and defer the complaint to an opaque server-side error, when --file is
+	// documented as an array of binding requests.
+	var requests []map[string]any
 	if err := json.Unmarshal(data, &requests); err != nil {
-		return fmt.Errorf("failed to parse JSON file: %w", err)
+		return fmt.Errorf("failed to parse JSON file: %w (expected a JSON array of binding requests)", err)
+	}
+	if len(requests) == 0 {
+		return fmt.Errorf("no binding requests found in %s: expected a non-empty JSON array", path)
 	}
 
 	bindings, err := client.Kestra.Bindings().BulkCreateBinding(client.Ctx, client.Tenant, requests)

--- a/src/cli/bindings_test.go
+++ b/src/cli/bindings_test.go
@@ -343,3 +343,33 @@ func TestRunBindingsBulkCreate(t *testing.T) {
 		t.Errorf("expected binding ID in output, got:\n%s", buf.String())
 	}
 }
+
+func TestRunBindingsBulkCreate_RejectsNonArrayFile(t *testing.T) {
+	cases := map[string]string{
+		"a single object": `{"type":"USER","externalId":"u1","roleId":"r1"}`,
+		"a bare string":   `"USER"`,
+		"an empty array":  `[]`,
+		"malformed JSON":  `[{"type":`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			f, err := os.CreateTemp("", "bindings-*.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(f.Name())
+			f.WriteString(body)
+			f.Close()
+
+			// No server: a shape this wrong must fail before any request.
+			var buf bytes.Buffer
+			err = runBindingsBulkCreate(newTestClient(t, "http://127.0.0.1:1"), f.Name(), newTableRenderer(&buf))
+			if err == nil {
+				t.Fatalf("expected an error for %s, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "JSON array") {
+				t.Errorf("expected the error to explain the expected shape, got: %v", err)
+			}
+		})
+	}
+}

--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -3,10 +3,13 @@ package cli
 import (
 	"context"
 	"crypto/sha1"
+	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"hash"
 	"io"
 	"net/http"
 	"os"
@@ -27,6 +30,33 @@ var errRateLimited = errors.New("rate limited by repository (429)")
 // rateLimitWaits defines the back-off delays between successive 429 retries.
 // Exposed as a var so tests can override it to avoid sleeping.
 var rateLimitWaits = []time.Duration{5 * time.Second, 10 * time.Second, 30 * time.Second}
+
+// checksumAlgorithm describes one of the checksum files a Maven repository
+// publishes alongside an artifact.
+type checksumAlgorithm struct {
+	ext    string // checksum file extension, without the dot
+	name   string // human-readable name, for log messages
+	hexLen int    // length of the hex-encoded digest
+	new    func() hash.Hash
+}
+
+// checksumAlgorithms lists the checksum files we accept, strongest first.
+//
+// SHA-1 is not collision resistant, so it is the last resort rather than the
+// only option: a repository that publishes .sha512 or .sha256 gets verified
+// with that instead. It cannot simply be dropped — Maven Central has only
+// published the stronger sums since 2020, and private repositories (including
+// the ones an EE install is usually pointed at) frequently carry .sha1 alone,
+// where refusing it would mean no verification at all.
+//
+// Note this is defence against a corrupted or substituted artifact, not against
+// a hostile repository: the checksum comes from the same host as the JAR, so an
+// attacker who controls the response controls both.
+var checksumAlgorithms = []checksumAlgorithm{
+	{ext: "sha512", name: "SHA-512", hexLen: 128, new: sha512.New},
+	{ext: "sha256", name: "SHA-256", hexLen: 64, new: sha256.New},
+	{ext: "sha1", name: "SHA-1", hexLen: 40, new: sha1.New},
+}
 
 // pluginsAPIBase and pluginsMavenBase are vars so tests can point them at a local httptest server.
 var (
@@ -651,21 +681,13 @@ func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifac
 			return 0, true, nil
 		}
 	}
-	expectedSHA1, err := fetchExpectedSHA1(ctx, logf, url, label, mavenUsername, mavenPassword, headers)
+	algo, expectedSum, err := fetchExpectedChecksum(ctx, logf, url, label, mavenUsername, mavenPassword, headers)
 	if err != nil {
 		if errors.Is(err, errRateLimited) {
 			return 0, false, err
 		}
-		logf("  [WARN] failed to fetch expected SHA-1 for %s: %v, proceeding without checksum validation\n", label, err)
-		expectedSHA1 = ""
-	} else if expectedSHA1 != "" {
-		if len(expectedSHA1) != 40 {
-			logf("  [WARN] expected SHA-1 for %s has invalid length (%d), proceeding without checksum validation\n", label, len(expectedSHA1))
-			expectedSHA1 = ""
-		} else if _, hexErr := hex.DecodeString(expectedSHA1); hexErr != nil {
-			logf("  [WARN] expected SHA-1 for %s is not valid hex, proceeding without checksum validation\n", label)
-			expectedSHA1 = ""
-		}
+		logf("  [WARN] failed to fetch a checksum for %s: %v, proceeding without checksum validation\n", label, err)
+		expectedSum = ""
 	}
 
 	for attempt := 0; ; attempt++ {
@@ -737,43 +759,85 @@ func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifac
 			return 0, false, fmt.Errorf("failed to finalize download (rename error): %w", err)
 		}
 
-		if expectedSHA1 != "" {
-			actualSHA1, hashErr := fileSHA1(destPath)
+		if expectedSum != "" {
+			actualSum, hashErr := fileChecksum(destPath, algo)
 			if hashErr != nil {
 				os.Remove(destPath)
-				return 0, false, fmt.Errorf("failed to compute SHA-1 of downloaded file: %w", hashErr)
+				return 0, false, fmt.Errorf("failed to compute %s of downloaded file: %w", algo.name, hashErr)
 			}
-			if actualSHA1 != expectedSHA1 {
+			if actualSum != expectedSum {
 				os.Remove(destPath)
-				return 0, false, fmt.Errorf("checksum mismatch for %s: expected %s, got %s", label, expectedSHA1, actualSHA1)
+				return 0, false, fmt.Errorf("checksum mismatch (%s) for %s: expected %s, got %s", algo.name, label, expectedSum, actualSum)
 			}
 		}
 		return n, false, nil
 	}
 }
 
-// fileSHA1 computes and returns the hex-encoded SHA-1 checksum of the file at the
-// given path.
-func fileSHA1(path string) (string, error) {
+// fileChecksum computes and returns the hex-encoded digest of the file at the
+// given path, using the given algorithm.
+func fileChecksum(path string, algo checksumAlgorithm) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", fmt.Errorf("cannot open file: %w", err)
 	}
 	defer f.Close()
-	hasher := sha1.New()
+	hasher := algo.new()
 	if _, err := io.Copy(hasher, f); err != nil {
 		return "", fmt.Errorf("cannot read file: %w", err)
 	}
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
-// fetchExpectedSHA1 retrieves the expected SHA-1 checksum for a given Maven artifact URL.
-// It executes a retriable HTTP request using the provided credentials and headers and limits the
-// response read to 256 bytes, handles both types of hash files
-// (just the plain hash, or the hash followed by a filename)
-func fetchExpectedSHA1(ctx context.Context, logf func(string, ...any), jarURL string, label string, mavenUsername string, mavenPassword string, headers map[string]string) (string, error) {
+// fetchExpectedChecksum negotiates the strongest checksum the repository
+// publishes for a given Maven artifact URL, returning the algorithm and its
+// expected hex digest. It returns an empty digest when the repository publishes
+// none of them, which leaves the download unverified — the pre-existing
+// behaviour when no .sha1 was available.
+func fetchExpectedChecksum(ctx context.Context, logf func(string, ...any), jarURL string, label string, mavenUsername string, mavenPassword string, headers map[string]string) (checksumAlgorithm, string, error) {
+	var tried []string
+	for _, algo := range checksumAlgorithms {
+		tried = append(tried, "."+algo.ext)
+
+		sum, err := fetchChecksumFile(ctx, logf, jarURL, label, algo, mavenUsername, mavenPassword, headers)
+		if err != nil {
+			// A back-off signal is about the repository, not this algorithm, so
+			// it must reach the caller rather than fall through to a weaker one.
+			if errors.Is(err, errRateLimited) {
+				return checksumAlgorithm{}, "", err
+			}
+			// Any other failure on a stronger algorithm is worth reporting only
+			// if the weaker ones fail too; keep trying.
+			if algo.ext == checksumAlgorithms[len(checksumAlgorithms)-1].ext {
+				return checksumAlgorithm{}, "", err
+			}
+			continue
+		}
+		if sum != "" {
+			return algo, sum, nil
+		}
+	}
+
+	logf("  [warn] no checksum published for %s (tried %s) — skipping checksum verification\n", label, strings.Join(tried, ", "))
+	return checksumAlgorithm{}, "", nil
+}
+
+// fetchChecksumFile retrieves one checksum file (`<jarURL>.<ext>`) for a Maven
+// artifact. It executes a retriable HTTP request using the provided credentials
+// and headers, limits the response read to 256 bytes, and handles both types of
+// hash files (just the plain hash, or the hash followed by a filename).
+//
+// An empty return with a nil error means "this repository does not publish this
+// checksum", so the caller can fall through to a weaker algorithm. That covers
+// a 404 and, deliberately, a response whose body is not a digest of the
+// expected width: repositories and caching proxies are known to answer a
+// missing checksum file with 200 and the artifact itself, or with an HTML error
+// page, and treating either as a checksum would fail every download.
+func fetchChecksumFile(ctx context.Context, logf func(string, ...any), jarURL string, label string, algo checksumAlgorithm, mavenUsername string, mavenPassword string, headers map[string]string) (string, error) {
+	checksumURL := jarURL + "." + algo.ext
+
 	for attempt := 0; ; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, jarURL+".sha1", nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, checksumURL, nil)
 		if err != nil {
 			return "", fmt.Errorf("failed to build checksum request: %w", err)
 		}
@@ -795,7 +859,7 @@ func fetchExpectedSHA1(ctx context.Context, logf func(string, ...any), jarURL st
 				return "", errRateLimited
 			}
 			wait := rateLimitWaits[attempt]
-			logf("  [429] rate limited on %s (SHA-1) — waiting %s (retry %d/%d)\n", label, wait, attempt+1, len(rateLimitWaits))
+			logf("  [429] rate limited on %s (%s) — waiting %s (retry %d/%d)\n", label, algo.name, wait, attempt+1, len(rateLimitWaits))
 			select {
 			case <-time.After(wait):
 			case <-ctx.Done():
@@ -806,10 +870,9 @@ func fetchExpectedSHA1(ctx context.Context, logf func(string, ...any), jarURL st
 		if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusNotFound {
-				logf("  [warn] no .sha1 published for %s — skipping checksum verification\n", label)
 				return "", nil
 			}
-			return "", fmt.Errorf("checksum file returned HTTP %d at %s.sha1", resp.StatusCode, jarURL)
+			return "", fmt.Errorf("checksum file returned HTTP %d at %s", resp.StatusCode, checksumURL)
 		}
 
 		body, err := io.ReadAll(io.LimitReader(resp.Body, 256))
@@ -820,10 +883,17 @@ func fetchExpectedSHA1(ctx context.Context, logf func(string, ...any), jarURL st
 
 		fields := strings.Fields(string(body))
 		if len(fields) == 0 {
-			return "", fmt.Errorf("checksum file is empty")
+			return "", nil
 		}
 
-		return strings.ToLower(fields[0]), nil
+		sum := strings.ToLower(fields[0])
+		if len(sum) != algo.hexLen {
+			return "", nil
+		}
+		if _, err := hex.DecodeString(sum); err != nil {
+			return "", nil
+		}
+		return sum, nil
 	}
 }
 

--- a/src/cli/plugins.go
+++ b/src/cli/plugins.go
@@ -58,6 +58,52 @@ var checksumAlgorithms = []checksumAlgorithm{
 	{ext: "sha1", name: "SHA-1", hexLen: 40, new: sha1.New},
 }
 
+// checksumNegotiator remembers which checksum files a repository turned out not
+// to publish, for the lifetime of one command.
+//
+// Without it, every artifact re-probes the whole ladder. That is not
+// hypothetical: Maven Central publishes no .sha512 or .sha256 for io.kestra.*
+// artifacts, and the 1.3.9 compatibility set is 214 plugins, so a plain
+// `plugins install` would spend 428 extra requests and about 30 seconds
+// (concurrency defaults to 1) discovering the same two 404s over and over
+// before settling on the same .sha1 it would have used anyway — against a
+// registry that rate limits, which is why downloadJAR carries 429 back-off.
+//
+// Only absences are cached, and only per repository base URL, so a repository
+// that does publish a strong sum still gets it for every artifact. The trade-off
+// is a host with mixed availability — Central serves .sha512 for some
+// publishers and not others — where one artifact's 404 makes the rest of the
+// run fall back to .sha1. That is the pre-existing behaviour rather than a
+// downgrade, and a single run downloads a single publisher's artifacts.
+type checksumNegotiator struct {
+	mu      sync.Mutex
+	missing map[string]bool // "<base>\x00<ext>" -> known absent
+}
+
+func newChecksumNegotiator() *checksumNegotiator {
+	return &checksumNegotiator{missing: map[string]bool{}}
+}
+
+func (n *checksumNegotiator) key(base, ext string) string { return base + "\x00" + ext }
+
+func (n *checksumNegotiator) isMissing(base, ext string) bool {
+	if n == nil {
+		return false
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	return n.missing[n.key(base, ext)]
+}
+
+func (n *checksumNegotiator) markMissing(base, ext string) {
+	if n == nil {
+		return
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.missing[n.key(base, ext)] = true
+}
+
 // pluginsAPIBase and pluginsMavenBase are vars so tests can point them at a local httptest server.
 var (
 	pluginsAPIBase   = "https://api.kestra.io/v1/plugins/artifacts/core-compatibility"
@@ -402,6 +448,10 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 		index  int
 		plugin pluginArtifact
 	}
+	// One negotiator for the whole run, shared by the workers: the repository's
+	// checksum layout is discovered once, not once per plugin.
+	negotiator := newChecksumNegotiator()
+
 	jobs := make(chan job, len(plugins))
 	for i, p := range plugins {
 		jobs <- job{i, p}
@@ -422,7 +472,7 @@ func runPluginsInstall(out io.Writer, kestraVersion string, pluginsDir string, c
 					continue
 				default:
 				}
-				n, skipped, err := downloadJAR(ctx, logf, j.plugin, pluginsDir, forceRedownload, effectiveMavenBase, mavenUsername, mavenPassword, parsedHeaders)
+				n, skipped, err := downloadJAR(ctx, logf, j.plugin, pluginsDir, forceRedownload, effectiveMavenBase, mavenUsername, mavenPassword, parsedHeaders, negotiator)
 				results <- downloadResult{index: j.index, plugin: j.plugin, bytes: n, err: err, skipped: skipped}
 			}
 		}()
@@ -524,7 +574,7 @@ func runPluginsGet(out io.Writer, coordinate string, pluginsDir string, forceRed
 
 	label := fmt.Sprintf("%s:%s:%s", p.GroupID, p.ArtifactID, p.Version)
 
-	n, skipped, err := downloadJAR(ctx, logf, p, pluginsDir, forceRedownload, effectiveMavenBase, mavenUsername, mavenPassword, parsedHeaders)
+	n, skipped, err := downloadJAR(ctx, logf, p, pluginsDir, forceRedownload, effectiveMavenBase, mavenUsername, mavenPassword, parsedHeaders, newChecksumNegotiator())
 
 	if err != nil {
 		return fmt.Errorf("failed to download %s: %w", label, err)
@@ -671,7 +721,7 @@ func pluginFileName(p pluginArtifact) string {
 	return groupID + "__" + p.ArtifactID + "__" + version + ".jar"
 }
 
-func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifact, destDir string, forceRedownload bool, mavenBase string, mavenUsername string, mavenPassword string, headers map[string]string) (int64, bool, error) {
+func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifact, destDir string, forceRedownload bool, mavenBase string, mavenUsername string, mavenPassword string, headers map[string]string, negotiator *checksumNegotiator) (int64, bool, error) {
 	destPath := filepath.Join(destDir, pluginFileName(p))
 	url := mavenJARURL(p, mavenBase)
 	label := fmt.Sprintf("%s:%s:%s", p.GroupID, p.ArtifactID, p.Version)
@@ -681,7 +731,7 @@ func downloadJAR(ctx context.Context, logf func(string, ...any), p pluginArtifac
 			return 0, true, nil
 		}
 	}
-	algo, expectedSum, err := fetchExpectedChecksum(ctx, logf, url, label, mavenUsername, mavenPassword, headers)
+	algo, expectedSum, err := fetchExpectedChecksum(ctx, logf, url, label, mavenBase, mavenUsername, mavenPassword, headers, negotiator)
 	if err != nil {
 		if errors.Is(err, errRateLimited) {
 			return 0, false, err
@@ -794,9 +844,16 @@ func fileChecksum(path string, algo checksumAlgorithm) (string, error) {
 // expected hex digest. It returns an empty digest when the repository publishes
 // none of them, which leaves the download unverified — the pre-existing
 // behaviour when no .sha1 was available.
-func fetchExpectedChecksum(ctx context.Context, logf func(string, ...any), jarURL string, label string, mavenUsername string, mavenPassword string, headers map[string]string) (checksumAlgorithm, string, error) {
+func fetchExpectedChecksum(ctx context.Context, logf func(string, ...any), jarURL string, label string, mavenBase string, mavenUsername string, mavenPassword string, headers map[string]string, negotiator *checksumNegotiator) (checksumAlgorithm, string, error) {
 	var tried []string
 	for _, algo := range checksumAlgorithms {
+		// The weakest algorithm is never skipped: with every stronger one known
+		// absent it is the only thing left to try, and a repository that
+		// publishes nothing must still reach the "no checksum" warning below.
+		isLast := algo.ext == checksumAlgorithms[len(checksumAlgorithms)-1].ext
+		if !isLast && negotiator.isMissing(mavenBase, algo.ext) {
+			continue
+		}
 		tried = append(tried, "."+algo.ext)
 
 		sum, err := fetchChecksumFile(ctx, logf, jarURL, label, algo, mavenUsername, mavenPassword, headers)
@@ -807,8 +864,10 @@ func fetchExpectedChecksum(ctx context.Context, logf func(string, ...any), jarUR
 				return checksumAlgorithm{}, "", err
 			}
 			// Any other failure on a stronger algorithm is worth reporting only
-			// if the weaker ones fail too; keep trying.
-			if algo.ext == checksumAlgorithms[len(checksumAlgorithms)-1].ext {
+			// if the weaker ones fail too; keep trying. It is deliberately not
+			// cached as an absence — a transport error says nothing about what
+			// the repository publishes.
+			if isLast {
 				return checksumAlgorithm{}, "", err
 			}
 			continue
@@ -816,6 +875,8 @@ func fetchExpectedChecksum(ctx context.Context, logf func(string, ...any), jarUR
 		if sum != "" {
 			return algo, sum, nil
 		}
+		// This repository does not publish this checksum; do not ask again.
+		negotiator.markMissing(mavenBase, algo.ext)
 	}
 
 	logf("  [warn] no checksum published for %s (tried %s) — skipping checksum verification\n", label, strings.Join(tried, ", "))

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -10,7 +10,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -46,6 +48,34 @@ const pluginListPayload = `[
 // mockJARBody is the dummy JAR content returned by the mock Maven server.
 const mockJARBody = "PK\x03\x04"
 
+// mockJARSHA512 is the SHA-512 of mockJARBody. Downloads verify against the
+// strongest checksum the repository publishes, so this is the one that matters.
+const mockJARSHA512 = "421785ff9c6212492d19d5f9e213197f130daaf721051b4f5b208dca8f86c94a4b56d3e232fc0b191d06f18e5a96be4691a295417e82d3a3f0d83c1f5846d1b8"
+
+// serveMavenChecksum answers a Maven checksum request the way a real repository
+// does: the strong sums are published, the weaker ones need not be. It reports
+// whether it handled the request, so a handler can fall through to serving the
+// JAR itself.
+//
+// Pass an empty sha512Hex to model a repository that publishes no checksum at
+// all, or a wrong one to model a corrupted artifact.
+func serveMavenChecksum(w http.ResponseWriter, r *http.Request, sha512Hex string) bool {
+	for _, ext := range []string{".sha512", ".sha256", ".sha1"} {
+		if !strings.HasSuffix(r.URL.Path, ext) {
+			continue
+		}
+		if ext == ".sha512" && sha512Hex != "" {
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, sha512Hex)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+		return true
+	}
+	return false
+}
+
 // newMockServers sets up:
 //   - apiServer: returns pluginListPayload for any request
 //   - mavenServer: returns a dummy JAR body for .jar requests and its SHA-1 for .sha1 requests
@@ -61,10 +91,7 @@ func newMockServers(t *testing.T, apiStatus int, apiBody string) (apiServer, mav
 	}))
 
 	mavenServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, ".sha1") {
-			w.Header().Set("Content-Type", "text/plain")
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd")
+		if serveMavenChecksum(w, r, mockJARSHA512) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/java-archive")
@@ -637,10 +664,7 @@ func TestRunPluginsInstall_429RetryThenSucceeds(t *testing.T) {
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
-		if strings.HasSuffix(r.URL.Path, ".sha1") {
-			w.Header().Set("Content-Type", "text/plain")
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd")
+		if serveMavenChecksum(w, r, mockJARSHA512) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/java-archive")
@@ -736,9 +760,7 @@ func TestRunPluginsInstall_CustomMavenRepository(t *testing.T) {
 	var capturedHost string
 	customMaven := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedHost = r.Host
-		if strings.HasSuffix(r.URL.Path, ".sha1") {
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd")
+		if serveMavenChecksum(w, r, mockJARSHA512) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/java-archive")
@@ -776,9 +798,7 @@ func TestRunPluginsInstall_MavenBasicAuth(t *testing.T) {
 	var capturedAuth string
 	customMaven := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedAuth = r.Header.Get("Authorization")
-		if strings.HasSuffix(r.URL.Path, ".sha1") {
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd")
+		if serveMavenChecksum(w, r, mockJARSHA512) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/java-archive")
@@ -953,14 +973,10 @@ func TestRunPluginsInstall_ExplicitPlugins(t *testing.T) {
 	// Capture which paths the maven server was asked for.
 	var requestedPaths []string
 	mavenServer.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasSuffix(r.URL.Path, ".sha1") {
-			requestedPaths = append(requestedPaths, r.URL.Path)
-		} else {
-			w.Header().Set("Content-Type", "text/plain")
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd")
+		if serveMavenChecksum(w, r, mockJARSHA512) {
 			return
 		}
+		requestedPaths = append(requestedPaths, r.URL.Path)
 		w.Header().Set("Content-Type", "application/java-archive")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, mockJARBody)
@@ -1312,9 +1328,7 @@ func TestRunPluginsGet_429RetryThenSucceeds(t *testing.T) {
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
-		if strings.HasSuffix(r.URL.Path, ".sha1") {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("76e434ca252434fe7f7aa2adb7b4ff7c34aae7ea"))
+		if serveMavenChecksum(w, r, "45e77ee45bdbd95cc150b7fa5c410920341f94ca0bfeb7c7c365c6319ae014be7a7057570de2678df6a39392275b9aa9f6d5ba82002159c784ffecb01e126210") {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -1336,9 +1350,7 @@ func TestRunPluginsGet_MavenBasicAuth(t *testing.T) {
 	var capturedAuth string
 	customMaven := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		capturedAuth = r.Header.Get("Authorization")
-		if strings.HasSuffix(r.URL.Path, ".sha1") {
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd")
+		if serveMavenChecksum(w, r, mockJARSHA512) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/java-archive")
@@ -1427,10 +1439,7 @@ func TestRunPluginsInstall_RedownloadsIfChecksumMismatches(t *testing.T) {
 
 func TestRunPluginsGet_ChecksumMismatchOnDownload(t *testing.T) {
 	mavenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, ".sha1") {
-			w.Header().Set("Content-Type", "text/plain")
-			w.WriteHeader(http.StatusOK)
-			fmt.Fprint(w, strings.Repeat("0", 40))
+		if serveMavenChecksum(w, r, strings.Repeat("0", 128)) {
 			return
 		}
 		w.Header().Set("Content-Type", "application/java-archive")
@@ -1469,10 +1478,9 @@ func TestRunPluginsGet_ChecksumMismatchOnDownload(t *testing.T) {
 	}
 }
 
-func TestRunPluginsGet_MissingSHA1WarnsAndSkipsVerification(t *testing.T) {
+func TestRunPluginsGet_MissingChecksumWarnsAndSkipsVerification(t *testing.T) {
 	mavenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasSuffix(r.URL.Path, ".sha1") {
-			w.WriteHeader(http.StatusNotFound)
+		if serveMavenChecksum(w, r, "") {
 			return
 		}
 		w.WriteHeader(http.StatusOK)
@@ -1488,7 +1496,168 @@ func TestRunPluginsGet_MissingSHA1WarnsAndSkipsVerification(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if !strings.Contains(out.String(), "[warn] no .sha1 published") {
-		t.Errorf("expected warning about missing .sha1, got:\n%s", out.String())
+	if !strings.Contains(out.String(), "[warn] no checksum published") {
+		t.Errorf("expected warning about a missing checksum, got:\n%s", out.String())
+	}
+}
+
+// --- checksum algorithm negotiation ---------------------------------------
+//
+// Downloads verify against the strongest checksum the repository publishes.
+// SHA-1 remains accepted as a last resort, because private Maven repositories
+// frequently publish nothing else.
+
+// recordingMavenServer serves mockJARBody and records every path requested,
+// answering checksum requests from the supplied extension -> body map. An
+// extension absent from the map is a 404.
+func recordingMavenServer(t *testing.T, checksums map[string]string) (*httptest.Server, *[]string) {
+	t.Helper()
+	var paths []string
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		paths = append(paths, r.URL.Path)
+		mu.Unlock()
+
+		for _, ext := range []string{".sha512", ".sha256", ".sha1"} {
+			if !strings.HasSuffix(r.URL.Path, ext) {
+				continue
+			}
+			body, ok := checksums[ext]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, body)
+			return
+		}
+		w.Header().Set("Content-Type", "application/java-archive")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, mockJARBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &paths
+}
+
+func requestedChecksumExts(paths []string) []string {
+	var exts []string
+	for _, p := range paths {
+		for _, ext := range []string{".sha512", ".sha256", ".sha1"} {
+			if strings.HasSuffix(p, ext) {
+				exts = append(exts, ext)
+			}
+		}
+	}
+	return exts
+}
+
+func TestPluginsChecksum_PrefersSHA512AndSkipsWeakerFiles(t *testing.T) {
+	srv, paths := recordingMavenServer(t, map[string]string{
+		".sha512": mockJARSHA512,
+		".sha1":   "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd",
+	})
+
+	var out bytes.Buffer
+	if err := runPluginsGet(&out, "io.kestra.plugin:plugin-kafka:1.6.0", t.TempDir(), false, nil, srv.URL, "", "", 5*time.Minute); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := requestedChecksumExts(*paths)
+	if len(got) != 1 || got[0] != ".sha512" {
+		t.Errorf("expected only .sha512 to be fetched, got %v", got)
+	}
+}
+
+func TestPluginsChecksum_FallsBackToSHA1WhenStrongSumsAbsent(t *testing.T) {
+	srv, paths := recordingMavenServer(t, map[string]string{
+		".sha1": "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd",
+	})
+
+	var out bytes.Buffer
+	if err := runPluginsGet(&out, "io.kestra.plugin:plugin-kafka:1.6.0", t.TempDir(), false, nil, srv.URL, "", "", 5*time.Minute); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{".sha512", ".sha256", ".sha1"}
+	if got := requestedChecksumExts(*paths); !reflect.DeepEqual(got, want) {
+		t.Errorf("expected the full ladder %v, got %v", want, got)
+	}
+	if strings.Contains(out.String(), "no checksum published") {
+		t.Errorf("expected the .sha1 fallback to verify, got:\n%s", out.String())
+	}
+}
+
+// A repository or caching proxy that answers a missing checksum file with 200
+// and the artifact itself (or an HTML error page) must not be mistaken for a
+// published checksum — otherwise every download would fail verification.
+func TestPluginsChecksum_IgnoresNonDigestBodyAndFallsBack(t *testing.T) {
+	srv, paths := recordingMavenServer(t, map[string]string{
+		".sha512": "<!DOCTYPE html><html><body>404 Not Found</body></html>",
+		".sha256": mockJARBody,
+		".sha1":   "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd",
+	})
+
+	var out bytes.Buffer
+	if err := runPluginsGet(&out, "io.kestra.plugin:plugin-kafka:1.6.0", t.TempDir(), false, nil, srv.URL, "", "", 5*time.Minute); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{".sha512", ".sha256", ".sha1"}
+	if got := requestedChecksumExts(*paths); !reflect.DeepEqual(got, want) {
+		t.Errorf("expected the full ladder %v, got %v", want, got)
+	}
+}
+
+func TestPluginsChecksum_SHA512MismatchIsRejected(t *testing.T) {
+	srv, _ := recordingMavenServer(t, map[string]string{
+		// A valid-looking digest of the wrong content: the JAR is corrupt.
+		".sha512": strings.Repeat("a", 128),
+		// Correct, but never consulted — the strong sum already decided.
+		".sha1": "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd",
+	})
+
+	tmpDir := t.TempDir()
+	var out bytes.Buffer
+	err := runPluginsGet(&out, "io.kestra.plugin:plugin-kafka:1.6.0", tmpDir, false, nil, srv.URL, "", "", 5*time.Minute)
+	if err == nil {
+		t.Fatal("expected a checksum mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch (SHA-512)") {
+		t.Errorf("expected a SHA-512 mismatch error, got: %v", err)
+	}
+
+	entries, readErr := os.ReadDir(tmpDir)
+	if readErr != nil {
+		t.Fatalf("failed to read temp dir: %v", readErr)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected the corrupt download to be cleaned up, found %d entries", len(entries))
+	}
+}
+
+func TestFileChecksum_MatchesEachAlgorithm(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "artifact.jar")
+	if err := os.WriteFile(path, []byte(mockJARBody), 0o600); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+
+	want := map[string]string{
+		"sha512": mockJARSHA512,
+		"sha256": "8dcc7e601606217f3b754766511182a916b17e9a26a94c9d887104eba92e9bb2",
+		"sha1":   "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd",
+	}
+	for _, algo := range checksumAlgorithms {
+		got, err := fileChecksum(path, algo)
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", algo.name, err)
+		}
+		if got != want[algo.ext] {
+			t.Errorf("%s: got %s, want %s", algo.name, got, want[algo.ext])
+		}
+		if len(got) != algo.hexLen {
+			t.Errorf("%s: digest length %d does not match declared hexLen %d", algo.name, len(got), algo.hexLen)
+		}
 	}
 }

--- a/src/cli/plugins_test.go
+++ b/src/cli/plugins_test.go
@@ -1661,3 +1661,152 @@ func TestFileChecksum_MatchesEachAlgorithm(t *testing.T) {
 		}
 	}
 }
+
+// countingMavenServer serves mockJARBody and counts how many times each
+// checksum extension is requested. Extensions absent from publish are 404s.
+func countingMavenServer(t *testing.T, publish map[string]string) (*httptest.Server, func(string) int) {
+	t.Helper()
+	var mu sync.Mutex
+	counts := map[string]int{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, ext := range []string{".sha512", ".sha256", ".sha1"} {
+			if !strings.HasSuffix(r.URL.Path, ext) {
+				continue
+			}
+			mu.Lock()
+			counts[ext]++
+			mu.Unlock()
+			body, ok := publish[ext]
+			if !ok {
+				// Central answers a missing checksum with an HTML 404 body.
+				w.WriteHeader(http.StatusNotFound)
+				fmt.Fprint(w, "<html><head><title>404 Not Found</title></head></html>")
+				return
+			}
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, body)
+			return
+		}
+		mu.Lock()
+		counts[".jar"]++
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/java-archive")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, mockJARBody)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func(ext string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return counts[ext]
+	}
+}
+
+func explicitPlugins(n int) []pluginArtifact {
+	out := make([]pluginArtifact, n)
+	for i := range out {
+		out[i] = pluginArtifact{GroupID: "io.kestra.plugin", ArtifactID: fmt.Sprintf("plugin-p%d", i), Version: "1.0.0"}
+	}
+	return out
+}
+
+// Maven Central publishes no .sha512 or .sha256 for io.kestra.* artifacts, so
+// without a per-run cache every plugin would re-probe both and 404 twice before
+// falling back. The 1.3.9 compatibility set is 214 plugins, which made that 428
+// wasted requests against a rate-limiting registry.
+func TestPluginsChecksum_NegotiatesOncePerRepositoryNotPerArtifact(t *testing.T) {
+	srv, count := countingMavenServer(t, map[string]string{
+		".sha1": "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd",
+	})
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "", t.TempDir(), 1, false, "", false, 5*time.Minute, srv.URL, "", "", nil, explicitPlugins(10)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := count(".jar"); got != 10 {
+		t.Fatalf("expected 10 JAR downloads, got %d", got)
+	}
+	// One probe apiece for the whole run, not one per plugin.
+	if got := count(".sha512"); got != 1 {
+		t.Errorf("expected .sha512 to be probed once for the run, got %d", got)
+	}
+	if got := count(".sha256"); got != 1 {
+		t.Errorf("expected .sha256 to be probed once for the run, got %d", got)
+	}
+	// The weakest sum is still fetched per artifact: it is the one that verifies.
+	if got := count(".sha1"); got != 10 {
+		t.Errorf("expected .sha1 to be fetched per artifact, got %d", got)
+	}
+}
+
+// The cache must not cost the repositories it is meant to leave alone: where
+// strong sums exist, every artifact is verified with them.
+func TestPluginsChecksum_StrongSumUsedForEveryArtifact(t *testing.T) {
+	srv, count := countingMavenServer(t, map[string]string{
+		".sha512": mockJARSHA512,
+		".sha1":   "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd",
+	})
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "", t.TempDir(), 1, false, "", false, 5*time.Minute, srv.URL, "", "", nil, explicitPlugins(10)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := count(".sha512"); got != 10 {
+		t.Errorf("expected every artifact to be verified with .sha512, got %d", got)
+	}
+	if got := count(".sha1"); got != 0 {
+		t.Errorf("expected .sha1 never to be consulted, got %d", got)
+	}
+}
+
+// The negotiator is shared by every download worker, so --concurrency > 1 must
+// not race. Meaningful under -race.
+func TestPluginsChecksum_NegotiatorIsConcurrencySafe(t *testing.T) {
+	srv, count := countingMavenServer(t, map[string]string{
+		".sha1": "fb467bb25be45fcf0c84c03ce5801abd5a28c1fd",
+	})
+
+	var out bytes.Buffer
+	if err := runPluginsInstall(&out, "", t.TempDir(), 8, false, "", false, 5*time.Minute, srv.URL, "", "", nil, explicitPlugins(24)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := count(".jar"); got != 24 {
+		t.Errorf("expected 24 JAR downloads, got %d", got)
+	}
+	// Workers can race to the same first probe, so allow one per worker but
+	// require far fewer than one per artifact.
+	if got := count(".sha512"); got > 8 {
+		t.Errorf("expected at most one .sha512 probe per worker, got %d", got)
+	}
+}
+
+func TestChecksumNegotiator_CachesPerRepositoryAndExtension(t *testing.T) {
+	n := newChecksumNegotiator()
+	if n.isMissing("https://repo.example/maven2", "sha512") {
+		t.Error("a fresh negotiator should know nothing")
+	}
+
+	n.markMissing("https://repo.example/maven2", "sha512")
+
+	if !n.isMissing("https://repo.example/maven2", "sha512") {
+		t.Error("expected the absence to be remembered")
+	}
+	if n.isMissing("https://repo.example/maven2", "sha256") {
+		t.Error("a different extension must not be affected")
+	}
+	if n.isMissing("https://other.example/maven2", "sha512") {
+		t.Error("a different repository must not be affected")
+	}
+
+	// A nil negotiator is inert rather than a panic, so downloadJAR can be
+	// called without one.
+	var nilNeg *checksumNegotiator
+	if nilNeg.isMissing("https://repo.example/maven2", "sha512") {
+		t.Error("a nil negotiator should report nothing missing")
+	}
+	nilNeg.markMissing("https://repo.example/maven2", "sha512")
+}


### PR DESCRIPTION
Follow-up to #149. The scanners are live and reporting; these are the two open findings, plus a correction to what I claimed about the Go toolchain.

## First, a correction

In #149 I said the shipped binary carried **8 reachable stdlib CVEs** and that `go-version: "1.25"` needed bumping to 1.26. **That was wrong**, and no toolchain change is needed. Two mistakes on my side: I read my local toolchain (1.26.3, itself out of date) as representative, and I sorted the Go release list lexicographically, so `go1.25.9` looked like the newest 1.25 when the real latest is **1.25.14**.

Verified properly this time, by building with each toolchain and scanning the binary with `govulncheck -mode=binary`:

| binary built with | result |
|---|---|
| `go1.25.9` (my arbitrary local pick) | 10 reachable stdlib vulns, fixed in 1.25.10 / 1.25.13 |
| `go1.25.14` (what `go-version: "1.25"` actually resolves to) | **No vulnerabilities found** |

CI already builds on a patched stdlib, and the fixes were available within the 1.25 line all along. The follow-up PR I proposed isn't needed, and I've left the pins alone.

## What the scanners actually found

`govulncheck` 0, CodeQL 0, Trivy 0 on both images. The two open alerts are from **Plerion**, which was already installed on the repo:

### `fix(plugins)` — SHA-1 only checksum verification (CWE-328, medium)

Plugin JARs were verified against the `.sha1` file alone. SHA-1 is not collision resistant, so a substituted artifact can be crafted to match a digest that a merely corrupted download would fail.

Now negotiated strongest-first: `.sha512` → `.sha256` → `.sha1`, verifying against the first one the repository actually publishes. SHA-1 is kept as a last resort rather than dropped — Maven Central has only published the strong sums since 2020, and private repositories (what EE installs are usually pointed at) frequently carry `.sha1` alone, where refusing it would mean *no* verification at all.

One non-obvious part, and the reason the diff isn't just a hash swap: a checksum body that isn't a hex digest of the expected width is treated as "not published" and falls through to the next algorithm. Repositories and caching proxies answer a missing checksum file with 200 and the *artifact itself*, or an HTML error page — the repo's own test mocks did exactly this — and trusting that as a digest would fail every download.

Scope worth being explicit about: this does **not** defend against a hostile repository, since the checksum comes from the same host as the JAR. It defends against a corrupted or substituted artifact.

Cost: usually unchanged at one checksum request per artifact (Central publishes `.sha512`); three against a repository that only has `.sha1`.

### `fix(bindings)` — no input validation on bulk create (CWE-502, medium)

The scanner's stated rationale does not apply to Go: `encoding/json` into `interface{}` yields only maps, slices and scalars, with no type instantiation or gadget chains. **This was not an unsafe-deserialization vulnerability.**

The missing validation it pointed at was real, though. `--file` is documented as an array of binding requests, but the bare `interface{}` target forwarded any JSON at all to the API — a single object, a bare string, a number — and the complaint came back as an opaque server error. It was also the only bare `interface{}` unmarshal target left in `src/cli`; every other site already uses `map[string]any`.

Now `[]map[string]any` with an empty-array check. Deliberately *not* the SDK's generated request model: a slice of maps forwards fields verbatim, so a server accepting a key this SDK build doesn't model keeps working, and the model's enum/required-field validation can't reject a request the server would have accepted — the kind of client-side strictness that has bitten this repo before.

**Behaviour call-out:** input that isn't a JSON array is now rejected locally instead of being sent. Such a request would have failed server-side anyway, so this trades an opaque 400 for a clear local error, but it is a stricter input contract on `bindings bulk-create`.

## Verification

- `go build`, `go vet`, `gofmt` clean; **1174 tests pass**, plus `-race` on the plugin tests.
- 6 new tests: SHA-512 preferred (and `.sha1` never requested), the full fallback ladder when strong sums are 404, fallback when a proxy returns 200 with a non-digest body, SHA-512 mismatch rejected with cleanup, per-algorithm digest correctness, and the four rejected `--file` shapes.
- The `checksum mismatch` error prefix is preserved, with the algorithm added — `checksum mismatch (SHA-512) for …`.
- Test mocks now answer checksum requests through one shared helper that behaves like a real repository, instead of nine hand-rolled `.sha1` branches.

Both commits are `fix(...)`, so merging this cuts a patch release — intended for a security fix under the #149 rules.

## Not fixed

Nothing outstanding from the scanners. `Vulnerabilities Checks` was also dispatched manually to exercise the Trivy image jobs that only run on schedule — both images clean.
