### PR TITLE
fix(bindings): validate that bulk-create input is an array of requests

### DIFF
--- a/src/cli/bindings.go
+++ b/src/cli/bindings.go
@@ -363,9 +363,18 @@ func runBindingsBulkCreate(client *Client, path string, renderer *Renderer) erro
 		return fmt.Errorf("failed to read file: %w", err)
 	}
 
-	var requests interface{}
+	// A slice of maps rather than the SDK's generated request model: the fields
+	// are forwarded to the API verbatim, so a server that accepts a key this
+	// SDK build does not model still works. It is also not a bare interface{} —
+	// that would accept any JSON at all (an object, a bare string, a number)
+	// and defer the complaint to an opaque server-side error, when --file is
+	// documented as an array of binding requests.
+	var requests []map[string]any
 	if err := json.Unmarshal(data, &requests); err != nil {
-		return fmt.Errorf("failed to parse JSON file: %w", err)
+		return fmt.Errorf("failed to parse JSON file: %w (expected a JSON array of binding requests)", err)
+	}
+	if len(requests) == 0 {
+		return fmt.Errorf("no binding requests found in %s: expected a non-empty JSON array", path)
 	}
 
 	bindings, err := client.Kestra.Bindings().BulkCreateBinding(client.Ctx, client.Tenant, requests)

--- a/src/cli/bindings_test.go
+++ b/src/cli/bindings_test.go
@@ -343,3 +343,33 @@ func TestRunBindingsBulkCreate(t *testing.T) {
 		t.Errorf("expected binding ID in output, got:\n%s", buf.String())
 	}
 }
+
+func TestRunBindingsBulkCreate_RejectsNonArrayFile(t *testing.T) {
+	cases := map[string]string{
+		"a single object": `{"type":"USER","externalId":"u1","roleId":"r1"}`,
+		"a bare string":   `"USER"`,
+		"an empty array":  `[]`,
+		"malformed JSON":  `[{"type":`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			f, err := os.CreateTemp("", "bindings-*.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.Remove(f.Name())
+			f.WriteString(body)
+			f.Close()
+
+			// No server: a shape this wrong must fail before any request.
+			var buf bytes.Buffer
+			err = runBindingsBulkCreate(newTestClient(t, "http://127.0.0.1:1"), f.Name(), newTableRenderer(&buf))
+			if err == nil {
+				t.Fatalf("expected an error for %s, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "JSON array") {
+				t.Errorf("expected the error to explain the expected shape, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Split out of #154, which is closed — see that PR for why the SHA-1 half was dropped.

`runBindingsBulkCreate` unmarshalled `--file` into a bare `interface{}`, so any JSON at all was forwarded to the API: a single object, a bare string, a number. The complaint then came back as an opaque server-side error, even though the flag is documented as an array of binding requests. It was also the only bare `interface{}` unmarshal target left in `src/cli` — every other site already uses `map[string]any` or `[]any`.

Now `[]map[string]any`, with an empty array rejected too.

**Why a slice of maps and not the SDK's `IAMBindingControllerApiCreateBindingRequest`:** the fields are forwarded verbatim, so a server that accepts a key this SDK build does not model keeps working, and the model's enum and required-field validation cannot reject a request the server would have accepted. Given this repo's history with SDK decode strictness, that seemed the wrong direction for *input*.

**Behaviour call-out:** input that isn't a JSON array is now rejected locally instead of being sent. Such a request would have failed server-side anyway, so this trades an opaque 400 for a clear local error — but it is a stricter input contract on `bindings bulk-create`.

This also closes the Plerion CWE-502 alert. To be clear about what that alert was: the scanner's stated rationale does not apply to Go — `encoding/json` into `interface{}` yields only maps, slices and scalars, with no type instantiation or gadget chains, so **this was not an unsafe-deserialization vulnerability**. The missing input validation it happened to point at was real, which is the only reason for this PR.

## Verification

- `go build`, `go vet`, `gofmt` clean; full suite passes.
- 4 new subtests covering the rejected shapes: a single object, a bare string, an empty array, and malformed JSON — each asserted to fail before any HTTP request is made.
