### PR TITLE
fix(ci): skip e2e and Slack notify on Dependabot runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,9 +107,18 @@ jobs:
 
   e2e-tests:
     needs: list-versions
-    # Fork PRs don't receive secrets (GCP creds for the private EE image, EE license), so e2e cannot run.
-    # Skip them. workflow_dispatch/workflow_call and internal PRs still run.
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+    # This job needs secrets (GCP creds for the private EE image, EE license), and two kinds of
+    # run never receive them, so e2e is skipped rather than left to fail on an empty license:
+    #   - Fork PRs: secrets are withheld from forks entirely.
+    #   - Dependabot: GitHub runs it in a restricted context that reads the *Dependabot* secrets
+    #     store, not the Actions one, so these resolve to "". It keys off the actor, not the event,
+    #     so a Dependabot branch's `push` run is restricted too -- hence the actor check, not an
+    #     event or head-ref one. Coverage is not lost: the merge to main runs the full suite on
+    #     push, which is what auto-tag.yml gates the release on.
+    # workflow_dispatch/workflow_call and internal PRs still run.
+    if: >-
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -152,7 +161,10 @@ jobs:
   notify-failure:
     name: Notify CI failure
     needs: [test, docker-build, list-versions, e2e-tests]
-    if: always() && github.event_name != 'pull_request' && contains(needs.*.result, 'failure')
+    # SLACK_WEBHOOK_URL is an Actions secret, so it is empty in Dependabot's restricted context
+    # (see the e2e-tests guard above). Skip rather than post to an empty webhook -- a failing
+    # dependency bump is already visible on its own PR.
+    if: always() && github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' && contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Collect failed jobs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,11 +87,26 @@ Five automated pieces, modelled on `kestra-io/kestra`'s setup and adapted to Go:
 - **`vulnerabilities-check.yml`** — `govulncheck` on both Go modules (the Go analogue of kestra's OWASP `dependencyCheckAggregate`; it reports only vulnerabilities reachable from our code, so it needs no NVD API key), plus a daily Trivy scan of the published `kestra/kestractl:latest` and `:latest-static` images.
 - **`dependency-submission.yml`** — submits the resolved `go mod graph` to GitHub's dependency graph on every push to `main`. Without it, Dependabot alerts only see `go.mod`'s direct requirements, so an advisory against a transitive module never fires.
 
-Four things to know before touching this:
+Five things to know before touching this:
 
 - **A security bump releases; a routine bump does not.** `main` auto-releases off the squashed merge subject, which GitHub takes from the PR title. Every ecosystem in `dependabot.yml` therefore uses `ci(deps)`, which scores no bump — a routine version update is not urgent and rides along with the next real change. Security updates are the exception, and Dependabot has one `commit-message.prefix` per ecosystem with no way to vary it by update type, so `dependabot-security-prefix.yml` promotes those to `fix(deps)` (→ patch) off the advisory metadata. The two files are coupled: change a prefix in `dependabot.yml` and the promotion step fails loudly on the next security PR rather than silently scoring it `none`.
 - **That promotion workflow runs on `pull_request_target` and must never check out the PR.** A `pull_request` token is read-only on a Dependabot PR, so it cannot retitle; `pull_request_target` gets a writable token, which is only safe because the job reads advisory metadata and calls the API, never the branch's code.
 - **Neither scanner is a job in `Tests`, deliberately.** `auto-tag.yml` releases on a green `Tests` run, so a CVE published against an already-released dependency, or a newly shipped CodeQL rule, would otherwise freeze the release line on work unrelated to the merge.
+- **A Dependabot run gets no Actions secrets, on `push` as well as `pull_request`.** GitHub executes any workflow whose actor is `dependabot[bot]` in a restricted context that resolves `secrets.*` from the *Dependabot* secrets store rather than the Actions one, so the EE license, `GCP_SERVICE_ACCOUNT` and `SLACK_WEBHOOK_URL` all come back as empty strings. Unguarded, `e2e-tests` writes an empty `application-secrets.yml` and every matrix leg dies on `KestraLicenseException: No license information configured` — a secrets failure that reads like a real regression in the bumped dependency. The restriction keys off the **actor, not the event**, so testing `github.event_name` or the head ref does not catch it; the guards in `tests.yml` test `github.actor != 'dependabot[bot]'`. Skipping loses no coverage, because the merge to `main` runs the full suite on `push` and that is the run `auto-tag.yml` gates the release on. Mirroring the secrets into the Dependabot store would make e2e run, at the cost of exposing the EE license and a GCP service account to a run whose dependency tree was just changed from outside — which is why this repo skips instead.
+
+  **To actually get an e2e result for a Dependabot PR, dispatch the suite yourself** — the actor
+  is then you, not the bot, so the Actions secrets resolve normally:
+
+  ```bash
+  gh workflow run tests.yml --repo kestra-io/kestractl --ref <dependabot-branch>
+  ```
+
+  Two caveats. The run's check-runs are registered against the PR's head SHA, but GitHub's PR
+  `statusCheckRollup` only surfaces runs from PR-associated events, so a `workflow_dispatch`
+  result does **not** turn the PR's checks green — open the run to read it. And the guard above
+  is deliberately compatible with this: it tests the actor, so it suppresses only the
+  automatic, doomed run and never a human dispatch. `main` has no branch protection, so the
+  red rollup blocks nothing.
 - **`govulncheck` runs on `stable` Go, not `go.mod`'s version.** govulncheck v1.8+ needs Go >= 1.26 to build at all. That means it scans the standard library of the current toolchain while releases are still built with the `go-version: "1.25"` pins in `tests.yml` and `release.yml` — bump those together, or the scan and the shipped binary disagree about which stdlib CVEs apply.
 
 Already enabled repo-side and needing no file here: secret scanning, push protection, and Dependabot security updates.


### PR DESCRIPTION
## Problem

Every e2e matrix leg on a Dependabot PR (e.g. #151) failed with:

```
io.kestra.ee.license.internals.KestraLicenseException: No license information configured,
please add your license at 'kestra.ee.license.id' and 'kestra.ee.license.key'
```

This reads like a regression in the bumped dependency. It is not one.

GitHub runs any workflow whose actor is `dependabot[bot]` in a **restricted context** that
resolves `secrets.*` from the *Dependabot* secrets store rather than the Actions one. Our
`GCP_SERVICE_ACCOUNT`, `KESTRA_EE_UNIT_TEST_LICENSE_FILE` and `KESTRA_EE_UNIT_TEST_LICENSE_LEGACY_FILE`
are org-level **Actions** secrets, so they come back as empty strings. `e2e-tests` then writes
an empty `application-secrets.yml` and Kestra EE refuses to boot.

Two details that made this non-obvious:

- The existing guard only covered **fork** PRs. A Dependabot branch is in-repo
  (`head.repo.fork == false`), so it sailed straight through.
- The restriction keys off the **actor, not the event**, which is why both the `pull_request`
  run *and* the `push` run failed — and why no `github.event_name` or head-ref test catches it.

Every secret-free job (`test`, `docker-build`, CodeQL, both govulncheck legs) passed
throughout, which is the signature of a secrets problem rather than a real failure.

## Change

- `tests.yml` — add `github.actor != 'dependabot[bot]'` to the `e2e-tests` guard, and the same
  to `notify-failure`, whose `SLACK_WEBHOOK_URL` is equally empty in that context (it was
  posting to an empty webhook on the Dependabot `push` run).
- `AGENTS.md` — document the trap alongside the other Dependabot notes, including the manual
  dispatch escape hatch and why mirroring the secrets was rejected.

## Why skip rather than mirror the secrets

Skipping loses no coverage: the merge to `main` runs the full suite on `push`, which is the run
`auto-tag.yml` already gates the release on.

The alternative was mirroring the three secrets into the org Dependabot store. Rejected: they
are **org-level**, so this would hand the EE license and a GCP service account to Dependabot
runs in *every* `kestra-io` repo in order to fix one repo's matrix.

Note the exposure is inherent to running the tests at all — a job that exercises a bumped
dependency executes that dependency next to the secrets, whichever trigger is used. So a
"only if the diff touches go.mod/go.sum" gate would be theater: a hostile bump looks exactly
like that.

## Getting a real e2e result on a Dependabot PR

The guard tests the actor, so it suppresses only the automatic, doomed run — never a human
dispatch:

```bash
gh workflow run tests.yml --repo kestra-io/kestractl --ref <dependabot-branch>
```

Verified on #151's branch: [run 34366100444](https://github.com/kestra-io/kestractl/actions/runs/34366100444)
went fully green across all six legs, which also confirmed the testify 1.11.1 -> 1.12.1 bump
was genuinely fine.

Caveat documented in AGENTS.md: the run's check-runs are registered against the PR's head SHA,
but GitHub's PR `statusCheckRollup` only surfaces runs from PR-associated events, so a
`workflow_dispatch` result does not turn the PR's checks green — you open the run to read it.
`main` has no branch protection, so nothing is blocked by the red rollup.

## Verification

- `go build ./...`, `go test ./src/...`, `render-compat-badges.sh --check` all clean
- Both `if:` expressions parse under `yq`
- Rebased onto latest `main` (`844bffb`); diff is 2 files