### PR TITLE
style: gofmt cobra command literals in apps and test-suites

### DIFF
--- a/src/cli/apps.go
+++ b/src/cli/apps.go
@@ -213,9 +213,9 @@ func newAppsUpdateCommand() *cobra.Command {
 	var filePath string
 
 	cmd := &cobra.Command{
-		Use:   "update <uid>",
-		Short: "Update an existing app from a YAML file.",
-		Args:  cobra.ExactArgs(1),
+		Use:     "update <uid>",
+		Short:   "Update an existing app from a YAML file.",
+		Args:    cobra.ExactArgs(1),
 		Example: `  kestractl apps update <uid> --file my-app.yml`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if filePath == "" {
@@ -370,9 +370,9 @@ func newAppsExportCommand() *cobra.Command {
 	var outputFile string
 
 	cmd := &cobra.Command{
-		Use:   "export",
-		Short: "Export all apps as a ZIP archive.",
-		Long:  "Export all apps as a ZIP archive. The file is written to stdout or --output-file.",
+		Use:     "export",
+		Short:   "Export all apps as a ZIP archive.",
+		Long:    "Export all apps as a ZIP archive. The file is written to stdout or --output-file.",
 		Example: `  kestractl apps export --output-file apps.zip`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := newClientFunc()
@@ -717,10 +717,10 @@ func newAppsFileMetaCommand() *cobra.Command {
 	var path string
 
 	cmd := &cobra.Command{
-		Use:   "file-meta <id>",
-		Short: "Get metadata for a file produced by an app execution.",
-		Long:  "Get metadata (e.g. size) for a file referenced by an app execution view.",
-		Args:  cobra.ExactArgs(1),
+		Use:     "file-meta <id>",
+		Short:   "Get metadata for a file produced by an app execution.",
+		Long:    "Get metadata (e.g. size) for a file referenced by an app execution view.",
+		Args:    cobra.ExactArgs(1),
 		Example: `  kestractl apps file-meta <view-id> --path /path/to/file`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if path == "" {

--- a/src/cli/test_suites.go
+++ b/src/cli/test_suites.go
@@ -175,8 +175,8 @@ func runTestSuitesGet(client *Client, namespace, id string, renderer *Renderer) 
 
 func newTestSuitesDeleteCommand() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "delete <namespace> <id>",
-		Short: "Delete a test suite.",
+		Use:     "delete <namespace> <id>",
+		Short:   "Delete a test suite.",
 		Example: `  kestractl test-suites delete my.namespace my-test-suite`,
 		Args:    cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Four `cobra.Command` struct literals had a misaligned key column, so `gofmt -l` reported both files as unformatted:

- `src/cli/apps.go` — `apps update`, `apps export`, `apps file-meta`
- `src/cli/test_suites.go` — `test-suites delete`

Same cause in each: an `Example` field was added after its neighbours. `Example` is the longest key in those blocks, so gofmt wants the whole key column re-aligned.

Whitespace only — 12 lines changed, no semantic change.

## Verification

- `gofmt -l .` clean
- `go vet ./src/...` clean
- `go build` ok
- `go test ./src/...` — 1164 tests pass

## Release impact

None. `style:` scores no version bump, so this rides along with the next real change rather than cutting a tag.

## Note

Nothing in CI enforces gofmt — `grep -rn gofmt .github/` hits only a fixture string in `next-version_test.sh`. That is why this drift survived since it was first noticed in August. Adding a `gofmt -l` step to `tests.yml` would catch the next one; deliberately left out of this PR to keep it whitespace-only.