### PR TITLE
docs: note Kestra 1.x and 2.x compatibility in the root help

### DIFF
--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -64,7 +64,13 @@ func NewRootCommand() *cobra.Command {
 		Long: `kestractl is a command-line tool for managing Kestra workflows.
 
 It provides commands to manage flows, namespaces, and executions,
-with support for multiple authentication contexts and output formats.`,
+with support for multiple authentication contexts and output formats.
+
+Compatibility:
+  This build is compatible with Kestra 1.x and 2.x. It targets 2.x, and
+  works against a 1.x server on a best-effort basis: commands that rely
+  on a feature only Kestra 2.0 introduced report that explicitly instead
+  of appearing to succeed against an older server.`,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			if cmd.Annotations[AnnotationOffline] == "true" {
 				return nil


### PR DESCRIPTION
The root help never said which Kestra servers the binary can talk to. This adds a `Compatibility` section to the root command's `Long` text — a one-file, six-line change.

```
Compatibility:
  This build is compatible with Kestra 1.x and 2.x. It targets 2.x, and
  works against a 1.x server on a best-effort basis: commands that rely
  on a feature only Kestra 2.0 introduced report that explicitly instead
  of appearing to succeed against an older server.
```

It shows in `kestractl --help` and in the help that bare `kestractl` prints via `RunE`.

## Why that wording

- **`1.x` and `2.x`** matches `COMPATIBLE_KESTRA_VERSION.properties`, which tests the `v1.0`–`v2.0` lines, and `compat.go`, whose `eraLegacy` covers 1.x as a whole rather than any single minor.
- **The 2.0-only sentence** is the part a user most needs told. A 1.x server drops an unknown request field and still answers `200`, so without `requireKestra2` (`compat.go:511`) that failure would look like a success.

## Verification

- real `--help` output confirmed from a built binary
- `go build` ok, `go vet ./src/...` clean
- `go test ./src/...` — 1164 pass

## Release impact

None. `docs:` scores no version bump, so this rides along with the next real change. Happy to retitle to `feat:` if you would rather it cut a minor release.