### PR TITLE
feat(flows): add validate-by-query to validate the flows stored on an instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,10 +355,8 @@ kestractl flows usage-report
 kestractl flows validate-by-query
 ```
 
-`validate-by-query` exits non-zero when any flow has constraint violations, and
-also cross-checks the flow inventory so a flow the server cannot deserialize at
-all is reported even when the export could not produce it. That makes it usable
-as a CI gate:
+`validate-by-query` exits non-zero when any flow has constraint violations,
+which makes it usable as a CI gate:
 
 ```bash
 kestractl flows validate-by-query --namespace my.namespace --output json

--- a/README.md
+++ b/README.md
@@ -355,10 +355,10 @@ kestractl flows usage-report
 kestractl flows validate-by-query
 ```
 
-`validate-by-query` exits non-zero when any flow has constraint violations or
-when the server cannot deserialize a stored flow source at all — the failure
-mode a plain export-then-validate round-trip misses, because such a flow is
-absent from the export. That makes it usable as a CI gate:
+`validate-by-query` exits non-zero when any flow has constraint violations, and
+also cross-checks the flow inventory so a flow the server cannot deserialize at
+all is reported even when the export could not produce it. That makes it usable
+as a CI gate:
 
 ```bash
 kestractl flows validate-by-query --namespace my.namespace --output json

--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ kestractl flows deploy ./flows/ --fail-fast
 kestractl flows validate path/to/flow.yaml
 kestractl flows validate ./flows/
 
+# Validate the flows already stored on the instance (no local copy needed)
+kestractl flows validate-by-query
+kestractl flows validate-by-query --namespace my.namespace
+
 # Validate a task or trigger definition inline
 kestractl flows validate-task --namespace my.namespace --flow my-flow --task-id my-task
 kestractl flows validate-trigger --namespace my.namespace --flow my-flow --trigger-id my-trigger
@@ -337,6 +341,32 @@ kestractl flows delete-revisions my.namespace my-flow --before-revision 5
 kestractl flows concurrency-limits my.namespace my-flow
 kestractl flows update-concurrency my.namespace my-flow --limit 10
 ```
+
+#### Verifying a migration
+
+After upgrading an instance and migrating flow definitions, two commands answer
+"did that work?" without exporting anything to disk:
+
+```bash
+# What does this instance use, and what needs attention for a 1.x -> 2.0 upgrade?
+kestractl flows usage-report
+
+# Are the flows now stored on the instance actually valid?
+kestractl flows validate-by-query
+```
+
+`validate-by-query` exits non-zero when any flow has constraint violations or
+when the server cannot deserialize a stored flow source at all — the failure
+mode a plain export-then-validate round-trip misses, because such a flow is
+absent from the export. That makes it usable as a CI gate:
+
+```bash
+kestractl flows validate-by-query --namespace my.namespace --output json
+```
+
+Drafts are not covered: the export the sources are read from deliberately skips
+them, so a draft-headed flow is validated at its last saved revision and a
+draft-only flow is not validated at all.
 
 ### Executions
 

--- a/README.md
+++ b/README.md
@@ -282,8 +282,8 @@ kestractl flows validate path/to/flow.yaml
 kestractl flows validate ./flows/
 
 # Validate the flows already stored on the instance (no local copy needed)
-kestractl flows validate-by-query
 kestractl flows validate-by-query --namespace my.namespace
+kestractl flows validate-by-query --all
 
 # Validate a task or trigger definition inline
 kestractl flows validate-task --namespace my.namespace --flow my-flow --task-id my-task
@@ -352,14 +352,18 @@ After upgrading an instance and migrating flow definitions, two commands answer
 kestractl flows usage-report
 
 # Are the flows now stored on the instance actually valid?
-kestractl flows validate-by-query
+kestractl flows validate-by-query --all
 ```
+
+A selection is required: `--namespace`, `--flow` or `--filter` to scope the run,
+or `--all` for every flow of the tenant. Validating a whole instance is
+deliberately something you ask for by name.
 
 `validate-by-query` exits non-zero when any flow has constraint violations,
 which makes it usable as a CI gate:
 
 ```bash
-kestractl flows validate-by-query --namespace my.namespace --output json
+kestractl flows validate-by-query --all --output json
 ```
 
 Drafts are not covered: the export the sources are read from deliberately skips

--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -559,25 +559,15 @@ func listAllFlows(client *Client) ([]parsedFlow, error) {
 // listAllFlowsForTenant pages through every flow of the given tenant. Commands
 // that scan more than the configured tenant call it directly.
 func listAllFlowsForTenant(client *Client, tenant string) ([]parsedFlow, error) {
-	return listAllFlowsForTenantFiltered(client, tenant, nil)
-}
-
-// listAllFlowsForTenantFiltered is listAllFlowsForTenant narrowed to the flows
-// matching the shared *-by-query filters. Nil filters means the whole tenant,
-// which is what the endpoint does by default.
-func listAllFlowsForTenantFiltered(client *Client, tenant string, filters []kestra.QueryFilter) ([]parsedFlow, error) {
 	const pageSize int32 = 1000
 	page := int32(1)
 	results := make([]parsedFlow, 0)
 
 	for {
-		req := client.API.FlowsAPI.SearchFlows(client.Ctx, tenant).
+		resp, _, err := client.API.FlowsAPI.SearchFlows(client.Ctx, tenant).
 			Page(page).
-			Size(pageSize)
-		if len(filters) > 0 {
-			req = req.Filters(filters)
-		}
-		resp, _, err := req.Execute()
+			Size(pageSize).
+			Execute()
 
 		var batch []parsedFlow
 		var total int64
@@ -615,11 +605,6 @@ type parsedFlow struct {
 	Description string
 	Revision    int32
 	Source      string
-	// Exception is set when the server could not deserialize the stored flow
-	// source and answered with a FlowWithException. Such a flow exists in the
-	// inventory but is absent from an export, so it is invisible to any check
-	// that only reads exported sources.
-	Exception string
 }
 
 // parsedFlowFromFlow normalizes a decoded SDK Flow into a parsedFlow.
@@ -629,24 +614,7 @@ func parsedFlowFromFlow(f kestra.Flow) parsedFlow {
 		Namespace:   f.GetNamespace(),
 		Description: f.GetDescription(),
 		Revision:    f.GetRevision(),
-		// "exception" is not in the generated Flow model; the SDK keeps such
-		// fields in AdditionalProperties.
-		Exception: flowException(f.AdditionalProperties),
 	}
-}
-
-// flowException reads the "exception" field the server adds to a flow it could
-// not deserialize. It is a string in practice, but the field is untyped, so
-// anything else is rendered rather than dropped.
-func flowException(m map[string]any) string {
-	value, ok := m["exception"]
-	if !ok || value == nil {
-		return ""
-	}
-	if s, ok := value.(string); ok {
-		return strings.TrimSpace(s)
-	}
-	return strings.TrimSpace(fmt.Sprint(value))
 }
 
 // parsedFlowFromMap extracts flow fields from a raw JSON object. Labels are
@@ -669,7 +637,6 @@ func parsedFlowFromMap(m map[string]any) parsedFlow {
 	if v, ok := m["revision"].(float64); ok {
 		f.Revision = int32(v)
 	}
-	f.Exception = flowException(m)
 	return f
 }
 

--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -1089,8 +1089,14 @@ func validateSourcesInBatches(client *Client, sources []string, batchSize int) (
 
 	for start := 0; start < len(sources); start += batchSize {
 		end := min(start+batchSize, len(sources))
+		count := end - start
 
-		body := strings.Join(sources[start:end], "\n---\n")
+		documents := make([]string, 0, count)
+		for _, source := range sources[start:end] {
+			documents = append(documents, trimDocumentMarkers(source))
+		}
+
+		body := strings.Join(documents, "\n---\n")
 		batch, _, err := client.API.FlowsAPI.ValidateFlows(client.Ctx, client.Tenant).
 			Body(body).
 			Execute()
@@ -1099,12 +1105,56 @@ func validateSourcesInBatches(client *Client, sources []string, batchSize int) (
 		}
 
 		for _, violation := range batch {
-			violation.SetIndex(violation.GetIndex() + int32(start))
+			index := violation.GetIndex()
+			// The server numbered a document this batch did not send, which
+			// means the body split into more documents than it has sources.
+			// Every index in the batch is then suspect, so report nothing
+			// rather than attach results to the wrong flows.
+			if index < 0 || int(index) >= count {
+				return nil, fmt.Errorf(
+					"cannot map validation results back to flows: the server reported document %d of a %d-document request, "+
+						"which happens when a flow source contains its own YAML document separator; "+
+						"re-run with --batch-size 1 to validate one flow per request",
+					index, count)
+			}
+			violation.SetIndex(index + int32(start))
 			violations = append(violations, violation)
 		}
 	}
 
 	return violations, nil
+}
+
+// trimDocumentMarkers strips the YAML document markers around a single flow
+// source so that joining sources with "\n---\n" yields exactly one document
+// per source.
+//
+// A stored flow source keeps whatever the author wrote, and a leading "---" is
+// ordinary YAML style. Joined as-is it produces "---\n---", i.e. an empty
+// document, which shifts every later index in the batch by one and makes a
+// valid flow fail with "No content to map due to end-of-input".
+func trimDocumentMarkers(source string) string {
+	lines := strings.Split(source, "\n")
+
+	start := 0
+	for start < len(lines) && strings.TrimSpace(lines[start]) == "" {
+		start++
+	}
+	if start < len(lines) && strings.TrimRight(lines[start], " \t") == "---" {
+		start++
+	}
+
+	end := len(lines)
+	for end > start {
+		last := strings.TrimRight(lines[end-1], " \t")
+		if last == "" || last == "---" || last == "..." {
+			end--
+			continue
+		}
+		break
+	}
+
+	return strings.Join(lines[start:end], "\n")
 }
 
 // formatValidateResults renders the violations of a local `flows validate`
@@ -1128,9 +1178,6 @@ func formatValidateResults(violations []kestra.ValidateConstraintViolation, file
 func buildValidateResults(violations []kestra.ValidateConstraintViolation, seeds []ValidateResult) ([]ValidateResult, int) {
 	results := make([]ValidateResult, len(seeds))
 	copy(results, seeds)
-	for i := range results {
-		results[i].Success = true
-	}
 
 	unknownResults := make([]ValidateResult, 0)
 

--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -71,6 +71,7 @@ func newFlowsCommand() *cobra.Command {
 	cmd.AddCommand(newFlowsEnableByQueryCommand())
 	cmd.AddCommand(newFlowsExportByIdsCommand())
 	cmd.AddCommand(newFlowsExportByQueryCommand())
+	cmd.AddCommand(newFlowsValidateByQueryCommand())
 	cmd.AddCommand(newFlowsGenerateGraphFromSourceCommand())
 	cmd.AddCommand(newFlowsGenerateGraphCommand())
 	cmd.AddCommand(newFlowsTaskCommand())
@@ -558,15 +559,25 @@ func listAllFlows(client *Client) ([]parsedFlow, error) {
 // listAllFlowsForTenant pages through every flow of the given tenant. Commands
 // that scan more than the configured tenant call it directly.
 func listAllFlowsForTenant(client *Client, tenant string) ([]parsedFlow, error) {
+	return listAllFlowsForTenantFiltered(client, tenant, nil)
+}
+
+// listAllFlowsForTenantFiltered is listAllFlowsForTenant narrowed to the flows
+// matching the shared *-by-query filters. Nil filters means the whole tenant,
+// which is what the endpoint does by default.
+func listAllFlowsForTenantFiltered(client *Client, tenant string, filters []kestra.QueryFilter) ([]parsedFlow, error) {
 	const pageSize int32 = 1000
 	page := int32(1)
 	results := make([]parsedFlow, 0)
 
 	for {
-		resp, _, err := client.API.FlowsAPI.SearchFlows(client.Ctx, tenant).
+		req := client.API.FlowsAPI.SearchFlows(client.Ctx, tenant).
 			Page(page).
-			Size(pageSize).
-			Execute()
+			Size(pageSize)
+		if len(filters) > 0 {
+			req = req.Filters(filters)
+		}
+		resp, _, err := req.Execute()
 
 		var batch []parsedFlow
 		var total int64
@@ -604,6 +615,11 @@ type parsedFlow struct {
 	Description string
 	Revision    int32
 	Source      string
+	// Exception is set when the server could not deserialize the stored flow
+	// source and answered with a FlowWithException. Such a flow exists in the
+	// inventory but is absent from an export, so it is invisible to any check
+	// that only reads exported sources.
+	Exception string
 }
 
 // parsedFlowFromFlow normalizes a decoded SDK Flow into a parsedFlow.
@@ -613,7 +629,24 @@ func parsedFlowFromFlow(f kestra.Flow) parsedFlow {
 		Namespace:   f.GetNamespace(),
 		Description: f.GetDescription(),
 		Revision:    f.GetRevision(),
+		// "exception" is not in the generated Flow model; the SDK keeps such
+		// fields in AdditionalProperties.
+		Exception: flowException(f.AdditionalProperties),
 	}
+}
+
+// flowException reads the "exception" field the server adds to a flow it could
+// not deserialize. It is a string in practice, but the field is untyped, so
+// anything else is rendered rather than dropped.
+func flowException(m map[string]any) string {
+	value, ok := m["exception"]
+	if !ok || value == nil {
+		return ""
+	}
+	if s, ok := value.(string); ok {
+		return strings.TrimSpace(s)
+	}
+	return strings.TrimSpace(fmt.Sprint(value))
 }
 
 // parsedFlowFromMap extracts flow fields from a raw JSON object. Labels are
@@ -636,6 +669,7 @@ func parsedFlowFromMap(m map[string]any) parsedFlow {
 	if v, ok := m["revision"].(float64); ok {
 		f.Revision = int32(v)
 	}
+	f.Exception = flowException(m)
 	return f
 }
 
@@ -1059,25 +1093,76 @@ func runFlowsValidate(client *Client, path string, recursive bool, renderer *Ren
 		contents = append(contents, string(data))
 	}
 
-	body := strings.Join(contents, "\n---\n")
-
-	violations, _, err := client.API.FlowsAPI.ValidateFlows(client.Ctx, client.Tenant).
-		Body(body).
-		Execute()
+	violations, err := validateSourcesInBatches(client, contents, validateBatchSize)
 	if err != nil {
-		return formatSDKError(err)
+		return err
 	}
 
 	return formatValidateResults(violations, files, renderer)
 }
 
-func formatValidateResults(violations []kestra.ValidateConstraintViolation, files []string, renderer *Renderer) error {
-	results := make([]ValidateResult, len(files))
-	for i, file := range files {
-		results[i] = ValidateResult{
-			FilePath: file,
-			Success:  true,
+// validateBatchSize bounds how many flow sources go into a single validate
+// request. The endpoint takes one multi-document YAML body, so an unbatched
+// run sends every source of a large directory — or of a whole instance — in
+// one request.
+const validateBatchSize = 100
+
+// validateSourcesInBatches validates sources in fixed-size batches and returns
+// the violations of all of them, re-indexed against the full source list.
+//
+// A violation identifies its source by position within the request body, so
+// every batch after the first comes back numbered from zero; the offset below
+// is what keeps a violation attached to the flow it actually belongs to.
+func validateSourcesInBatches(client *Client, sources []string, batchSize int) ([]kestra.ValidateConstraintViolation, error) {
+	if batchSize < 1 {
+		batchSize = validateBatchSize
+	}
+
+	violations := make([]kestra.ValidateConstraintViolation, 0, len(sources))
+
+	for start := 0; start < len(sources); start += batchSize {
+		end := min(start+batchSize, len(sources))
+
+		body := strings.Join(sources[start:end], "\n---\n")
+		batch, _, err := client.API.FlowsAPI.ValidateFlows(client.Ctx, client.Tenant).
+			Body(body).
+			Execute()
+		if err != nil {
+			return nil, formatSDKError(err)
 		}
+
+		for _, violation := range batch {
+			violation.SetIndex(violation.GetIndex() + int32(start))
+			violations = append(violations, violation)
+		}
+	}
+
+	return violations, nil
+}
+
+// formatValidateResults renders the violations of a local `flows validate`
+// run, one row per validated file.
+func formatValidateResults(violations []kestra.ValidateConstraintViolation, files []string, renderer *Renderer) error {
+	seeds := make([]ValidateResult, len(files))
+	for i, file := range files {
+		seeds[i] = ValidateResult{FilePath: file, Success: true}
+	}
+
+	results, failed := buildValidateResults(violations, seeds)
+	return renderValidateResults(results, failed, "FILE", renderer)
+}
+
+// buildValidateResults maps the server's violations back onto the seeded
+// results. A violation carries the positional index of the source it belongs
+// to within the validated batch, so seeds must be in the order the sources
+// were sent; an index outside that range lands in a synthetic row rather than
+// being dropped. A result fails only on a constraint — warnings, infos,
+// deprecations and the outdated flag are reported but never fail validation.
+func buildValidateResults(violations []kestra.ValidateConstraintViolation, seeds []ValidateResult) ([]ValidateResult, int) {
+	results := make([]ValidateResult, len(seeds))
+	copy(results, seeds)
+	for i := range results {
+		results[i].Success = true
 	}
 
 	unknownResults := make([]ValidateResult, 0)
@@ -1149,10 +1234,18 @@ func formatValidateResults(violations []kestra.ValidateConstraintViolation, file
 		}
 	}
 
-	valid := len(allResults) - failed
-	if err := renderer.Render(allResults, func(w *tabwriter.Writer) error {
-		fmt.Fprintln(w, "FILE\tSTATUS\tCONSTRAINTS\tWARNINGS\tINFOS\tOUTDATED\tDEPRECATIONS")
-		for _, result := range allResults {
+	return allResults, failed
+}
+
+// renderValidateResults writes the result table and returns a non-nil error
+// when anything failed, which main.go turns into a non-zero exit code.
+// labelHeader names the first column: the local path for `flows validate`, the
+// flow identity for `flows validate-by-query`.
+func renderValidateResults(results []ValidateResult, failed int, labelHeader string, renderer *Renderer) error {
+	valid := len(results) - failed
+	if err := renderer.Render(results, func(w *tabwriter.Writer) error {
+		fmt.Fprintf(w, "%s\tSTATUS\tCONSTRAINTS\tWARNINGS\tINFOS\tOUTDATED\tDEPRECATIONS\n", labelHeader)
+		for _, result := range results {
 			status := "OK"
 			constraints := "-"
 			if len(result.Constraints) > 0 {

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -1449,16 +1449,40 @@ func (m *markdownWriter) printf(format string, args ...any) {
 // rather than buffered.
 const maxZipEntrySize = 10 << 20 // 10 MiB
 
+// zipFlowSource is one flow source read out of an export archive, together
+// with its archive entry name. Kestra names the entries
+// "<namespace>/<flow-id>.yaml", which is the only identity an OK flow has
+// before the server has said anything about it.
+type zipFlowSource struct {
+	Name   string
+	Source string
+}
+
 // flowsFromZip reads the YAML sources out of a flow export archive entirely in
 // memory — the archive never touches disk. It returns the sources plus the
 // number of entries that were skipped (oversized or unreadable).
 func flowsFromZip(data []byte) ([]string, int, error) {
+	entries, skipped, err := flowSourcesFromZip(data)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	sources := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		sources = append(sources, entry.Source)
+	}
+	return sources, skipped, nil
+}
+
+// flowSourcesFromZip is flowsFromZip keeping the archive entry names, which
+// the caller needs when it has to label a flow it has no violation for.
+func flowSourcesFromZip(data []byte) ([]zipFlowSource, int, error) {
 	reader, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to read the flow export archive: %w", err)
 	}
 
-	sources := make([]string, 0, len(reader.File))
+	sources := make([]zipFlowSource, 0, len(reader.File))
 	skipped := 0
 
 	for _, entry := range reader.File {
@@ -1475,7 +1499,7 @@ func flowsFromZip(data []byte) ([]string, int, error) {
 			skipped++
 			continue
 		}
-		sources = append(sources, source)
+		sources = append(sources, zipFlowSource{Name: entry.Name, Source: source})
 	}
 
 	return sources, skipped, nil

--- a/src/cli/flows_usage_analysis.go
+++ b/src/cli/flows_usage_analysis.go
@@ -1450,9 +1450,10 @@ func (m *markdownWriter) printf(format string, args ...any) {
 const maxZipEntrySize = 10 << 20 // 10 MiB
 
 // zipFlowSource is one flow source read out of an export archive, together
-// with its archive entry name. Kestra names the entries
-// "<namespace>/<flow-id>.yaml", which is the only identity an OK flow has
-// before the server has said anything about it.
+// with its archive entry name. A Kestra export is flat: entries are named
+// "<namespace>-<flow-id>.yml", which cannot be split back into the two halves
+// because either may contain a hyphen. The name is therefore only good as a
+// last-resort label — read the identity from the source instead.
 type zipFlowSource struct {
 	Name   string
 	Source string

--- a/src/cli/flows_validate_by_query.go
+++ b/src/cli/flows_validate_by_query.go
@@ -11,6 +11,7 @@ import (
 func newFlowsValidateByQueryCommand() *cobra.Command {
 	var filterFlags byQueryFilterFlags
 	var batchSize int
+	var all bool
 
 	cmd := &cobra.Command{
 		Use:          "validate-by-query",
@@ -22,8 +23,10 @@ them to disk first. This is the post-migration check: 'flows validate <path>'
 answers "are my local files valid?", this answers "is what is on the instance
 valid?".
 
-Without a selection flag every flow of the tenant is validated. --namespace,
---flow and --filter narrow it down, exactly as they do for 'flows export-by-query'.
+A selection is required. --namespace, --flow and --filter narrow it down,
+exactly as they do for 'flows export-by-query'; --all validates every flow of
+the tenant and cannot be combined with the other three. Validating a whole
+instance is deliberately something you have to ask for by name.
 
 This catches both a flow with constraint violations and one whose stored source
 the server can no longer deserialize at all (e.g. a task type removed in 2.0):
@@ -36,14 +39,14 @@ deprecations and outdated flags are reported but do not fail.
 Drafts are not covered: the export the sources are read from deliberately skips
 them, so a draft-headed flow is validated at its last saved revision and a
 draft-only flow is not validated at all.`,
-		Example: `  # Validate every flow stored on the instance
-	  kestractl flows validate-by-query
-
-	  # Scope to one namespace
+		Example: `  # Scope to one namespace
 	  kestractl flows validate-by-query --namespace company.team
 
+	  # Every flow stored on the instance
+	  kestractl flows validate-by-query --all
+
 	  # Gate a migration in CI (exits non-zero when anything fails)
-	  kestractl flows validate-by-query --output json`,
+	  kestractl flows validate-by-query --all --output json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateOutputFormat(); err != nil {
 				return err
@@ -59,6 +62,19 @@ draft-only flow is not validated at all.`,
 				return err
 			}
 
+			// A missing selection is a usage mistake, not a failed run, so it
+			// is the one error here that prints the help. SilenceUsage stays on
+			// for everything else: a flow that fails validation must not bury
+			// the report under the flag list.
+			switch {
+			case all && len(filters) > 0:
+				cmd.SilenceUsage = false
+				return fmt.Errorf("--all validates every flow of the tenant and cannot be combined with --namespace, --flow or --filter")
+			case !all && len(filters) == 0:
+				cmd.SilenceUsage = false
+				return fmt.Errorf("a selection is required: use --namespace, --flow or --filter to scope the run, or --all to validate every flow of the tenant")
+			}
+
 			client, err := newClientFunc()
 			if err != nil {
 				return err
@@ -68,6 +84,8 @@ draft-only flow is not validated at all.`,
 		},
 	}
 
+	cmd.Flags().BoolVar(&all, "all", false,
+		"Validate every flow of the tenant (mutually exclusive with --namespace, --flow and --filter)")
 	cmd.Flags().IntVar(&batchSize, "batch-size", validateBatchSize,
 		"Number of flow sources sent per validation request")
 	addByQueryFilterFlags(cmd, &filterFlags)

--- a/src/cli/flows_validate_by_query.go
+++ b/src/cli/flows_validate_by_query.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"strings"
 
 	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/spf13/cobra"
@@ -26,15 +25,13 @@ valid?".
 Without a selection flag every flow of the tenant is validated. --namespace,
 --flow and --filter narrow it down, exactly as they do for 'flows export-by-query'.
 
-Two failure classes are reported:
+This catches both a flow with constraint violations and one whose stored source
+the server can no longer deserialize at all (e.g. a task type removed in 2.0):
+the export copies the stored source text without parsing it, so a flow that no
+longer loads is still sent to the validate endpoint and reported.
 
-  - a flow the server can read but that has constraint violations
-  - a flow whose stored source the server cannot deserialize at all (e.g. a task
-    type removed in 2.0), including one the export could not produce and that a
-    plain export-then-validate round-trip therefore never sees
-
-Validation fails if any flow has constraint violations or cannot be deserialized.
-Warnings, infos, deprecations and outdated flags are reported but do not fail.
+Validation fails if any flow has constraint violations. Warnings, infos,
+deprecations and outdated flags are reported but do not fail.
 
 Drafts are not covered: the export the sources are read from deliberately skips
 them, so a draft-headed flow is validated at its last saved revision and a
@@ -114,16 +111,6 @@ func runFlowsValidateByQuery(client *Client, filters []kestra.QueryFilter, batch
 
 	results, failed := buildValidateResults(violations, seeds)
 
-	// The undeserializable flows are appended after the mapping, because their
-	// positions must not shift the violation indices above.
-	broken, err := undeserializableFlows(client, filters, results)
-	if err != nil {
-		fmt.Fprintf(renderer.ErrWriter(),
-			"warning: the undeserializable-flow check was skipped (%s); only the exported sources were validated\n", err)
-	}
-	results = append(results, broken...)
-	failed += len(broken)
-
 	if len(results) == 0 {
 		fmt.Fprintln(renderer.ErrWriter(), "no flows matched the query")
 	}
@@ -131,51 +118,11 @@ func runFlowsValidateByQuery(client *Client, filters []kestra.QueryFilter, batch
 	return renderValidateResults(results, failed, "FLOW", renderer)
 }
 
-// undeserializableFlows returns a failing result for every flow the server
-// listed but could not deserialize, skipping the ones already covered by
-// validated is the export-derived result set.
-//
-// Most such flows are in the export too: it writes the stored source text
-// back out without deserializing it, so the validate endpoint sees them and
-// reports the same breakage in its own words. Reporting both would count one
-// broken flow twice. What this catches is the narrower case of a flow the
-// inventory knows about but the export did not produce.
-func undeserializableFlows(client *Client, filters []kestra.QueryFilter, validated []ValidateResult) ([]ValidateResult, error) {
-	inventory, err := listAllFlowsForTenantFiltered(client, client.Tenant, filters)
-	if err != nil {
-		return nil, err
-	}
-
-	seen := make(map[string]bool, len(validated))
-	for _, result := range validated {
-		if result.Namespace != "" && result.FlowID != "" {
-			seen[result.Namespace+"/"+result.FlowID] = true
-		}
-	}
-
-	results := make([]ValidateResult, 0)
-	for _, flow := range inventory {
-		if flow.Exception == "" || seen[flow.Namespace+"/"+flow.ID] {
-			continue
-		}
-		results = append(results, ValidateResult{
-			FilePath:  flowLabel(flow.Namespace, flow.ID, flow.ID),
-			Namespace: flow.Namespace,
-			FlowID:    flow.ID,
-			Constraints: []string{
-				"the stored flow source cannot be deserialized by the server: " +
-					strings.ReplaceAll(flow.Exception, "\n", "; "),
-			},
-			Success: false,
-		})
-	}
-	return results, nil
-}
-
 // flowLabel names a row in the result table. A stored flow has no path, so it
 // is identified as "<namespace>/<flow-id>" — not by its archive entry name,
 // which is a flattened "<namespace>-<flow-id>.yml" and reads worse. fallback
-// covers a source whose identity could not be read.
+// covers a source whose identity could not be read, which is the archive
+// entry name.
 func flowLabel(namespace, flowID, fallback string) string {
 	if namespace == "" || flowID == "" {
 		return fallback

--- a/src/cli/flows_validate_by_query.go
+++ b/src/cli/flows_validate_by_query.go
@@ -1,0 +1,174 @@
+package cli
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+	"github.com/spf13/cobra"
+)
+
+func newFlowsValidateByQueryCommand() *cobra.Command {
+	var filterFlags byQueryFilterFlags
+	var batchSize int
+
+	cmd := &cobra.Command{
+		Use:          "validate-by-query",
+		Short:        "Validate the flows already stored on the instance.",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		Long: `Validate the flow sources already stored on the instance, without exporting
+them to disk first. This is the post-migration check: 'flows validate <path>'
+answers "are my local files valid?", this answers "is what is on the instance
+valid?".
+
+Without a selection flag every flow of the tenant is validated. --namespace,
+--flow and --filter narrow it down, exactly as they do for 'flows export-by-query'.
+
+Two failure classes are reported:
+
+  - a flow the server can read but that has constraint violations
+  - a flow whose stored source the server cannot deserialize at all (e.g. a task
+    type removed in 2.0). Such a flow is absent from an export, so a plain
+    export-then-validate round-trip reports it as valid
+
+Validation fails if any flow has constraint violations or cannot be deserialized.
+Warnings, infos, deprecations and outdated flags are reported but do not fail.
+
+Drafts are not covered: the export the sources are read from deliberately skips
+them, so a draft-headed flow is validated at its last saved revision and a
+draft-only flow is not validated at all.`,
+		Example: `  # Validate every flow stored on the instance
+	  kestractl flows validate-by-query
+
+	  # Scope to one namespace
+	  kestractl flows validate-by-query --namespace company.team
+
+	  # Gate a migration in CI (exits non-zero when anything fails)
+	  kestractl flows validate-by-query --output json`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateOutputFormat(); err != nil {
+				return err
+			}
+			renderer, err := NewRendererFromFlags(cmd.OutOrStdout())
+			if err != nil {
+				return err
+			}
+			renderer.WithErrWriter(cmd.ErrOrStderr())
+
+			filters, err := filterFlags.resolveOptional()
+			if err != nil {
+				return err
+			}
+
+			client, err := newClientFunc()
+			if err != nil {
+				return err
+			}
+
+			return runFlowsValidateByQuery(client, filters, batchSize, renderer)
+		},
+	}
+
+	cmd.Flags().IntVar(&batchSize, "batch-size", validateBatchSize,
+		"Number of flow sources sent per validation request")
+	addByQueryFilterFlags(cmd, &filterFlags)
+
+	return cmd
+}
+
+func runFlowsValidateByQuery(client *Client, filters []kestra.QueryFilter, batchSize int, renderer *Renderer) error {
+	archive, err := client.Kestra.Flows().ExportFlowsByQuery(client.Ctx, client.Tenant, queryFiltersToSearchFilters(filters))
+	if err != nil {
+		return formatSDKError(err)
+	}
+
+	entries, skipped, err := flowSourcesFromZip(archive)
+	if err != nil {
+		return err
+	}
+	if skipped > 0 {
+		fmt.Fprintf(renderer.ErrWriter(),
+			"warning: %d archive entry/entries were skipped (unreadable or larger than %d MiB)\n",
+			skipped, maxZipEntrySize>>20)
+	}
+
+	sources := make([]string, 0, len(entries))
+	seeds := make([]ValidateResult, 0, len(entries))
+	for _, entry := range entries {
+		namespace, flowID := flowIdentityFromZipEntry(entry.Name)
+		sources = append(sources, entry.Source)
+		seeds = append(seeds, ValidateResult{
+			FilePath:  entry.Name,
+			Namespace: namespace,
+			FlowID:    flowID,
+			Success:   true,
+		})
+	}
+
+	violations, err := validateSourcesInBatches(client, sources, batchSize)
+	if err != nil {
+		return err
+	}
+
+	results, failed := buildValidateResults(violations, seeds)
+
+	// The undeserializable flows are appended after the mapping, because their
+	// positions must not shift the violation indices above.
+	broken, err := undeserializableFlows(client, filters)
+	if err != nil {
+		fmt.Fprintf(renderer.ErrWriter(),
+			"warning: the undeserializable-flow check was skipped (%s); only the exported sources were validated\n", err)
+	}
+	results = append(results, broken...)
+	failed += len(broken)
+
+	if len(results) == 0 {
+		fmt.Fprintln(renderer.ErrWriter(), "no flows matched the query")
+	}
+
+	return renderValidateResults(results, failed, "FLOW", renderer)
+}
+
+// undeserializableFlows returns a failing result for every flow the server
+// listed but could not deserialize. These never reach the validate endpoint —
+// they are missing from the export, and there is no source to send.
+func undeserializableFlows(client *Client, filters []kestra.QueryFilter) ([]ValidateResult, error) {
+	inventory, err := listAllFlowsForTenantFiltered(client, client.Tenant, filters)
+	if err != nil {
+		return nil, err
+	}
+
+	results := make([]ValidateResult, 0)
+	for _, flow := range inventory {
+		if flow.Exception == "" {
+			continue
+		}
+		results = append(results, ValidateResult{
+			FilePath:  flow.Namespace + "/" + flow.ID,
+			Namespace: flow.Namespace,
+			FlowID:    flow.ID,
+			Constraints: []string{
+				"the stored flow source cannot be deserialized by the server: " +
+					strings.ReplaceAll(flow.Exception, "\n", "; "),
+			},
+			Success: false,
+		})
+	}
+	return results, nil
+}
+
+// flowIdentityFromZipEntry splits a flow export entry name into its namespace
+// and flow id. Kestra names them "<namespace>/<flow-id>.yaml"; anything that
+// does not look like that yields an empty namespace, and the renderer falls
+// back to the entry name.
+func flowIdentityFromZipEntry(name string) (namespace, flowID string) {
+	trimmed := strings.TrimPrefix(path.Clean(name), "/")
+	dir, file := path.Split(trimmed)
+
+	flowID = strings.TrimSuffix(file, path.Ext(file))
+	namespace = strings.ReplaceAll(strings.Trim(dir, "/"), "/", ".")
+
+	return namespace, flowID
+}

--- a/src/cli/flows_validate_by_query.go
+++ b/src/cli/flows_validate_by_query.go
@@ -2,11 +2,11 @@ package cli
 
 import (
 	"fmt"
-	"path"
 	"strings"
 
 	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 func newFlowsValidateByQueryCommand() *cobra.Command {
@@ -30,8 +30,8 @@ Two failure classes are reported:
 
   - a flow the server can read but that has constraint violations
   - a flow whose stored source the server cannot deserialize at all (e.g. a task
-    type removed in 2.0). Such a flow is absent from an export, so a plain
-    export-then-validate round-trip reports it as valid
+    type removed in 2.0), including one the export could not produce and that a
+    plain export-then-validate round-trip therefore never sees
 
 Validation fails if any flow has constraint violations or cannot be deserialized.
 Warnings, infos, deprecations and outdated flags are reported but do not fail.
@@ -97,10 +97,10 @@ func runFlowsValidateByQuery(client *Client, filters []kestra.QueryFilter, batch
 	sources := make([]string, 0, len(entries))
 	seeds := make([]ValidateResult, 0, len(entries))
 	for _, entry := range entries {
-		namespace, flowID := flowIdentityFromZipEntry(entry.Name)
+		namespace, flowID := flowIdentityFromSource(entry.Source)
 		sources = append(sources, entry.Source)
 		seeds = append(seeds, ValidateResult{
-			FilePath:  entry.Name,
+			FilePath:  flowLabel(namespace, flowID, entry.Name),
 			Namespace: namespace,
 			FlowID:    flowID,
 			Success:   true,
@@ -116,7 +116,7 @@ func runFlowsValidateByQuery(client *Client, filters []kestra.QueryFilter, batch
 
 	// The undeserializable flows are appended after the mapping, because their
 	// positions must not shift the violation indices above.
-	broken, err := undeserializableFlows(client, filters)
+	broken, err := undeserializableFlows(client, filters, results)
 	if err != nil {
 		fmt.Fprintf(renderer.ErrWriter(),
 			"warning: the undeserializable-flow check was skipped (%s); only the exported sources were validated\n", err)
@@ -132,21 +132,34 @@ func runFlowsValidateByQuery(client *Client, filters []kestra.QueryFilter, batch
 }
 
 // undeserializableFlows returns a failing result for every flow the server
-// listed but could not deserialize. These never reach the validate endpoint —
-// they are missing from the export, and there is no source to send.
-func undeserializableFlows(client *Client, filters []kestra.QueryFilter) ([]ValidateResult, error) {
+// listed but could not deserialize, skipping the ones already covered by
+// validated is the export-derived result set.
+//
+// Most such flows are in the export too: it writes the stored source text
+// back out without deserializing it, so the validate endpoint sees them and
+// reports the same breakage in its own words. Reporting both would count one
+// broken flow twice. What this catches is the narrower case of a flow the
+// inventory knows about but the export did not produce.
+func undeserializableFlows(client *Client, filters []kestra.QueryFilter, validated []ValidateResult) ([]ValidateResult, error) {
 	inventory, err := listAllFlowsForTenantFiltered(client, client.Tenant, filters)
 	if err != nil {
 		return nil, err
 	}
 
+	seen := make(map[string]bool, len(validated))
+	for _, result := range validated {
+		if result.Namespace != "" && result.FlowID != "" {
+			seen[result.Namespace+"/"+result.FlowID] = true
+		}
+	}
+
 	results := make([]ValidateResult, 0)
 	for _, flow := range inventory {
-		if flow.Exception == "" {
+		if flow.Exception == "" || seen[flow.Namespace+"/"+flow.ID] {
 			continue
 		}
 		results = append(results, ValidateResult{
-			FilePath:  flow.Namespace + "/" + flow.ID,
+			FilePath:  flowLabel(flow.Namespace, flow.ID, flow.ID),
 			Namespace: flow.Namespace,
 			FlowID:    flow.ID,
 			Constraints: []string{
@@ -159,16 +172,36 @@ func undeserializableFlows(client *Client, filters []kestra.QueryFilter) ([]Vali
 	return results, nil
 }
 
-// flowIdentityFromZipEntry splits a flow export entry name into its namespace
-// and flow id. Kestra names them "<namespace>/<flow-id>.yaml"; anything that
-// does not look like that yields an empty namespace, and the renderer falls
-// back to the entry name.
-func flowIdentityFromZipEntry(name string) (namespace, flowID string) {
-	trimmed := strings.TrimPrefix(path.Clean(name), "/")
-	dir, file := path.Split(trimmed)
+// flowLabel names a row in the result table. A stored flow has no path, so it
+// is identified as "<namespace>/<flow-id>" — not by its archive entry name,
+// which is a flattened "<namespace>-<flow-id>.yml" and reads worse. fallback
+// covers a source whose identity could not be read.
+func flowLabel(namespace, flowID, fallback string) string {
+	if namespace == "" || flowID == "" {
+		return fallback
+	}
+	return namespace + "/" + flowID
+}
 
-	flowID = strings.TrimSuffix(file, path.Ext(file))
-	namespace = strings.ReplaceAll(strings.Trim(dir, "/"), "/", ".")
-
-	return namespace, flowID
+// flowIdentityFromSource reads the namespace and id out of a flow source.
+//
+// The archive entry name is not usable for this: a Kestra export flattens the
+// archive to "<namespace>-<flow-id>.yml", and since both halves may contain a
+// hyphen, that name cannot be split back apart unambiguously. The source is
+// authoritative anyway.
+//
+// This is only a seed. The validate endpoint returns the identity of every
+// source it was given, valid ones included, and that overwrites what is set
+// here; this is what a row falls back to if the server ever omits one.
+func flowIdentityFromSource(source string) (namespace, flowID string) {
+	var root struct {
+		ID        string `yaml:"id"`
+		Namespace string `yaml:"namespace"`
+	}
+	// A source that does not parse is exactly what this command reports on, so
+	// a failure here is expected and leaves the identity to the server.
+	if err := yaml.Unmarshal([]byte(source), &root); err != nil {
+		return "", ""
+	}
+	return root.Namespace, root.ID
 }

--- a/src/cli/flows_validate_by_query.go
+++ b/src/cli/flows_validate_by_query.go
@@ -73,6 +73,9 @@ draft-only flow is not validated at all.`,
 			case !all && len(filters) == 0:
 				cmd.SilenceUsage = false
 				return fmt.Errorf("a selection is required: use --namespace, --flow or --filter to scope the run, or --all to validate every flow of the tenant")
+			case batchSize < 1:
+				cmd.SilenceUsage = false
+				return fmt.Errorf("--batch-size must be at least 1, got %d", batchSize)
 			}
 
 			client, err := newClientFunc()
@@ -128,12 +131,25 @@ func runFlowsValidateByQuery(client *Client, filters []kestra.QueryFilter, batch
 	}
 
 	results, failed := buildValidateResults(violations, seeds)
+	relabelFromServerIdentity(results)
 
 	if len(results) == 0 {
 		fmt.Fprintln(renderer.ErrWriter(), "no flows matched the query")
 	}
 
 	return renderValidateResults(results, failed, "FLOW", renderer)
+}
+
+// relabelFromServerIdentity rewrites each row's label from the identity the
+// validate endpoint returned. The seed label is parsed out of the source, so
+// it is only as good as our own YAML read of it; the server's answer is
+// authoritative and covers a source we could not parse at all.
+func relabelFromServerIdentity(results []ValidateResult) {
+	for i := range results {
+		if results[i].Namespace != "" && results[i].FlowID != "" {
+			results[i].FilePath = results[i].Namespace + "/" + results[i].FlowID
+		}
+	}
 }
 
 // flowLabel names a row in the result table. A stored flow has no path, so it
@@ -155,9 +171,9 @@ func flowLabel(namespace, flowID, fallback string) string {
 // hyphen, that name cannot be split back apart unambiguously. The source is
 // authoritative anyway.
 //
-// This is only a seed. The validate endpoint returns the identity of every
-// source it was given, valid ones included, and that overwrites what is set
-// here; this is what a row falls back to if the server ever omits one.
+// This is only a seed: relabelFromServerIdentity replaces it with the identity
+// the validate endpoint returns, which is authoritative. It is what a row
+// falls back to when the server omits one.
 func flowIdentityFromSource(source string) (namespace, flowID string) {
 	var root struct {
 		ID        string `yaml:"id"`

--- a/src/cli/flows_validate_by_query_test.go
+++ b/src/cli/flows_validate_by_query_test.go
@@ -75,11 +75,11 @@ func flowSource(id string) string {
 
 func TestFlowSourcesFromZip_KeepsEntryNames(t *testing.T) {
 	archive := buildFlowZip(t, map[string]string{
-		"company.team/first.yaml": flowSource("first"),
-		"company.team/second.yml": flowSource("second"),
-		"company.team/README.md":  "not a flow",
-		"company.team/nested/":    "",
-		"company.team/notes.txt":  "not a flow either",
+		"company.team-first.yml":   flowSource("first"),
+		"company.team-second.yaml": flowSource("second"),
+		"company.team-README.md":   "not a flow",
+		"nested/":                  "",
+		"company.team-notes.txt":   "not a flow either",
 	})
 
 	entries, skipped, err := flowSourcesFromZip(archive)
@@ -97,17 +97,17 @@ func TestFlowSourcesFromZip_KeepsEntryNames(t *testing.T) {
 	for _, entry := range entries {
 		byName[entry.Name] = entry.Source
 	}
-	if byName["company.team/first.yaml"] != flowSource("first") {
-		t.Errorf("first.yaml source not preserved: %q", byName["company.team/first.yaml"])
+	if byName["company.team-first.yml"] != flowSource("first") {
+		t.Errorf("first.yml source not preserved: %q", byName["company.team-first.yml"])
 	}
-	if _, ok := byName["company.team/second.yml"]; !ok {
-		t.Errorf("second.yml missing from %v", byName)
+	if _, ok := byName["company.team-second.yaml"]; !ok {
+		t.Errorf("second.yaml missing from %v", byName)
 	}
 }
 
 func TestFlowsFromZip_WrapperStillReturnsSourcesOnly(t *testing.T) {
 	archive := buildFlowZip(t, map[string]string{
-		"company.team/only.yaml": flowSource("only"),
+		"company.team-only.yml": flowSource("only"),
 	})
 
 	sources, skipped, err := flowsFromZip(archive)
@@ -401,5 +401,129 @@ func TestFlowsValidateByQueryCommand_KeepsUsageSilencedOnceRunning(t *testing.T)
 	}
 	if !cmd.SilenceUsage {
 		t.Error("a failure past the selection check must not print the help")
+	}
+}
+
+// TestTrimDocumentMarkers covers the join hazard: a stored flow source keeps
+// whatever the author wrote, and a leading "---" is ordinary YAML style.
+func TestTrimDocumentMarkers(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{"plain source is untouched", "id: a\nnamespace: n", "id: a\nnamespace: n"},
+		{"leading separator", "---\nid: a", "id: a"},
+		{"leading separator after a blank line", "\n---\nid: a", "id: a"},
+		{"trailing separator", "id: a\n---", "id: a"},
+		{"trailing end-of-document marker", "id: a\n...", "id: a"},
+		{"trailing newline", "id: a\n", "id: a"},
+		{"both ends", "---\nid: a\n...\n", "id: a"},
+		{"a --- inside a string is not a marker", "id: a\nmessage: \"---\"", "id: a\nmessage: \"---\""},
+		{"an indented --- is not a marker", "id: a\nmessage: |\n  ---", "id: a\nmessage: |\n  ---"},
+		{"only a separator", "---", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := trimDocumentMarkers(tc.source); got != tc.want {
+				t.Errorf("trimDocumentMarkers(%q) = %q, want %q", tc.source, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateSourcesInBatches_StripsSeparatorsSoIndicesLineUp is the
+// regression test for the live failure: two valid flows, the second written
+// with a leading "---", produced a spurious "No content to map due to
+// end-of-input" on the second flow plus a phantom <index 2> row, because the
+// joined body split into three documents instead of two.
+func TestValidateSourcesInBatches_StripsSeparatorsSoIndicesLineUp(t *testing.T) {
+	var got string
+	server := &validateByQueryServer{
+		violate: func(body string) []map[string]any {
+			got = body
+			return nil
+		},
+	}
+	client := newTestClient(t, server.start(t))
+
+	sources := []string{"id: first\nnamespace: n\n", "---\nid: second\nnamespace: n\n"}
+	if _, err := validateSourcesInBatches(client, sources, 10); err != nil {
+		t.Fatalf("validateSourcesInBatches error: %v", err)
+	}
+
+	if strings.Contains(got, "---\n---") {
+		t.Errorf("the joined body must not contain an empty document:\n%s", got)
+	}
+	if want := "id: first\nnamespace: n\n---\nid: second\nnamespace: n"; got != want {
+		t.Errorf("joined body =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// A source can still hold a document separator we cannot strip — one in the
+// middle. Guessing which flow a shifted index belongs to would silently
+// mis-report, so the run fails instead.
+func TestValidateSourcesInBatches_RefusesToMapAnOutOfRangeIndex(t *testing.T) {
+	for _, index := range []int{2, -1} {
+		server := &validateByQueryServer{
+			violate: func(string) []map[string]any {
+				return []map[string]any{{"index": index, "constraints": "boom"}}
+			},
+		}
+		client := newTestClient(t, server.start(t))
+
+		_, err := validateSourcesInBatches(client, []string{"id: a\n", "id: b\n"}, 10)
+		if err == nil {
+			t.Fatalf("index %d: expected the desync to be reported", index)
+		}
+		if !strings.Contains(err.Error(), "cannot map validation results back to flows") {
+			t.Errorf("index %d: unexpected error: %v", index, err)
+		}
+	}
+}
+
+// The server's identity wins over what we parsed out of the source, so a row
+// is labelled correctly even when the source could not be read.
+func TestRunFlowsValidateByQuery_LabelsFromServerIdentity(t *testing.T) {
+	server := &validateByQueryServer{
+		// A source our own YAML read cannot get an id out of.
+		archive: buildFlowZip(t, map[string]string{
+			"company.team-mystery.yml": "id: [unterminated\n",
+		}),
+		violate: func(string) []map[string]any {
+			return []map[string]any{
+				{"index": 0, "constraints": "Illegal Flow source", "flow": "mystery", "namespace": "company.team"},
+			}
+		},
+	}
+	client := newTestClient(t, server.start(t))
+
+	var out bytes.Buffer
+	if err := runFlowsValidateByQuery(client, nil, validateBatchSize, newTableRenderer(&out)); err == nil {
+		t.Fatal("expected the unreadable flow to fail validation")
+	}
+	if !strings.Contains(out.String(), "company.team/mystery") {
+		t.Errorf("expected the server's identity as the label, got:\n%s", out.String())
+	}
+	if strings.Contains(out.String(), "company.team-mystery.yml") {
+		t.Errorf("the archive entry name should have been replaced:\n%s", out.String())
+	}
+}
+
+func TestFlowsValidateByQueryCommand_RejectsANonPositiveBatchSize(t *testing.T) {
+	for _, size := range []string{"0", "-5"} {
+		cmd := newFlowsValidateByQueryCommand()
+		_, err := executeCommand(cmd, "--all", "--batch-size", size)
+		if err == nil {
+			t.Errorf("--batch-size %s should be rejected", size)
+			continue
+		}
+		if !strings.Contains(err.Error(), "--batch-size must be at least 1") {
+			t.Errorf("--batch-size %s: unexpected error: %v", size, err)
+		}
+		if cmd.SilenceUsage {
+			t.Errorf("--batch-size %s: a flag mistake should print the help", size)
+		}
 	}
 }

--- a/src/cli/flows_validate_by_query_test.go
+++ b/src/cli/flows_validate_by_query_test.go
@@ -16,9 +16,12 @@ import (
 // validateByQueryServer stands in for a Kestra instance: it serves an export
 // archive, a validate endpoint driven by the caller, and a flow inventory.
 type validateByQueryServer struct {
-	archive   []byte
-	violate   func(body string) []map[string]any
-	inventory []map[string]any
+	archive []byte
+	violate func(body string) []map[string]any
+
+	// searched records a hit on /flows/search, which this command must never
+	// make: it validates what the export gives it and nothing else.
+	searched bool
 
 	mu     sync.Mutex
 	bodies []string
@@ -46,11 +49,11 @@ func (s *validateByQueryServer) start(t *testing.T) string {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(violations)
 		case strings.HasSuffix(r.URL.Path, "/flows/search"):
+			s.mu.Lock()
+			s.searched = true
+			s.mu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"results": s.inventory,
-				"total":   len(s.inventory),
-			})
+			_ = json.NewEncoder(w).Encode(map[string]any{"results": []any{}, "total": 0})
 		default:
 			t.Errorf("unexpected request to %s", r.URL.Path)
 			w.WriteHeader(http.StatusNotFound)
@@ -272,66 +275,11 @@ func TestBuildValidateResults_OutOfRangeIndexGetsItsOwnRow(t *testing.T) {
 	}
 }
 
-func TestRunFlowsValidateByQuery_ReportsConstraintsAndExceptions(t *testing.T) {
-	server := &validateByQueryServer{
-		archive: buildFlowZip(t, map[string]string{
-			"company.team-good.yml": flowSource("good"),
-			"company.team-bad.yml":  flowSource("bad"),
-		}),
-		violate: func(body string) []map[string]any {
-			index := 0
-			// The archive order is not guaranteed, so key off the source.
-			if strings.Index(body, "id: bad") > strings.Index(body, "id: good") {
-				index = 1
-			}
-			return []map[string]any{
-				{"index": index, "constraints": "tasks: must not be empty", "flow": "bad", "namespace": "company.team"},
-			}
-		},
-		inventory: []map[string]any{
-			{"id": "good", "namespace": "company.team", "revision": 1},
-			{"id": "bad", "namespace": "company.team", "revision": 1},
-			// Absent from the archive above: only such a flow is reported by
-			// the cross-check, the rest come back from the validate endpoint.
-			{"id": "broken", "namespace": "company.team", "revision": 1,
-				"exception": "Invalid type: io.kestra.core.tasks.flows.EachSequential"},
-		},
-	}
-	client := newTestClient(t, server.start(t))
-
-	var out bytes.Buffer
-	err := runFlowsValidateByQuery(client, nil, validateBatchSize, newTableRenderer(&out))
-	if err == nil {
-		t.Fatal("expected a non-nil error so the command exits non-zero")
-	}
-	if !strings.Contains(err.Error(), "validation failed for 2 flow(s)") {
-		t.Errorf("expected 2 failures in the error, got: %v", err)
-	}
-
-	rendered := out.String()
-	if !strings.HasPrefix(strings.TrimSpace(rendered), "FLOW") {
-		t.Errorf("expected the table to be keyed by FLOW, got:\n%s", rendered)
-	}
-	if !strings.Contains(rendered, "tasks: must not be empty") {
-		t.Errorf("expected the constraint in the output:\n%s", rendered)
-	}
-	if !strings.Contains(rendered, "cannot be deserialized") ||
-		!strings.Contains(rendered, "company.team/broken") {
-		t.Errorf("expected the undeserializable flow to be reported:\n%s", rendered)
-	}
-	if !strings.Contains(rendered, "1 valid flow(s), 2 failed") {
-		t.Errorf("expected the 1/2 summary, got:\n%s", rendered)
-	}
-}
-
 func TestRunFlowsValidateByQuery_AllValid(t *testing.T) {
 	server := &validateByQueryServer{
 		archive: buildFlowZip(t, map[string]string{
 			"company.team-good.yml": flowSource("good"),
 		}),
-		inventory: []map[string]any{
-			{"id": "good", "namespace": "company.team", "revision": 1},
-		},
 	}
 	client := newTestClient(t, server.start(t))
 
@@ -341,39 +289,6 @@ func TestRunFlowsValidateByQuery_AllValid(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "1 valid flow(s), 0 failed") {
 		t.Errorf("unexpected output:\n%s", out.String())
-	}
-}
-
-// The inventory is a cross-check, not the main event: losing it degrades into
-// a warning so the exported sources are still validated.
-func TestRunFlowsValidateByQuery_InventoryFailureDegradesToWarning(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case strings.HasSuffix(r.URL.Path, "/flows/export/by-query"):
-			w.Header().Set("Content-Type", "application/zip")
-			_, _ = w.Write(buildFlowZip(t, map[string]string{
-				"company.team-good.yml": flowSource("good"),
-			}))
-		case strings.HasSuffix(r.URL.Path, "/flows/validate"):
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`[]`))
-		default:
-			w.WriteHeader(http.StatusForbidden)
-			_, _ = w.Write([]byte(`{"message":"no permission to list flows"}`))
-		}
-	}))
-	t.Cleanup(server.Close)
-
-	var out, errOut bytes.Buffer
-	renderer := newTableRenderer(&out).WithErrWriter(&errOut)
-	if err := runFlowsValidateByQuery(newTestClient(t, server.URL), nil, validateBatchSize, renderer); err != nil {
-		t.Fatalf("an unreadable inventory must not fail the command, got: %v", err)
-	}
-	if !strings.Contains(errOut.String(), "undeserializable-flow check was skipped") {
-		t.Errorf("expected a warning on stderr, got: %q", errOut.String())
-	}
-	if !strings.Contains(out.String(), "1 valid flow(s), 0 failed") {
-		t.Errorf("the exported sources should still have been validated:\n%s", out.String())
 	}
 }
 
@@ -395,27 +310,27 @@ func newViolation(index int32, constraints string, warnings []string) kestra.Val
 	return *violation
 }
 
-// TestRunFlowsValidateByQuery_DoesNotDoubleCountExportedBrokenFlows is the
-// regression test for what live QA against a migrated 1.3.37 -> 2.0.0 instance
-// turned up: an undeserializable flow is usually still in the export, because
-// the export writes the stored source text back out without deserializing it.
-// Reporting it from both the validate endpoint and the inventory counted one
-// broken flow twice.
-func TestRunFlowsValidateByQuery_DoesNotDoubleCountExportedBrokenFlows(t *testing.T) {
+// TestRunFlowsValidateByQuery_ReportsBrokenStoredFlows covers what live QA on
+// an instance migrated in place from 1.3.37 to 2.0.0 actually produces: the
+// export copies the stored source text without parsing it, so a flow whose
+// task type no longer exists still reaches the validate endpoint and is
+// reported there — once.
+func TestRunFlowsValidateByQuery_ReportsBrokenStoredFlows(t *testing.T) {
+	legacy := "id: legacy\nnamespace: company.team\ntasks:\n  - id: loop\n    type: io.kestra.plugin.core.flow.EachSequential\n"
 	server := &validateByQueryServer{
 		archive: buildFlowZip(t, map[string]string{
-			"company.team-legacy.yml": "id: legacy\nnamespace: company.team\ntasks:\n  - id: loop\n    type: io.kestra.plugin.core.flow.EachSequential\n",
+			"company.team-legacy.yml": legacy,
+			"company.team-good.yml":   flowSource("good"),
 		}),
-		violate: func(string) []map[string]any {
+		violate: func(body string) []map[string]any {
+			index := 0
+			if strings.Index(body, "id: legacy") > strings.Index(body, "id: good") {
+				index = 1
+			}
 			return []map[string]any{
-				{"index": 0, "constraints": "Invalid type: io.kestra.plugin.core.flow.EachSequential",
+				{"index": index, "constraints": "Validation error: Invalid type: io.kestra.plugin.core.flow.EachSequential",
 					"flow": "legacy", "namespace": "company.team"},
 			}
-		},
-		// The same flow, also flagged by the inventory.
-		inventory: []map[string]any{
-			{"id": "legacy", "namespace": "company.team", "revision": 1,
-				"exception": "Could not resolve type id 'io.kestra.plugin.core.flow.EachSequential'"},
 		},
 	}
 	client := newTestClient(t, server.start(t))
@@ -423,17 +338,26 @@ func TestRunFlowsValidateByQuery_DoesNotDoubleCountExportedBrokenFlows(t *testin
 	var out bytes.Buffer
 	err := runFlowsValidateByQuery(client, nil, validateBatchSize, newTableRenderer(&out))
 	if err == nil {
-		t.Fatal("expected the broken flow to fail validation")
+		t.Fatal("expected a non-nil error so the command exits non-zero")
 	}
 	if !strings.Contains(err.Error(), "validation failed for 1 flow(s)") {
-		t.Errorf("the flow must be counted once, got: %v", err)
+		t.Errorf("the broken flow must be counted once, got: %v", err)
 	}
 
 	rendered := out.String()
 	if got := strings.Count(rendered, "company.team/legacy"); got != 1 {
-		t.Errorf("expected exactly 1 row for the flow, got %d:\n%s", got, rendered)
+		t.Errorf("expected exactly 1 row for the broken flow, got %d:\n%s", got, rendered)
 	}
-	if !strings.Contains(rendered, "0 valid flow(s), 1 failed") {
+	if !strings.Contains(rendered, "Invalid type: io.kestra.plugin.core.flow.EachSequential") {
+		t.Errorf("expected the server's message in the output:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "1 valid flow(s), 1 failed") {
 		t.Errorf("unexpected summary:\n%s", rendered)
+	}
+
+	server.mu.Lock()
+	defer server.mu.Unlock()
+	if server.searched {
+		t.Error("validate-by-query must not call /flows/search")
 	}
 }

--- a/src/cli/flows_validate_by_query_test.go
+++ b/src/cli/flows_validate_by_query_test.go
@@ -1,0 +1,375 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	kestra "github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
+)
+
+// validateByQueryServer stands in for a Kestra instance: it serves an export
+// archive, a validate endpoint driven by the caller, and a flow inventory.
+type validateByQueryServer struct {
+	archive   []byte
+	violate   func(body string) []map[string]any
+	inventory []map[string]any
+
+	mu     sync.Mutex
+	bodies []string
+}
+
+func (s *validateByQueryServer) start(t *testing.T) string {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/flows/export/by-query"):
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(s.archive)
+		case strings.HasSuffix(r.URL.Path, "/flows/validate"):
+			buf := new(bytes.Buffer)
+			_, _ = buf.ReadFrom(r.Body)
+
+			s.mu.Lock()
+			s.bodies = append(s.bodies, buf.String())
+			s.mu.Unlock()
+
+			var violations []map[string]any
+			if s.violate != nil {
+				violations = s.violate(buf.String())
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(violations)
+		case strings.HasSuffix(r.URL.Path, "/flows/search"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"results": s.inventory,
+				"total":   len(s.inventory),
+			})
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+func (s *validateByQueryServer) requestBodies() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.bodies...)
+}
+
+func flowSource(id string) string {
+	return "id: " + id + "\nnamespace: company.team\ntasks: []\n"
+}
+
+func TestFlowSourcesFromZip_KeepsEntryNames(t *testing.T) {
+	archive := buildFlowZip(t, map[string]string{
+		"company.team/first.yaml": flowSource("first"),
+		"company.team/second.yml": flowSource("second"),
+		"company.team/README.md":  "not a flow",
+		"company.team/nested/":    "",
+		"company.team/notes.txt":  "not a flow either",
+	})
+
+	entries, skipped, err := flowSourcesFromZip(archive)
+	if err != nil {
+		t.Fatalf("flowSourcesFromZip error: %v", err)
+	}
+	if skipped != 0 {
+		t.Errorf("expected no skipped entries, got %d", skipped)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected the 2 YAML entries, got %d: %+v", len(entries), entries)
+	}
+
+	byName := map[string]string{}
+	for _, entry := range entries {
+		byName[entry.Name] = entry.Source
+	}
+	if byName["company.team/first.yaml"] != flowSource("first") {
+		t.Errorf("first.yaml source not preserved: %q", byName["company.team/first.yaml"])
+	}
+	if _, ok := byName["company.team/second.yml"]; !ok {
+		t.Errorf("second.yml missing from %v", byName)
+	}
+}
+
+func TestFlowsFromZip_WrapperStillReturnsSourcesOnly(t *testing.T) {
+	archive := buildFlowZip(t, map[string]string{
+		"company.team/only.yaml": flowSource("only"),
+	})
+
+	sources, skipped, err := flowsFromZip(archive)
+	if err != nil {
+		t.Fatalf("flowsFromZip error: %v", err)
+	}
+	if skipped != 0 {
+		t.Errorf("expected no skipped entries, got %d", skipped)
+	}
+	if len(sources) != 1 || sources[0] != flowSource("only") {
+		t.Errorf("unexpected sources: %+v", sources)
+	}
+}
+
+func TestFlowIdentityFromZipEntry(t *testing.T) {
+	cases := []struct {
+		entry     string
+		namespace string
+		flowID    string
+	}{
+		{"company.team/my-flow.yaml", "company.team", "my-flow"},
+		{"company/team/my-flow.yml", "company.team", "my-flow"},
+		{"/company.team/my-flow.yaml", "company.team", "my-flow"},
+		{"my-flow.yaml", "", "my-flow"},
+	}
+
+	for _, tc := range cases {
+		namespace, flowID := flowIdentityFromZipEntry(tc.entry)
+		if namespace != tc.namespace || flowID != tc.flowID {
+			t.Errorf("flowIdentityFromZipEntry(%q) = (%q, %q), want (%q, %q)",
+				tc.entry, namespace, flowID, tc.namespace, tc.flowID)
+		}
+	}
+}
+
+// TestValidateSourcesInBatches_OffsetsViolationIndices is the regression test
+// for the batching: the endpoint numbers violations from zero within each
+// request, so without the offset a violation lands on the wrong flow.
+func TestValidateSourcesInBatches_OffsetsViolationIndices(t *testing.T) {
+	sources := make([]string, 7)
+	for i := range sources {
+		sources[i] = flowSource(fmt.Sprintf("flow-%d", i))
+	}
+
+	server := &validateByQueryServer{
+		violate: func(body string) []map[string]any {
+			// Fail the second flow of every batch, which is index 1 locally
+			// and 1, 4 and (in the final 1-source batch) nothing globally.
+			if strings.Count(body, "\n---\n") < 1 {
+				return nil
+			}
+			return []map[string]any{
+				{"index": 1, "constraints": "boom", "flow": "x", "namespace": "company.team"},
+			}
+		},
+	}
+	client := newTestClient(t, server.start(t))
+
+	violations, err := validateSourcesInBatches(client, sources, 3)
+	if err != nil {
+		t.Fatalf("validateSourcesInBatches error: %v", err)
+	}
+
+	bodies := server.requestBodies()
+	if len(bodies) != 3 {
+		t.Fatalf("expected 3 batches for 7 sources at batch size 3, got %d", len(bodies))
+	}
+	if got := strings.Count(bodies[0], "\n---\n"); got != 2 {
+		t.Errorf("expected 3 sources in the first batch, got %d separators", got)
+	}
+	if strings.Contains(bodies[2], "\n---\n") {
+		t.Errorf("expected a single source in the last batch, got: %q", bodies[2])
+	}
+
+	got := make([]int32, 0, len(violations))
+	for _, violation := range violations {
+		got = append(got, violation.GetIndex())
+	}
+	want := []int32{1, 4}
+	if fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("violation indices = %v, want %v", got, want)
+	}
+}
+
+func TestValidateSourcesInBatches_SingleRequestWhenBatchIsLarger(t *testing.T) {
+	server := &validateByQueryServer{}
+	client := newTestClient(t, server.start(t))
+
+	if _, err := validateSourcesInBatches(client, []string{flowSource("a"), flowSource("b")}, 100); err != nil {
+		t.Fatalf("validateSourcesInBatches error: %v", err)
+	}
+	if bodies := server.requestBodies(); len(bodies) != 1 {
+		t.Fatalf("expected exactly 1 request, got %d", len(bodies))
+	}
+}
+
+func TestBuildValidateResults_MapsViolationsOntoSeeds(t *testing.T) {
+	seeds := []ValidateResult{
+		{FilePath: "a.yaml", Success: true},
+		{FilePath: "b.yaml", Success: true},
+	}
+	violations := []kestra.ValidateConstraintViolation{
+		newViolation(1, "invalid task", []string{"deprecated"}),
+	}
+
+	results, failed := buildValidateResults(violations, seeds)
+	if failed != 1 {
+		t.Fatalf("expected 1 failure, got %d", failed)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if !results[0].Success {
+		t.Errorf("a.yaml should have passed: %+v", results[0])
+	}
+	if results[1].Success || len(results[1].Constraints) != 1 {
+		t.Errorf("b.yaml should have failed with one constraint: %+v", results[1])
+	}
+	if len(results[1].Warnings) != 1 {
+		t.Errorf("expected the warning to be kept: %+v", results[1])
+	}
+	// A warning alone must never fail validation.
+	if _, failedOnWarning := buildValidateResults(
+		[]kestra.ValidateConstraintViolation{newViolation(0, "", []string{"deprecated"})},
+		seeds,
+	); failedOnWarning != 0 {
+		t.Errorf("a warning must not fail validation, got %d failures", failedOnWarning)
+	}
+}
+
+func TestBuildValidateResults_OutOfRangeIndexGetsItsOwnRow(t *testing.T) {
+	seeds := []ValidateResult{{FilePath: "a.yaml", Success: true}}
+	results, failed := buildValidateResults(
+		[]kestra.ValidateConstraintViolation{newViolation(9, "boom", nil)},
+		seeds,
+	)
+
+	if failed != 1 {
+		t.Fatalf("expected 1 failure, got %d", failed)
+	}
+	if len(results) != 2 || results[1].FilePath != "<index 9>" {
+		t.Fatalf("expected a synthetic <index 9> row, got %+v", results)
+	}
+	if !results[0].Success {
+		t.Errorf("the seeded row must be untouched: %+v", results[0])
+	}
+}
+
+func TestRunFlowsValidateByQuery_ReportsConstraintsAndExceptions(t *testing.T) {
+	server := &validateByQueryServer{
+		archive: buildFlowZip(t, map[string]string{
+			"company.team/good.yaml": flowSource("good"),
+			"company.team/bad.yaml":  flowSource("bad"),
+		}),
+		violate: func(body string) []map[string]any {
+			index := 0
+			// The archive order is not guaranteed, so key off the source.
+			if strings.Index(body, "id: bad") > strings.Index(body, "id: good") {
+				index = 1
+			}
+			return []map[string]any{
+				{"index": index, "constraints": "tasks: must not be empty", "flow": "bad", "namespace": "company.team"},
+			}
+		},
+		inventory: []map[string]any{
+			{"id": "good", "namespace": "company.team", "revision": 1},
+			{"id": "bad", "namespace": "company.team", "revision": 1},
+			{"id": "broken", "namespace": "company.team", "revision": 1,
+				"exception": "Invalid type: io.kestra.core.tasks.flows.EachSequential"},
+		},
+	}
+	client := newTestClient(t, server.start(t))
+
+	var out bytes.Buffer
+	err := runFlowsValidateByQuery(client, nil, validateBatchSize, newTableRenderer(&out))
+	if err == nil {
+		t.Fatal("expected a non-nil error so the command exits non-zero")
+	}
+	if !strings.Contains(err.Error(), "validation failed for 2 flow(s)") {
+		t.Errorf("expected 2 failures in the error, got: %v", err)
+	}
+
+	rendered := out.String()
+	if !strings.HasPrefix(strings.TrimSpace(rendered), "FLOW") {
+		t.Errorf("expected the table to be keyed by FLOW, got:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "tasks: must not be empty") {
+		t.Errorf("expected the constraint in the output:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "cannot be deserialized") ||
+		!strings.Contains(rendered, "company.team/broken") {
+		t.Errorf("expected the undeserializable flow to be reported:\n%s", rendered)
+	}
+	if !strings.Contains(rendered, "1 valid flow(s), 2 failed") {
+		t.Errorf("expected the 1/2 summary, got:\n%s", rendered)
+	}
+}
+
+func TestRunFlowsValidateByQuery_AllValid(t *testing.T) {
+	server := &validateByQueryServer{
+		archive: buildFlowZip(t, map[string]string{
+			"company.team/good.yaml": flowSource("good"),
+		}),
+		inventory: []map[string]any{
+			{"id": "good", "namespace": "company.team", "revision": 1},
+		},
+	}
+	client := newTestClient(t, server.start(t))
+
+	var out bytes.Buffer
+	if err := runFlowsValidateByQuery(client, nil, validateBatchSize, newTableRenderer(&out)); err != nil {
+		t.Fatalf("expected no error for a clean instance, got: %v", err)
+	}
+	if !strings.Contains(out.String(), "1 valid flow(s), 0 failed") {
+		t.Errorf("unexpected output:\n%s", out.String())
+	}
+}
+
+// The inventory is a cross-check, not the main event: losing it degrades into
+// a warning so the exported sources are still validated.
+func TestRunFlowsValidateByQuery_InventoryFailureDegradesToWarning(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/flows/export/by-query"):
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(buildFlowZip(t, map[string]string{
+				"company.team/good.yaml": flowSource("good"),
+			}))
+		case strings.HasSuffix(r.URL.Path, "/flows/validate"):
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"message":"no permission to list flows"}`))
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var out, errOut bytes.Buffer
+	renderer := newTableRenderer(&out).WithErrWriter(&errOut)
+	if err := runFlowsValidateByQuery(newTestClient(t, server.URL), nil, validateBatchSize, renderer); err != nil {
+		t.Fatalf("an unreadable inventory must not fail the command, got: %v", err)
+	}
+	if !strings.Contains(errOut.String(), "undeserializable-flow check was skipped") {
+		t.Errorf("expected a warning on stderr, got: %q", errOut.String())
+	}
+	if !strings.Contains(out.String(), "1 valid flow(s), 0 failed") {
+		t.Errorf("the exported sources should still have been validated:\n%s", out.String())
+	}
+}
+
+func TestFlowsValidateByQueryCommand_RejectsPositionalArgs(t *testing.T) {
+	cmd := newFlowsValidateByQueryCommand()
+	if _, err := executeCommand(cmd, "./flows/"); err == nil {
+		t.Fatal("expected validate-by-query to reject a path argument")
+	}
+}
+
+func newViolation(index int32, constraints string, warnings []string) kestra.ValidateConstraintViolation {
+	violation := kestra.NewValidateConstraintViolation(index)
+	if constraints != "" {
+		violation.SetConstraints(constraints)
+	}
+	if len(warnings) > 0 {
+		violation.SetWarnings(warnings)
+	}
+	return *violation
+}

--- a/src/cli/flows_validate_by_query_test.go
+++ b/src/cli/flows_validate_by_query_test.go
@@ -119,24 +119,43 @@ func TestFlowsFromZip_WrapperStillReturnsSourcesOnly(t *testing.T) {
 	}
 }
 
-func TestFlowIdentityFromZipEntry(t *testing.T) {
+func TestFlowIdentityFromSource(t *testing.T) {
 	cases := []struct {
-		entry     string
+		name      string
+		source    string
 		namespace string
 		flowID    string
 	}{
-		{"company.team/my-flow.yaml", "company.team", "my-flow"},
-		{"company/team/my-flow.yml", "company.team", "my-flow"},
-		{"/company.team/my-flow.yaml", "company.team", "my-flow"},
-		{"my-flow.yaml", "", "my-flow"},
+		{
+			name:      "a flow with a hyphen in both halves",
+			source:    "id: my-flow\nnamespace: company.team-eu\ntasks: []\n",
+			namespace: "company.team-eu",
+			flowID:    "my-flow",
+		},
+		{
+			name:      "key order does not matter",
+			source:    "namespace: company.team\nid: my-flow\n",
+			namespace: "company.team",
+			flowID:    "my-flow",
+		},
+		{
+			name:   "a source that does not parse leaves it to the server",
+			source: "id: [unterminated\n",
+		},
+		{
+			name:   "an empty source",
+			source: "",
+		},
 	}
 
 	for _, tc := range cases {
-		namespace, flowID := flowIdentityFromZipEntry(tc.entry)
-		if namespace != tc.namespace || flowID != tc.flowID {
-			t.Errorf("flowIdentityFromZipEntry(%q) = (%q, %q), want (%q, %q)",
-				tc.entry, namespace, flowID, tc.namespace, tc.flowID)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			namespace, flowID := flowIdentityFromSource(tc.source)
+			if namespace != tc.namespace || flowID != tc.flowID {
+				t.Errorf("flowIdentityFromSource(%q) = (%q, %q), want (%q, %q)",
+					tc.source, namespace, flowID, tc.namespace, tc.flowID)
+			}
+		})
 	}
 }
 
@@ -256,8 +275,8 @@ func TestBuildValidateResults_OutOfRangeIndexGetsItsOwnRow(t *testing.T) {
 func TestRunFlowsValidateByQuery_ReportsConstraintsAndExceptions(t *testing.T) {
 	server := &validateByQueryServer{
 		archive: buildFlowZip(t, map[string]string{
-			"company.team/good.yaml": flowSource("good"),
-			"company.team/bad.yaml":  flowSource("bad"),
+			"company.team-good.yml": flowSource("good"),
+			"company.team-bad.yml":  flowSource("bad"),
 		}),
 		violate: func(body string) []map[string]any {
 			index := 0
@@ -272,6 +291,8 @@ func TestRunFlowsValidateByQuery_ReportsConstraintsAndExceptions(t *testing.T) {
 		inventory: []map[string]any{
 			{"id": "good", "namespace": "company.team", "revision": 1},
 			{"id": "bad", "namespace": "company.team", "revision": 1},
+			// Absent from the archive above: only such a flow is reported by
+			// the cross-check, the rest come back from the validate endpoint.
 			{"id": "broken", "namespace": "company.team", "revision": 1,
 				"exception": "Invalid type: io.kestra.core.tasks.flows.EachSequential"},
 		},
@@ -306,7 +327,7 @@ func TestRunFlowsValidateByQuery_ReportsConstraintsAndExceptions(t *testing.T) {
 func TestRunFlowsValidateByQuery_AllValid(t *testing.T) {
 	server := &validateByQueryServer{
 		archive: buildFlowZip(t, map[string]string{
-			"company.team/good.yaml": flowSource("good"),
+			"company.team-good.yml": flowSource("good"),
 		}),
 		inventory: []map[string]any{
 			{"id": "good", "namespace": "company.team", "revision": 1},
@@ -331,7 +352,7 @@ func TestRunFlowsValidateByQuery_InventoryFailureDegradesToWarning(t *testing.T)
 		case strings.HasSuffix(r.URL.Path, "/flows/export/by-query"):
 			w.Header().Set("Content-Type", "application/zip")
 			_, _ = w.Write(buildFlowZip(t, map[string]string{
-				"company.team/good.yaml": flowSource("good"),
+				"company.team-good.yml": flowSource("good"),
 			}))
 		case strings.HasSuffix(r.URL.Path, "/flows/validate"):
 			w.Header().Set("Content-Type", "application/json")
@@ -372,4 +393,47 @@ func newViolation(index int32, constraints string, warnings []string) kestra.Val
 		violation.SetWarnings(warnings)
 	}
 	return *violation
+}
+
+// TestRunFlowsValidateByQuery_DoesNotDoubleCountExportedBrokenFlows is the
+// regression test for what live QA against a migrated 1.3.37 -> 2.0.0 instance
+// turned up: an undeserializable flow is usually still in the export, because
+// the export writes the stored source text back out without deserializing it.
+// Reporting it from both the validate endpoint and the inventory counted one
+// broken flow twice.
+func TestRunFlowsValidateByQuery_DoesNotDoubleCountExportedBrokenFlows(t *testing.T) {
+	server := &validateByQueryServer{
+		archive: buildFlowZip(t, map[string]string{
+			"company.team-legacy.yml": "id: legacy\nnamespace: company.team\ntasks:\n  - id: loop\n    type: io.kestra.plugin.core.flow.EachSequential\n",
+		}),
+		violate: func(string) []map[string]any {
+			return []map[string]any{
+				{"index": 0, "constraints": "Invalid type: io.kestra.plugin.core.flow.EachSequential",
+					"flow": "legacy", "namespace": "company.team"},
+			}
+		},
+		// The same flow, also flagged by the inventory.
+		inventory: []map[string]any{
+			{"id": "legacy", "namespace": "company.team", "revision": 1,
+				"exception": "Could not resolve type id 'io.kestra.plugin.core.flow.EachSequential'"},
+		},
+	}
+	client := newTestClient(t, server.start(t))
+
+	var out bytes.Buffer
+	err := runFlowsValidateByQuery(client, nil, validateBatchSize, newTableRenderer(&out))
+	if err == nil {
+		t.Fatal("expected the broken flow to fail validation")
+	}
+	if !strings.Contains(err.Error(), "validation failed for 1 flow(s)") {
+		t.Errorf("the flow must be counted once, got: %v", err)
+	}
+
+	rendered := out.String()
+	if got := strings.Count(rendered, "company.team/legacy"); got != 1 {
+		t.Errorf("expected exactly 1 row for the flow, got %d:\n%s", got, rendered)
+	}
+	if !strings.Contains(rendered, "0 valid flow(s), 1 failed") {
+		t.Errorf("unexpected summary:\n%s", rendered)
+	}
 }

--- a/src/cli/flows_validate_by_query_test.go
+++ b/src/cli/flows_validate_by_query_test.go
@@ -361,3 +361,45 @@ func TestRunFlowsValidateByQuery_ReportsBrokenStoredFlows(t *testing.T) {
 		t.Error("validate-by-query must not call /flows/search")
 	}
 }
+
+// Validating a whole instance has to be asked for by name, so a bare
+// invocation is a usage mistake and prints the help.
+func TestFlowsValidateByQueryCommand_RequiresASelection(t *testing.T) {
+	cmd := newFlowsValidateByQueryCommand()
+	out, err := executeCommand(cmd)
+	if err == nil {
+		t.Fatal("expected a bare validate-by-query to be rejected")
+	}
+	if !strings.Contains(err.Error(), "a selection is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if cmd.SilenceUsage {
+		t.Error("a usage mistake must print the help")
+	}
+	if !strings.Contains(out, "--all") {
+		t.Errorf("the help should point at --all, got:\n%s", out)
+	}
+}
+
+func TestFlowsValidateByQueryCommand_AllIsExclusive(t *testing.T) {
+	for _, flag := range []string{"--namespace=company.team", "--flow=my-flow", "--filter=NAMESPACE:EQUALS:x"} {
+		cmd := newFlowsValidateByQueryCommand()
+		if _, err := executeCommand(cmd, "--all", flag); err == nil {
+			t.Errorf("expected --all %s to be rejected", flag)
+		} else if !strings.Contains(err.Error(), "cannot be combined") {
+			t.Errorf("--all %s: unexpected error: %v", flag, err)
+		}
+	}
+}
+
+// The counterpart to the two above: a run that reaches the server must not
+// bury its report under the flag list, whatever the outcome.
+func TestFlowsValidateByQueryCommand_KeepsUsageSilencedOnceRunning(t *testing.T) {
+	cmd := newFlowsValidateByQueryCommand()
+	if _, err := executeCommand(cmd, "--all"); err == nil {
+		t.Fatal("expected the run to fail without a reachable server")
+	}
+	if !cmd.SilenceUsage {
+		t.Error("a failure past the selection check must not print the help")
+	}
+}


### PR DESCRIPTION
Closes #161.

Answering "is what is on the instance valid?" needed a three-step round-trip through the filesystem:

```bash
kestractl flows export-by-query --output-file flows.zip
unzip -q -o flows.zip -d flows/
kestractl flows validate ./flows/
```

This adds `flows validate-by-query`, which does it in one command, in memory:

```bash
kestractl flows validate-by-query --namespace company.team  # scoped
kestractl flows validate-by-query --all                     # every flow on the instance
kestractl flows validate-by-query --all --output json       # CI gate, exits non-zero
```

Named after the existing `-by-query` family, so it takes the same `--namespace` / `--flow` / `--filter` flags as `export-by-query`. A selection is required — with no flags the command errors and prints the help, since validating a whole instance should be asked for by name. `flows validate <path>` is unchanged.

It finds the same flows the three-step recipe does — the win is ergonomics, not extra detection.

Drafts are not covered: the export skips them, so a draft-headed flow is validated at its last saved revision.

## Changes

- **new** `src/cli/flows_validate_by_query.go` + tests.
- `flows_usage_analysis.go` — `flowSourcesFromZip` extracted to keep archive entry names; `flowsFromZip` is now a wrapper, `usage-report` untouched.
- `flows.go` — split `formatValidateResults` into a builder and a renderer, and added `validateSourcesInBatches` (100 sources per request, violation indices offset per batch). `flows validate` uses it too, so large local directories stop going out as one request.
- `README.md` — the command, plus a "Verifying a migration" section.

No breaking changes: `flows validate`'s table output is byte-identical and `ValidateResult`'s JSON shape is unchanged.

## Testing

1186 unit tests, `go vet`, `gofmt`, clean under `-race`.

Live QA against EE 2.0.0 on an instance migrated in place from 1.3.37 — [full report and matrix in the comment below](https://github.com/kestra-io/kestractl/pull/162#issuecomment-5620663814). It caught two bugs, both fixed here: export archives are flat (`namespace-flow.yml`, not `namespace/flow.yaml`), and broken flows were reported twice. Tenant handling (`--tenant`, `KESTRACTL_TENANT`, flag-over-env) verified across two tenants.