### PR TITLE
fix: default bulk-update --delete to false

### DIFF
--- a/src/cli/flows.go
+++ b/src/cli/flows.go
@@ -1732,7 +1732,7 @@ func newFlowsBulkUpdateCommand() *cobra.Command {
 		Short: "Update multiple flows from a YAML file (flows separated by ---).",
 		Long: `Create or update all flows defined in a multi-document YAML file.
 Flows already existing in the namespace but not present in the file will be deleted
-if --delete is set (default true).`,
+if --delete is set (default false).`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := validateOutputFormat(); err != nil {
 				return err
@@ -1758,7 +1758,7 @@ if --delete is set (default true).`,
 
 	cmd.Flags().StringVarP(&filePath, "file", "f", "", "Path to YAML file with flows separated by --- (required)")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "Target namespace for all flows")
-	cmd.Flags().BoolVar(&deleteUnlisted, "delete", true, "Delete flows not present in the file")
+	cmd.Flags().BoolVar(&deleteUnlisted, "delete", false, "Delete flows not present in the file")
 	cmd.Flags().BoolVar(&allowNamespaceChild, "allow-namespace-child", false, "Allow updating flows in child namespaces")
 
 	return cmd

--- a/src/cli/flows_test.go
+++ b/src/cli/flows_test.go
@@ -858,6 +858,17 @@ func TestFlowsBulkUpdateCommand_MissingFile(t *testing.T) {
 	}
 }
 
+func TestFlowsBulkUpdateCommand_DeleteDefaultFalse(t *testing.T) {
+	cmd := newFlowsBulkUpdateCommand()
+	defaultVal, err := cmd.Flags().GetBool("delete")
+	if err != nil {
+		t.Fatalf("get delete flag: %v", err)
+	}
+	if defaultVal {
+		t.Fatal("bulk-update --delete should default to false (match namespace-sync)")
+	}
+}
+
 func TestFlowsBulkUpdateCommand_ClientError(t *testing.T) {
 	f, err := os.CreateTemp("", "flows-*.yaml")
 	if err != nil {


### PR DESCRIPTION
Closes #164

`flows bulk-update` had `--delete` defaulting to true while `namespace-sync` defaults to false. That makes a truncated/partial YAML file delete everything else in the namespace.

Flip the default to false and update the Long help. Added a unit test on the flag default.